### PR TITLE
Change SystemMessage to Instructions

### DIFF
--- a/packages/ai/src/microsoft/teams/ai/agent.py
+++ b/packages/ai/src/microsoft/teams/ai/agent.py
@@ -35,8 +35,8 @@ class Agent(ChatPrompt):
         self,
         input: str | Message,
         *,
-        system_message: SystemMessage | None = None,
+        instructions: SystemMessage | None = None,
         memory: Memory | None = None,
         on_chunk: Callable[[str], Awaitable[None]] | Callable[[str], None] | None = None,
     ) -> ChatSendResult:
-        return await super().send(input, memory=memory or self.memory, system_message=system_message, on_chunk=on_chunk)
+        return await super().send(input, memory=memory or self.memory, instructions=instructions, on_chunk=on_chunk)

--- a/packages/ai/src/microsoft/teams/ai/chat_prompt.py
+++ b/packages/ai/src/microsoft/teams/ai/chat_prompt.py
@@ -51,13 +51,13 @@ class ChatPrompt:
         *,
         memory: Memory | None = None,
         on_chunk: Callable[[str], Awaitable[None]] | Callable[[str], None] | None = None,
-        system_message: SystemMessage | None = None,
+        instructions: SystemMessage | None = None,
     ) -> ChatSendResult:
         if isinstance(input, str):
             input = UserMessage(content=input)
 
         current_input = await self._run_before_send_hooks(input)
-        current_system_message = await self._run_build_system_message_hooks(system_message)
+        current_system_message = await self._run_build_instructions_hooks(instructions)
         wrapped_functions = await self._build_wrapped_functions()
 
         async def on_chunk_fn(chunk: str):
@@ -113,13 +113,13 @@ class ChatPrompt:
                 current_input = plugin_result
         return current_input
 
-    async def _run_build_system_message_hooks(self, system_message: SystemMessage | None) -> SystemMessage | None:
-        current_system_message = system_message
+    async def _run_build_instructions_hooks(self, instructions: SystemMessage | None) -> SystemMessage | None:
+        current_instructions = instructions
         for plugin in self.plugins:
-            plugin_result = await plugin.on_build_system_message(current_system_message)
+            plugin_result = await plugin.on_build_instructions(current_instructions)
             if plugin_result is not None:
-                current_system_message = plugin_result
-        return current_system_message
+                current_instructions = plugin_result
+        return current_instructions
 
     async def _build_wrapped_functions(self) -> dict[str, Function[BaseModel]] | None:
         functions_list = list(self.functions.values()) if self.functions else []

--- a/packages/ai/src/microsoft/teams/ai/plugin.py
+++ b/packages/ai/src/microsoft/teams/ai/plugin.py
@@ -44,7 +44,7 @@ class AIPluginProtocol(Protocol):
         """Modify the functions array passed to the model."""
         ...
 
-    async def on_build_system_message(self, system_message: SystemMessage | None) -> SystemMessage | None:
+    async def on_build_instructions(self, instructions: SystemMessage | None) -> SystemMessage | None:
         """Modify the system message before sending to model."""
         ...
 
@@ -80,6 +80,6 @@ class BaseAIPlugin:
         """Modify the functions array passed to the model."""
         return functions
 
-    async def on_build_system_message(self, system_message: SystemMessage | None) -> SystemMessage | None:
+    async def on_build_instructions(self, instructions: SystemMessage | None) -> SystemMessage | None:
         """Modify the system message before sending to model."""
-        return system_message
+        return instructions


### PR DESCRIPTION
Change `SystemMessage` to `Instructions` for parity with the TypeScript package. Closes #136. 