### PR TITLE
Add create_stream to devtools plugin

### DIFF
--- a/packages/devtools/src/microsoft/teams/devtools/devtools_plugin.py
+++ b/packages/devtools/src/microsoft/teams/devtools/devtools_plugin.py
@@ -31,6 +31,7 @@ from microsoft.teams.apps import (
     PluginErrorEvent,
     PluginStartEvent,
     Sender,
+    StreamerProtocol,
 )
 
 from .event import DevToolsActivityEvent, DevToolsActivityReceivedEvent, DevToolsActivitySentEvent
@@ -233,6 +234,9 @@ class DevToolsPlugin(Sender):
 
     async def send(self, activity: ActivityParams, ref: ConversationReference) -> SentActivity:
         return await self.http.send(activity, ref)
+
+    def create_stream(self, ref: ConversationReference) -> StreamerProtocol:
+        return self.http.create_stream(ref)
 
     async def emit_activity_to_sockets(self, event: DevToolsActivityEvent):
         data = event.model_dump(mode="json", exclude_none=True)


### PR DESCRIPTION
Added method
```
def create_stream(self, ref: ConversationReference) -> StreamerProtocol:
        return self.http.create_stream(ref)
```
to devtools_plugin.py to return the http plugin's streamer.

<img width="800" height="259" alt="image" src="https://github.com/user-attachments/assets/9fbc6a97-2b0d-4939-b0f8-dfda655221f7" />

