### PR TITLE
Add augmentable activity context

### DIFF
--- a/packages/app/src/microsoft/teams/app/options.py
+++ b/packages/app/src/microsoft/teams/app/options.py
@@ -24,7 +24,7 @@ class AppOptions:
     # Infrastructure
     logger: Optional[Logger] = None
     storage: Optional[Storage[str, Any]] = None
-    plugins: List[Plugin] = field(default_factory=list[Plugin])
+    plugins: List[Plugin[Any]] = field(default_factory=list[Plugin[Any]])
     enable_token_validation: bool = True
 
     # Oauth

--- a/packages/app/src/microsoft/teams/app/plugins/plugin.py
+++ b/packages/app/src/microsoft/teams/app/plugins/plugin.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Callable
+from typing import Any, Callable, TypeVar
 
 from microsoft.teams.api.clients.conversation import ActivityParams
 from microsoft.teams.api.models import Resource
@@ -27,8 +27,10 @@ OnActivityPluginEvent = Callable[[ActivityEvent], None]
 Emitted when the plugin receives an activity
 """
 
+TExtraContext = TypeVar("TExtraContext", bound=dict[str, Any] | None)
 
-class Plugin:
+
+class Plugin[TExtraContext]:
     """The base plugin for Teams app plugins."""
 
     async def on_init(self) -> None:
@@ -47,7 +49,7 @@ class Plugin:
         """Called by the App when an error occurs."""
         ...
 
-    async def on_activity(self, event: PluginActivityEvent) -> None:
+    async def on_activity(self, event: PluginActivityEvent) -> TExtraContext:
         """Called by the App when an activity is received."""
         ...
 

--- a/packages/app/src/microsoft/teams/app/plugins/plugin_activity_event.py
+++ b/packages/app/src/microsoft/teams/app/plugins/plugin_activity_event.py
@@ -3,16 +3,15 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from microsoft.teams.api import Activity, TokenProtocol
-from microsoft.teams.api.models.conversation import ConversationReference
 
 if TYPE_CHECKING:
     from .sender import Sender
 
 
-class PluginActivityEvent(ConversationReference):
+class PluginActivityEvent(NamedTuple):
     """Event emitted by a plugin when an activity is received."""
 
     sender: "Sender"


### PR DESCRIPTION
This is a similar draft for being able to create augmentable activity context (See https://github.com/microsoft/teams.ts/pull/288). Here is how it actually looks like in practice:

```py


class Foo:
    bar: str


class FooPlugin(Plugin[Foo]):
    def on_activity(self):
        return Foo()


app = App(AppOptions(plugins=[FooPlugin()]))

@app.on_message
async def handle_message(ctx: ActivityContext[MessageActivity]):
   foo_ctx = ctx.get_plugin_context(FooPlugin)
   foo_ctx.bar # this is correctly str
```

What this means is that we can build plugins like a GraphPlugin which will then give us access to graph_ctx.user_graph, for example. And it gives plugins additonal flexibility to add custom things to the activity context as desired.

In typescript, the nice thing is that we can just do activityContext.bar, and it'll be correctly inferred. But python's type system is not nearly as powerful as typescript, so we have to explicitly ask ActivityContext the type for the plugin (hence `foo_ctx = ctx.get_plugin_context(FooPlugin)`) so we get the right types.