### PR TITLE
[fix]: fix short-circuit on execute_middleware_chain

### DIFF
--- a/packages/app/src/microsoft/teams/app/app_process.py
+++ b/packages/app/src/microsoft/teams/app/app_process.py
@@ -76,7 +76,7 @@ class ActivityProcessor:
                     # Execute current handler and capture return value
                     result = await handlers[index](ctx)
 
-                    # Update the response
+                    # Update the response iff response hasn't already been received
                     if result is not None:
                         response = result
 


### PR DESCRIPTION
- fixed the short-circuit on `execute_middleware_chain`
-> was previously checking if `result is None`, but we want to execute all the handlers + return the final result
- changed null check into length check - list of handlers is always passed in