### PR TITLE
Unpack App Options

### DIFF
--- a/packages/apps/src/microsoft/teams/apps/app.py
+++ b/packages/apps/src/microsoft/teams/apps/app.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 import asyncio
 import importlib.metadata
 import os
-from dataclasses import asdict
 from logging import Logger
 from typing import Any, Awaitable, Callable, List, Optional, TypeVar, Union, Unpack, cast, overload
 
@@ -42,7 +41,7 @@ from .events import (
 )
 from .graph_token_manager import GraphTokenManager
 from .http_plugin import HttpPlugin
-from .options import AppOptions, AppOptionsDefaults
+from .options import AppOptions, merge_app_options_with_defaults
 from .plugins import PluginBase, PluginStartEvent, get_metadata
 from .routing import ActivityHandlerMixin, ActivityRouter
 
@@ -62,8 +61,7 @@ class App(ActivityHandlerMixin):
     """
 
     def __init__(self, **options: Unpack[AppOptions]):
-        defaults = asdict(AppOptionsDefaults())
-        self.options = cast(AppOptions, {**defaults, **options})
+        self.options = merge_app_options_with_defaults(**options)
 
         self.log = self.options.get("logger") or ConsoleLogger().create_logger("@teams/app")
         self.storage = self.options.get("storage") or LocalStorage()

--- a/packages/apps/src/microsoft/teams/apps/app.py
+++ b/packages/apps/src/microsoft/teams/apps/app.py
@@ -41,7 +41,7 @@ from .events import (
 )
 from .graph_token_manager import GraphTokenManager
 from .http_plugin import HttpPlugin
-from .options import AppOptions, merge_app_options_with_defaults
+from .options import AppOptions, InternalAppOptions
 from .plugins import PluginBase, PluginStartEvent, get_metadata
 from .routing import ActivityHandlerMixin, ActivityRouter
 
@@ -61,10 +61,10 @@ class App(ActivityHandlerMixin):
     """
 
     def __init__(self, **options: Unpack[AppOptions]):
-        self.options = merge_app_options_with_defaults(**options)
+        self.options = InternalAppOptions.from_typeddict(options)
 
-        self.log = self.options.get("logger") or ConsoleLogger().create_logger("@teams/app")
-        self.storage = self.options.get("storage") or LocalStorage()
+        self.log = self.options.logger or ConsoleLogger().create_logger("@teams/app")
+        self.storage = self.options.storage or LocalStorage()
 
         self.http_client = Client(
             ClientOptions(
@@ -93,7 +93,7 @@ class App(ActivityHandlerMixin):
             self.http_client.clone(ClientOptions(token=lambda: self.tokens.bot)),
         )
 
-        plugins: List[PluginBase] = list(self.options.get("plugins", []))
+        plugins: List[PluginBase] = list(self.options.plugins)
 
         http_plugin = None
         for i, plugin in enumerate(plugins):
@@ -108,7 +108,7 @@ class App(ActivityHandlerMixin):
             if self.credentials and hasattr(self.credentials, "client_id"):
                 app_id = self.credentials.client_id
 
-            http_plugin = HttpPlugin(app_id, self.log, self.options.get("enable_token_validation", True))
+            http_plugin = HttpPlugin(app_id, self.log, self.options.enable_token_validation)
 
         plugins.insert(0, http_plugin)
         self.http = cast(HttpPlugin, http_plugin)
@@ -127,7 +127,7 @@ class App(ActivityHandlerMixin):
             self.log,
             self.id,
             self.storage,
-            self.options.get("default_connection_name", "graph"),
+            self.options.default_connection_name,
             self.http_client,
             self.tokens,
             self.graph_token_manager,
@@ -139,7 +139,7 @@ class App(ActivityHandlerMixin):
 
         # default event handlers
         oauth_handlers = OauthHandlers(
-            default_connection_name=self.options.get("default_connection_name", "graph"),
+            default_connection_name=self.options.default_connection_name,
             event_emitter=self._events,
         )
         self.on_signin_token_exchange(oauth_handlers.sign_in_token_exchange)
@@ -285,9 +285,9 @@ class App(ActivityHandlerMixin):
 
     def _init_credentials(self) -> Optional[Credentials]:
         """Initialize authentication credentials from options and environment."""
-        client_id = self.options.get("client_id") or os.getenv("CLIENT_ID")
-        client_secret = self.options.get("client_secret") or os.getenv("CLIENT_SECRET")
-        tenant_id = self.options.get("tenant_id") or os.getenv("TENANT_ID")
+        client_id = self.options.client_id or os.getenv("CLIENT_ID")
+        client_secret = self.options.client_secret or os.getenv("CLIENT_SECRET")
+        tenant_id = self.options.tenant_id or os.getenv("TENANT_ID")
 
         self.log.debug(f"Using CLIENT_ID: {client_id}")
         if not tenant_id:

--- a/packages/apps/src/microsoft/teams/apps/options.py
+++ b/packages/apps/src/microsoft/teams/apps/options.py
@@ -5,27 +5,35 @@ Licensed under the MIT License.
 
 from dataclasses import dataclass, field
 from logging import Logger
-from typing import Any, List, Optional
+from typing import Any, List, Optional, TypedDict
 
 from microsoft.teams.common.storage import Storage
 
 from .plugins import PluginBase
 
 
-@dataclass
-class AppOptions:
+class AppOptions(TypedDict, total=False):
     """Configuration options for the Teams App."""
 
     # Authentication credentials
-    client_id: Optional[str] = None
-    client_secret: Optional[str] = None
-    tenant_id: Optional[str] = None
+    client_id: Optional[str]
+    client_secret: Optional[str]
+    tenant_id: Optional[str]
 
     # Infrastructure
-    logger: Optional[Logger] = None
-    storage: Optional[Storage[str, Any]] = None
-    plugins: List[PluginBase] = field(default_factory=list[PluginBase])
-    enable_token_validation: bool = True
+    logger: Optional[Logger]
+    storage: Optional[Storage[str, Any]]
+    plugins: List[PluginBase]
+    enable_token_validation: bool
 
     # Oauth
+    default_connection_name: str
+
+
+@dataclass
+class AppOptionsDefaults:
+    """Default values for AppOptions."""
+
+    enable_token_validation: bool = True
     default_connection_name: str = "graph"
+    plugins: List[PluginBase] = field(default_factory=list[PluginBase])

--- a/packages/apps/src/microsoft/teams/apps/options.py
+++ b/packages/apps/src/microsoft/teams/apps/options.py
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from dataclasses import dataclass, field
 from logging import Logger
 from typing import Any, List, Optional, TypedDict, cast
 
@@ -28,6 +29,37 @@ class AppOptions(TypedDict, total=False):
 
     # Oauth
     default_connection_name: Optional[str]
+
+
+@dataclass
+class InternalAppOptions:
+    """Internal dataclass for AppOptions with defaults and non-nullable fields."""
+
+    # Fields with defaults
+    enable_token_validation: bool = True
+    default_connection_name: str = "graph"
+    plugins: List[PluginBase] = field(default_factory=lambda: [])
+
+    # Optional fields
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    tenant_id: Optional[str] = None
+    logger: Optional[Logger] = None
+    storage: Optional[Storage[str, Any]] = None
+
+    @classmethod
+    def from_typeddict(cls, options: AppOptions) -> "InternalAppOptions":
+        """
+        Create InternalAppOptions from AppOptions TypedDict with defaults applied.
+
+        Args:
+            options: AppOptions TypedDict (potentially with None values)
+
+        Returns:
+            InternalAppOptions with proper defaults and non-nullable required fields
+        """
+        kwargs: dict[str, Any] = {k: v for k, v in options.items() if v is not None}
+        return cls(**kwargs)
 
 
 def merge_app_options_with_defaults(**options: Unpack[AppOptions]) -> AppOptions:

--- a/packages/apps/src/microsoft/teams/apps/options.py
+++ b/packages/apps/src/microsoft/teams/apps/options.py
@@ -4,30 +4,30 @@ Licensed under the MIT License.
 """
 
 from logging import Logger
-from typing import Any, List, TypedDict, cast
+from typing import Any, List, Optional, TypedDict, cast
 
 from microsoft.teams.common.storage import Storage
-from typing_extensions import NotRequired, Unpack
+from typing_extensions import Unpack
 
 from .plugins import PluginBase
 
 
-class AppOptions(TypedDict):
+class AppOptions(TypedDict, total=False):
     """Configuration options for the Teams App."""
 
     # Authentication credentials
-    client_id: NotRequired[str]
-    client_secret: NotRequired[str]
-    tenant_id: NotRequired[str]
+    client_id: Optional[str]
+    client_secret: Optional[str]
+    tenant_id: Optional[str]
 
     # Infrastructure
-    logger: NotRequired[Logger]
-    storage: NotRequired[Storage[str, Any]]
-    plugins: NotRequired[List[PluginBase]]
-    enable_token_validation: NotRequired[bool]
+    logger: Optional[Logger]
+    storage: Optional[Storage[str, Any]]
+    plugins: Optional[List[PluginBase]]
+    enable_token_validation: Optional[bool]
 
     # Oauth
-    default_connection_name: NotRequired[str]
+    default_connection_name: Optional[str]
 
 
 def merge_app_options_with_defaults(**options: Unpack[AppOptions]) -> AppOptions:

--- a/packages/apps/src/microsoft/teams/apps/options.py
+++ b/packages/apps/src/microsoft/teams/apps/options.py
@@ -3,37 +3,47 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from dataclasses import dataclass, field
 from logging import Logger
-from typing import Any, List, Optional, TypedDict
+from typing import Any, List, TypedDict, cast
 
 from microsoft.teams.common.storage import Storage
+from typing_extensions import NotRequired, Unpack
 
 from .plugins import PluginBase
 
 
-class AppOptions(TypedDict, total=False):
+class AppOptions(TypedDict):
     """Configuration options for the Teams App."""
 
     # Authentication credentials
-    client_id: Optional[str]
-    client_secret: Optional[str]
-    tenant_id: Optional[str]
+    client_id: NotRequired[str]
+    client_secret: NotRequired[str]
+    tenant_id: NotRequired[str]
 
     # Infrastructure
-    logger: Optional[Logger]
-    storage: Optional[Storage[str, Any]]
-    plugins: List[PluginBase]
-    enable_token_validation: bool
+    logger: NotRequired[Logger]
+    storage: NotRequired[Storage[str, Any]]
+    plugins: NotRequired[List[PluginBase]]
+    enable_token_validation: NotRequired[bool]
 
     # Oauth
-    default_connection_name: str
+    default_connection_name: NotRequired[str]
 
 
-@dataclass
-class AppOptionsDefaults:
-    """Default values for AppOptions."""
+def merge_app_options_with_defaults(**options: Unpack[AppOptions]) -> AppOptions:
+    """
+    Create AppOptions with default values merged with provided options.
 
-    enable_token_validation: bool = True
-    default_connection_name: str = "graph"
-    plugins: List[PluginBase] = field(default_factory=list[PluginBase])
+    Args:
+        **options: Configuration options to override defaults
+
+    Returns:
+        AppOptions with defaults applied
+    """
+    defaults: AppOptions = {
+        "enable_token_validation": True,
+        "default_connection_name": "graph",
+        "plugins": [],
+    }
+
+    return cast(AppOptions, {**defaults, **options})

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -102,7 +102,7 @@ class TestApp:
     @pytest.fixture(scope="function")
     def app_with_options(self, basic_options):
         """Create App with basic options."""
-        app = App(basic_options)
+        app = App(**basic_options)
         return self._mock_http_plugin(app)
 
     @pytest.fixture(scope="function")
@@ -115,13 +115,13 @@ class TestApp:
             client_secret="test-secret",
             plugins=[],
         )
-        app = App(options)
+        app = App(**options)
         app.on_activity(mock_activity_handler)
         return self._mock_http_plugin(app)
 
     def test_app_starts_successfully(self, basic_options):
         """Test that app can be created and initialized."""
-        app = App(basic_options)
+        app = App(**basic_options)
 
         # Basic functional test - app should be created and not running
         assert not app.is_running

--- a/tests/ai-test/src/main.py
+++ b/tests/ai-test/src/main.py
@@ -10,7 +10,7 @@ from os import getenv
 from dotenv import find_dotenv, load_dotenv
 from microsoft.teams.ai import Agent, Function, ListMemory, UserMessage
 from microsoft.teams.api import MessageActivity
-from microsoft.teams.apps import ActivityContext, App, AppOptions
+from microsoft.teams.apps import ActivityContext, App
 from microsoft.teams.devtools import DevToolsPlugin
 from microsoft.teams.openai import OpenAICompletionsAIModel, OpenAIResponsesAIModel
 from pydantic import BaseModel
@@ -30,7 +30,7 @@ AZURE_OPENAI_ENDPOINT = get_required_env("AZURE_OPENAI_ENDPOINT")
 AZURE_OPENAI_MODEL = get_required_env("AZURE_OPENAI_MODEL")
 AZURE_OPENAI_API_VERSION = get_required_env("AZURE_OPENAI_API_VERSION")
 
-app = App(AppOptions(plugins=[DevToolsPlugin()]))
+app = App(plugins=[DevToolsPlugin()])
 
 # Global state for mode switching
 current_mode = "responses"  # "chat" or "responses"

--- a/tests/dialogs/src/main.py
+++ b/tests/dialogs/src/main.py
@@ -22,7 +22,7 @@ from microsoft.teams.api import (
     UrlTaskModuleTaskInfo,
     card_attachment,
 )
-from microsoft.teams.apps import ActivityContext, App, AppOptions
+from microsoft.teams.apps import ActivityContext, App
 from microsoft.teams.apps.events.types import ErrorEvent
 from microsoft.teams.cards import AdaptiveCard
 from microsoft.teams.common.logging import ConsoleLogger
@@ -33,8 +33,7 @@ logger: Logger = logger_instance.create_logger("@apps/dialogs")
 if not os.getenv("BOT_ENDPOINT"):
     logger.warning("No remote endpoint detected. Using webpages for dialog will not work as expected")
 
-options = AppOptions(client_id=os.getenv("BOT_ID"), client_secret=os.getenv("BOT_PASSWORD"))
-app = App(options)
+app = App(client_id=os.getenv("BOT_ID"), client_secret=os.getenv("BOT_PASSWORD"))
 
 app.page("customform", os.path.join(os.path.dirname(__file__), "views", "customform"), "/tabs/dialog-form")
 

--- a/tests/echo/src/main.py
+++ b/tests/echo/src/main.py
@@ -8,10 +8,10 @@ import re
 
 from microsoft.teams.api import MessageActivity
 from microsoft.teams.api.activities.typing import TypingActivityInput
-from microsoft.teams.apps import ActivityContext, App, AppOptions
+from microsoft.teams.apps import ActivityContext, App
 from microsoft.teams.devtools import DevToolsPlugin
 
-app = App(AppOptions(plugins=[DevToolsPlugin()]))
+app = App(plugins=[DevToolsPlugin()])
 
 
 @app.on_message_pattern(re.compile(r"hello|hi|greetings"))

--- a/tests/graph/src/main.py
+++ b/tests/graph/src/main.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 # Create app with OAuth connection
 app_options = AppOptions(default_connection_name=os.getenv("CONNECTION_NAME", "graph"))
-app = App(app_options)
+app = App(**app_options)
 
 
 async def get_authenticated_graph_client(ctx: ActivityContext[MessageActivity]):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [manifest]
@@ -1613,15 +1613,15 @@ crypto = [
 
 [[package]]
 name = "pyright"
-version = "1.1.404"
+version = "1.1.405"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/6e/026be64c43af681d5632722acd100b06d3d39f383ec382ff50a71a6d5bce/pyright-1.1.404.tar.gz", hash = "sha256:455e881a558ca6be9ecca0b30ce08aa78343ecc031d37a198ffa9a7a1abeb63e", size = 4065679, upload-time = "2025-08-20T18:46:14.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/6c/ba4bbee22e76af700ea593a1d8701e3225080956753bee9750dcc25e2649/pyright-1.1.405.tar.gz", hash = "sha256:5c2a30e1037af27eb463a1cc0b9f6d65fec48478ccf092c1ac28385a15c55763", size = 4068319, upload-time = "2025-09-04T03:37:06.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/30/89aa7f7d7a875bbb9a577d4b1dc5a3e404e3d2ae2657354808e905e358e0/pyright-1.1.404-py3-none-any.whl", hash = "sha256:c7b7ff1fdb7219c643079e4c3e7d4125f0dafcc19d253b47e898d130ea426419", size = 5902951, upload-time = "2025-08-20T18:46:12.096Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1a/524f832e1ff1962a22a1accc775ca7b143ba2e9f5924bb6749dce566784a/pyright-1.1.405-py3-none-any.whl", hash = "sha256:a2cb13700b5508ce8e5d4546034cb7ea4aedb60215c6c33f56cec7f53996035a", size = 5905038, upload-time = "2025-09-04T03:37:04.913Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes AppOptions to a TypedDict, and uses `Unpack` in `App` constructor. This allows us to do a simple App(client_id="Foo", ...) pattern, which is much cleaner. Fans of the old approach may also do App(**AppOptions(...)).




#### PR Dependency Tree


* **PR #127** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)