### PR TITLE
Merge the activity sent with response in http stream before passing it back to event manager in app 

### DIFF
--- a/packages/apps/src/microsoft/teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft/teams/apps/http_stream.py
@@ -254,6 +254,8 @@ class HttpStream(StreamerProtocol):
         to_send.conversation = self._ref.conversation
 
         if to_send.id and not any(e.type == "streaminfo" for e in (to_send.entities or [])):
-            return await self._client.conversations.activities(self._ref.conversation.id).update(to_send.id, to_send)
+            res = await self._client.conversations.activities(self._ref.conversation.id).update(to_send.id, to_send)
         else:
-            return await self._client.conversations.activities(self._ref.conversation.id).create(to_send)
+            res = await self._client.conversations.activities(self._ref.conversation.id).create(to_send)
+
+        return SentActivity.merge(to_send, res)


### PR DESCRIPTION
<img width="905" height="268" alt="Screenshot 2025-09-04 162334" src="https://github.com/user-attachments/assets/b7beddaa-f2b4-413f-b027-a4c00c9ccad9" />

Change: `return res`  ->  `return SentActivity.merge(to_send, res)`  in `_send` method of `http_stream.py`.

This gets sent to `app.event_manager.on_activity_sent(....)` which routes it to `devtools_plugin.on_activity_sent(...)` where we emit activity to web socket `await self.emit_activity_to_sockets(activity)`.

Without this change, only the content inside activity_params is present 
<img width="314" height="425" alt="image" src="https://github.com/user-attachments/assets/108035ca-0a30-4282-af24-9fc6fee9a820" />

