### PR TITLE
Add support for Deferred Functions

### DIFF
--- a/AsyncFunction_Design.md
+++ b/AsyncFunction_Design.md
@@ -1,0 +1,740 @@
+# AsyncFunction Design and Architecture
+
+## Overview
+
+This document outlines the design and implementation plan for AsyncFunction support in the Microsoft Teams Python SDK. AsyncFunctions enable functions to suspend execution, wait for external input (user responses, webhooks, timers), and resume seamlessly while maintaining conversation state.
+
+## Core Concept
+
+AsyncFunctions can **suspend** during execution and be **resumed** later with additional input. When a function suspends, it returns a `DeferredResult` containing:
+- The suspension state (for later resume)
+- A handler specifying what type of interaction is needed
+- The current conversation pauses until external input is provided
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    A[User Input] --> B[ChatPrompt.send()]
+    B --> C{Suspended Functions?}
+    C -->|Yes| D[Resume AsyncFunction]
+    C -->|No| E[Normal Processing]
+    
+    D --> F[AsyncFunction.resume()]
+    F --> G{Still Suspended?}
+    G -->|Yes| H[Return DeferredResult]
+    G -->|No| I[Create FunctionMessage]
+    
+    E --> J[AIModel.generate_text()]
+    I --> J
+    J --> K{Function Calls?}
+    K -->|Yes| L[Execute Functions]
+    K -->|No| M[Return ModelMessage]
+    
+    L --> N{DeferredResult?}
+    N -->|Yes| O[Store Suspension State]
+    N -->|No| P[Continue Recursively]
+    
+    O --> H
+    P --> K
+    H --> Q[Return to User]
+    M --> Q
+```
+
+## Core Types and Interfaces
+
+### 1. Handler Types
+
+```python
+from dataclasses import dataclass
+from typing import Literal, Union
+
+@dataclass
+class AskUserHandler:
+    type: Literal["ask_user"] = "ask_user"
+    question: str
+
+@dataclass  
+class GetApprovalHandler:
+    type: Literal["get_approval"] = "get_approval"
+    prompt: str
+
+@dataclass
+class SelectFromOptionsHandler:
+    type: Literal["select_options"] = "select_options"
+    question: str
+    options: list[str]
+
+@dataclass
+class WebhookHandler:
+    type: Literal["webhook"] = "webhook"  
+    webhook_url: str
+
+@dataclass
+class TimerHandler:
+    type: Literal["timer"] = "timer"
+    delay_seconds: int
+    message: str
+
+# Union of all handler types
+DeferredHandler = Union[
+    AskUserHandler, 
+    GetApprovalHandler, 
+    SelectFromOptionsHandler,
+    WebhookHandler,
+    TimerHandler
+]
+```
+
+### 2. Generic DeferredResult
+
+```python
+from typing import TypeVar, Generic
+
+THandler = TypeVar("THandler")
+TResumer = TypeVar("TResumer") 
+
+@dataclass
+class DeferredResult(Generic[THandler, TResumer]):
+    type: Literal["deferred"] = "deferred"
+    state: dict[str, Any]
+    handler: THandler
+
+# Type aliases for common patterns
+AskUserResult = DeferredResult[AskUserHandler, UserMessage]
+GetApprovalResult = DeferredResult[GetApprovalHandler, UserMessage] 
+WebhookResult = DeferredResult[WebhookHandler, dict[str, Any]]
+TimerResult = DeferredResult[TimerHandler, None]
+
+AnyDeferredResult = Union[
+    AskUserResult,
+    GetApprovalResult, 
+    SelectFromOptionsHandler,
+    WebhookResult,
+    TimerResult
+]
+```
+
+### 3. AsyncFunction Protocol
+
+```python
+class AsyncFunctionHandler(Protocol[Params]):
+    def __call__(self, params: Params) -> Union[str, AnyDeferredResult]: ...
+    def resume(self, resumer: Any, state: dict[str, Any]) -> Union[str, AnyDeferredResult]: ...
+
+@dataclass
+class AsyncFunction(Generic[Params]):
+    name: str
+    description: str  
+    parameter_schema: Union[type[Params], Dict[str, Any]]
+    handler: AsyncFunctionHandler[Params]
+```
+
+### 4. Extended FunctionCall
+
+```python
+@dataclass
+class FunctionCall:
+    id: str
+    name: str
+    arguments: dict[str, Any]
+    # New async-specific fields:
+    type: Literal["sync", "async"] | None = None
+    status: Literal["running", "suspended", "completed", "failed"] | None = None
+    state: dict[str, Any] | None = None
+    handler: DeferredHandler | None = None
+```
+
+## Implementation Examples
+
+### 1. Simple AskUser Function
+
+```python
+class ShoppingParams(BaseModel):
+    items: list[str]
+    budget: float
+
+class ShoppingHandler:
+    def __call__(self, params: ShoppingParams) -> AskUserResult:
+        return DeferredResult[AskUserHandler, UserMessage](
+            state={"items": params.items, "budget": params.budget},
+            handler=AskUserHandler(question="What additional item would you like to add?")
+        )
+    
+    def resume(self, user_message: UserMessage, state: dict[str, Any]) -> str:
+        user_choice = user_message.content
+        original_items = state["items"]
+        return f"Adding '{user_choice}' to cart with {original_items}"
+
+# Usage
+shopping_function = AsyncFunction(
+    name="add_to_cart",
+    description="Add items to shopping cart",
+    parameter_schema=ShoppingParams,
+    handler=ShoppingHandler()
+)
+```
+
+### 2. Multi-Step Approval Workflow
+
+```python
+class ApprovalParams(BaseModel):
+    document: str
+    amount: float
+
+class DocumentApprovalHandler:
+    def __call__(self, params: ApprovalParams) -> GetApprovalResult:
+        return DeferredResult[GetApprovalHandler, UserMessage](
+            state={
+                "document": params.document, 
+                "amount": params.amount,
+                "step": "manager_approval"
+            },
+            handler=GetApprovalHandler(
+                prompt=f"Manager approval needed for ${params.amount} expense: '{params.document}'"
+            )
+        )
+    
+    def resume(self, user_message: UserMessage, state: dict[str, Any]) -> Union[str, GetApprovalResult]:
+        user_input = user_message.content.lower()
+        
+        if state["step"] == "manager_approval":
+            if "yes" in user_input or "approve" in user_input:
+                return DeferredResult[GetApprovalHandler, UserMessage](
+                    state={**state, "step": "director_approval", "manager_approved": True},
+                    handler=GetApprovalHandler(
+                        prompt=f"Director approval needed for ${state['amount']} expense"
+                    )
+                )
+            else:
+                return f"Expense rejected by manager: {state['document']}"
+        
+        elif state["step"] == "director_approval":
+            if "yes" in user_input or "approve" in user_input:
+                return f"Expense '${state['amount']} - {state['document']}' fully approved!"
+            else:
+                return f"Expense rejected by director: {state['document']}"
+```
+
+## Data Flow Diagrams
+
+### Normal Function Execution Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CP as ChatPrompt
+    participant M as AIModel
+    participant F as Function
+    participant LLM as OpenAI API
+
+    U->>CP: send("Calculate 2+2")
+    CP->>M: generate_text(UserMessage)
+    M->>LLM: chat.completions.create()
+    LLM->>M: ModelMessage with function_calls
+    M->>F: handler(params)
+    F->>M: "4"
+    M->>M: Create FunctionMessage
+    M->>LLM: chat.completions.create() (recursive)
+    LLM->>M: ModelMessage("The answer is 4")
+    M->>CP: ModelMessage
+    CP->>U: ChatSendResult
+```
+
+### AsyncFunction Suspension Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CP as ChatPrompt
+    participant M as AIModel
+    participant AF as AsyncFunction
+    participant LLM as OpenAI API
+    participant Mem as Memory
+
+    U->>CP: send("Process payment")
+    CP->>M: generate_text(UserMessage)
+    M->>LLM: chat.completions.create()
+    LLM->>M: ModelMessage with function_calls
+    M->>AF: handler(params)
+    AF->>M: DeferredResult(handler=GetApprovalHandler)
+    M->>CP: DeferredResult
+    CP->>Mem: store_suspended_call()
+    CP->>U: ChatSendResult(DeferredResult)
+    
+    Note over U: User sees: "Approve payment of $100? (yes/no)"
+```
+
+### AsyncFunction Resume Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CP as ChatPrompt
+    participant AF as AsyncFunction
+    participant M as AIModel
+    participant LLM as OpenAI API
+    participant Mem as Memory
+
+    U->>CP: send("yes")
+    CP->>Mem: get_suspended_calls()
+    Mem->>CP: FunctionCall with state
+    CP->>AF: resume(UserMessage("yes"), state)
+    AF->>CP: "Payment processed successfully"
+    CP->>CP: Create FunctionMessage
+    CP->>M: generate_text(FunctionMessage)
+    M->>LLM: chat.completions.create()
+    LLM->>M: ModelMessage("Your payment is complete!")
+    M->>CP: ModelMessage
+    CP->>U: ChatSendResult(ModelMessage)
+```
+
+## Resume Handler Patterns
+
+AsyncFunction resume handling varies based on the type of interaction required:
+
+### 1. **Structured Responses: Dedicated Handler Aliases**
+
+For AsyncFunctions that expect structured data (cards, webhooks, specific payloads), the system generates dedicated handler aliases:
+
+```python
+# Generated handler aliases for structured responses
+class TeamsApp(GeneratedActivityHandlerMixin):
+    
+    @on_expense_approval_response  # Alias for @on_card_action
+    async def handle_approval(self, activity: AdaptiveCardInvokeActivity):
+        """Handle approval card responses"""
+        action = activity.value.get("action")  # "approve", "deny", "request_info"
+        await self.resume_function("expense_approval", action)
+    
+    @on_payment_webhook_response  # Alias for @on_invoke
+    async def handle_payment_webhook(self, activity: InvokeActivity):
+        """Handle payment webhook callbacks"""
+        webhook_data = activity.value
+        await self.resume_function("payment_webhook", webhook_data)
+    
+    @on_menu_selection_response  # Alias for @on_card_action
+    async def handle_menu_selection(self, activity: AdaptiveCardInvokeActivity):
+        """Handle menu option selections"""
+        selection = activity.value.get("selected_option")
+        await self.resume_function("menu_selection", selection)
+```
+
+### 2. **Text Responses: Handle in `@on_message`**
+
+For AsyncFunctions expecting text responses (human-in-the-loop, open-ended questions), developers handle resume logic in the generic `@on_message` handler:
+
+```python
+class TeamsApp(GeneratedActivityHandlerMixin):
+    
+    @on_message
+    async def handle_all_text_messages(self, activity: MessageActivity):
+        """Handle both normal chat AND AsyncFunction text responses"""
+        
+        # Strategy 1: Check for suspended HITL functions first
+        if await self.has_suspended_hitl():
+            await self.resume_hitl_function(activity.text)
+            return
+            
+        # Strategy 2: Use heuristics to detect HITL responses
+        if self.looks_like_hitl_response(activity.text):
+            await self.try_resume_hitl(activity.text)
+            return
+            
+        # Strategy 3: Normal conversation
+        result = await self.chat.send(activity.text)
+        await self.send_response(result)
+    
+    async def has_suspended_hitl(self) -> bool:
+        """Check if any human-in-the-loop functions are suspended"""
+        suspended = await self.get_suspended_functions(handler_type="ask_user")
+        return len(suspended) > 0
+    
+    async def resume_hitl_function(self, user_text: str):
+        """Resume suspended HITL function with user response"""
+        suspended_hitl = await self.get_suspended_hitl_function()
+        if suspended_hitl:
+            result = await suspended_hitl.resume(UserMessage(content=user_text), suspended_hitl.state)
+            await self.handle_resume_result(result)
+```
+
+### 3. **Handler Generation Strategy**
+
+The system generates handler aliases based on AsyncFunction handler types:
+
+```python
+# Handler generation mapping
+handler_mappings = {
+    AskUserHandler: None,  # No alias - handle in @on_message
+    GetApprovalHandler: ("on_{function_name}_response", "card.action", AdaptiveCardInvokeActivity),  
+    WebhookHandler: ("on_{function_name}_webhook", "invoke", InvokeActivity),
+    SelectFromOptionsHandler: ("on_{function_name}_selection", "card.action", AdaptiveCardInvokeActivity),
+    TimerHandler: None,  # No handler needed - auto-resume
+}
+
+# Documentation generated for each AsyncFunction
+"""
+AsyncFunction Handler Requirements:
+
+STRUCTURED RESPONSES (get dedicated handlers):
+- GetApprovalHandler -> @on_{name}_response (AdaptiveCardInvokeActivity)
+- WebhookHandler -> @on_{name}_webhook (InvokeActivity)  
+- SelectFromOptionsHandler -> @on_{name}_selection (AdaptiveCardInvokeActivity)
+
+TEXT RESPONSES (handled in @on_message):
+- AskUserHandler -> Handle in @on_message with suspend/resume logic
+- HumanInTheLoopHandler -> Handle in @on_message with suspend/resume logic
+
+Example:
+
+approval_function = AsyncFunction(name="expense_approval", handler=GetApprovalHandler())
+# REQUIRES: @on_expense_approval_response
+
+hitl_function = AsyncFunction(name="human_in_loop", handler=AskUserHandler()) 
+# REQUIRES: Logic in @on_message to detect and resume HITL responses
+"""
+```
+
+### 4. **Developer Resume Strategies**
+
+Developers can choose different strategies for handling ambiguous text message routing:
+
+**Strategy A: Suspend-First**
+```python
+@on_message
+async def handle(self, activity):
+    if await self.has_suspended_hitl():
+        await self.resume_hitl(activity.text)
+    else:
+        await self.normal_chat(activity.text)
+```
+
+**Strategy B: Keyword Detection**
+```python
+@on_message  
+async def handle(self, activity):
+    if self.is_likely_hitl_response(activity.text):
+        await self.try_resume_hitl(activity.text)
+    else:
+        await self.normal_chat(activity.text)
+```
+
+**Strategy C: Always Try HITL First**
+```python
+@on_message
+async def handle(self, activity):
+    if not await self.try_resume_hitl(activity.text):
+        await self.normal_chat(activity.text)
+```
+
+## Integration Points
+
+### 1. ChatPrompt Changes
+
+```python
+class ChatPrompt:
+    def __init__(self, model: AIModel, *, functions: list[Union[Function[Any], AsyncFunction[Any]]] | None = None):
+        # Support both Function and AsyncFunction types
+        self.functions: dict[str, Union[Function[Any], AsyncFunction[Any]]] = {
+            func.name: func for func in functions
+        } if functions else {}
+
+    async def send(self, input: str | Message, **kwargs) -> ChatSendResult:
+        if isinstance(input, str):
+            input = UserMessage(content=input)
+        
+        # Check for suspended functions
+        suspended_calls = await memory.get_suspended_calls()
+        
+        if suspended_calls:
+            return await self._resume_suspended_function(input, suspended_calls[0])
+        else:
+            return await self._process_new_message(input, **kwargs)
+
+    async def _resume_suspended_function(self, user_input: UserMessage, call: FunctionCall) -> ChatSendResult:
+        function = self.functions[call.name]
+        
+        # Resume the function
+        result = function.resume(user_input, call.state)
+        if inspect.isawaitable(result):
+            result = await result
+        
+        if isinstance(result, DeferredResult):
+            # Function suspended again
+            await memory.store_suspended_call(call)
+            return ChatSendResult(response=result)
+        else:
+            # Function completed - send result to LLM
+            function_message = FunctionMessage(content=result, function_id=call.id)
+            response = await self.model.generate_text(function_message, memory=memory, functions=self.functions)
+            return ChatSendResult(response=response)
+```
+
+### 2. AIModel Protocol Update
+
+```python
+class AIModel(Protocol):
+    async def generate_text(
+        self,
+        input: Message,
+        *,
+        system: SystemMessage | None = None,
+        memory: Memory | None = None,
+        functions: dict[str, Union[Function[BaseModel], AsyncFunction[BaseModel]]] | None = None,
+        on_chunk: Callable[[str], Awaitable[None]] | None = None,
+    ) -> Union[ModelMessage, AnyDeferredResult]:
+        # Can return either completed ModelMessage OR suspension
+        ...
+```
+
+### 3. OpenAI Model Changes
+
+```python
+async def generate_text(self, input, **kwargs) -> Union[ModelMessage, AnyDeferredResult]:
+    function_results = await self._execute_functions(input, functions)
+    
+    # Check if any function suspended
+    for result in function_results:
+        if isinstance(result, DeferredResult):
+            return result  # Return suspension immediately
+    
+    # No suspensions - continue with normal LLM call
+    openai_messages = self._convert_messages(input, system, messages)
+    response = await self._client.chat.completions.create(...)
+    model_response = self._convert_response(response)
+    
+    if model_response.function_calls:
+        return await self.generate_text(model_response, **kwargs)
+    
+    return model_response
+
+async def _execute_functions(self, input: Message, functions) -> list[Union[FunctionMessage, DeferredResult]]:
+    results = []
+    
+    if isinstance(input, ModelMessage) and input.function_calls:
+        for call in input.function_calls:
+            function = functions[call.name]
+            parsed_args = parse_function_arguments(function, call.arguments)
+            
+            if isinstance(function, AsyncFunction):
+                result = function.handler(parsed_args)
+            else:
+                result = function.handler(parsed_args)
+            
+            if inspect.isawaitable(result):
+                result = await result
+                
+            if isinstance(result, DeferredResult):
+                # Update call with suspension info
+                call.type = "async"
+                call.status = "suspended" 
+                call.state = result.state
+                call.handler = result.handler
+                results.append(result)
+                break  # Stop processing on suspension
+            else:
+                results.append(FunctionMessage(content=result, function_id=call.id))
+    
+    return results
+```
+
+### 4. Memory Extensions
+
+```python
+class Memory(Protocol):
+    # Existing methods
+    async def push(self, message: Message) -> None: ...
+    async def get_all(self) -> list[Message]: ...
+    
+    # New methods for suspension
+    async def store_suspended_call(self, call: FunctionCall) -> None: ...
+    async def get_suspended_calls(self) -> list[FunctionCall]: ...
+    async def clear_suspended_calls(self) -> None: ...
+
+class ListMemory:
+    def __init__(self):
+        self._messages: list[Message] = []
+        self._suspended_calls: list[FunctionCall] = []
+    
+    async def store_suspended_call(self, call: FunctionCall) -> None:
+        self._suspended_calls.append(call)
+    
+    async def get_suspended_calls(self) -> list[FunctionCall]:
+        return self._suspended_calls.copy()
+    
+    async def clear_suspended_calls(self) -> None:
+        self._suspended_calls.clear()
+```
+
+## User Experience Examples
+
+### Simple Interaction
+
+```python
+# Setup
+chat = ChatPrompt(model=openai_model, functions=[shopping_function])
+
+# Initial call suspends
+result = await chat.send("Add something to my cart")
+print(result.response.handler.question)  # "What additional item would you like to add?"
+
+# Resume automatically
+result = await chat.send("socks")
+print(result.response.content)  # "I've added 'socks' to your cart with ['shoes', 'shirts']"
+```
+
+### Multi-Step Workflow
+
+```python
+# Step 1: Suspension
+result = await chat.send("Submit my expense report")
+print(result.response.handler.prompt)  # "Manager approval needed for $250 expense: 'Office supplies'"
+
+# Step 2: Still suspended
+result = await chat.send("approved")
+print(result.response.handler.prompt)  # "Director approval needed for $250 expense"
+
+# Step 3: Completion
+result = await chat.send("approved")
+print(result.response.content)  # "Expense 'Office supplies - $250' fully approved!"
+```
+
+## Implementation Plan: Human-in-the-Loop AsyncFunction
+
+### Phase 1: Core Types (function.py)
+1. Add AskUserHandler and DeferredResult types
+2. Extend FunctionCall with async fields
+3. Create AsyncFunction protocol and dataclass
+4. Update imports and type variables
+
+### Phase 2: Memory Support
+5. Update Memory protocol with suspension methods
+6. Implement ListMemory suspension support
+
+### Phase 3: Model Integration
+7. Update AIModel protocol return type
+8. Modify OpenAI models _execute_functions for DeferredResult
+9. Update ChatPrompt to handle DeferredResult and resume
+
+### Phase 4: Testing
+10. Create simple HITL test/example
+11. Update __init__.py exports
+
+## Key Files to Modify
+
+- `packages/ai/src/microsoft/teams/ai/function.py` - Core types
+- `packages/ai/src/microsoft/teams/ai/memory.py` - Memory protocol
+- `packages/ai/src/microsoft/teams/ai/list_memory.py` - Memory implementation  
+- `packages/ai/src/microsoft/teams/ai/ai_model.py` - AIModel protocol
+- `packages/ai/src/microsoft/teams/ai/chat_prompt.py` - ChatPrompt logic
+- `packages/openai/src/microsoft/teams/openai/completions_model.py` - OpenAI implementation
+- `packages/openai/src/microsoft/teams/openai/responses_chat_model.py` - OpenAI implementation
+- `packages/ai/src/microsoft/teams/ai/__init__.py` - Exports
+
+## Backward Compatibility
+
+- All existing `Function` objects continue working unchanged
+- No breaking changes to existing function handlers
+- ChatPrompt can mix both sync and async functions
+- Models handle both types transparently
+- Existing memory implementations work (new methods optional)
+
+## Benefits
+
+1. **Type Safety**: Generic DeferredResult ensures handler/resumer type matching
+2. **Clean Separation**: ChatPrompt handles conversation flow, models handle execution
+3. **Simple Integration**: Minimal changes to existing codebase
+4. **Flexible**: Supports various interaction patterns (user input, webhooks, timers)
+5. **Natural UX**: Users continue normal conversation flow during suspensions
+
+---
+
+## Appendix: Alternative Approaches Considered
+
+### A1. Suspend Callback Approach
+
+**Initial Design:**
+```python
+async def handler(params: AsyncParams[T], suspend: SuspendCallback) -> str:
+    if params.type == "init":
+        suspend(state_data)
+    elif params.type == "resumed":
+        # Handle resume
+```
+
+**Issues:**
+- Complex AsyncParams type trying to handle both init and resume data
+- Different data shapes (structured params vs simple user responses) 
+- Magic suspend callback felt indirect
+- Harder to follow workflow logic across init/resume
+
+### A2. String-Based Handlers
+
+**Alternative Design:**
+```python
+@dataclass
+class DeferredResult:
+    state: dict[str, Any]
+    handler: str  # "AskUser", "GetApproval"
+    output: str   # Display text
+```
+
+**Issues:**
+- No type safety for handler types
+- String typos ("AskUer" vs "AskUser")
+- No IDE autocomplete support
+- Hard to extend with new handler types
+
+### A3. Complex Recursion Control
+
+**Alternative Design:**
+```python
+async def generate_text(...) -> ModelMessage:
+    function_results, has_suspended = await self._execute_functions(...)
+    
+    if model_response.function_calls and not has_suspended:
+        return await self.generate_text(...)  # Only recurse if no suspensions
+```
+
+**Issues:**
+- Complex state tracking in models
+- Need to modify ModelMessage structure
+- Suspension state scattered across multiple places
+- Harder to reason about control flow
+
+### A4. Explicit Resume API
+
+**Alternative Design:**
+```python
+# Suspend
+result = await chat.send("Process payment")
+
+# Explicit resume method
+resume_result = await chat.resume("yes, I approve")
+```
+
+**Issues:**
+- Two different APIs for users to learn
+- More complex state management
+- Less natural conversation flow
+- Users need to understand suspend/resume mechanics
+
+### A5. Models Return Complex Union Types
+
+**Alternative Design:**
+```python
+async def generate_text(...) -> Union[ModelMessage, DeferredResult, SuspendedState]:
+    # Multiple return types based on execution state
+```
+
+**Issues:**
+- Complex type handling throughout system
+- Unclear which type to expect when
+- More difficult error handling
+- Harder to extend with new states
+
+---
+
+## Conclusion
+
+The chosen design balances simplicity, type safety, and clean integration. The generic DeferredResult approach provides strong typing while the simplified resume flow (AsyncFunction.resume → FunctionMessage → LLM) keeps the implementation straightforward and maintainable.

--- a/packages/ai/src/microsoft/teams/ai/__init__.py
+++ b/packages/ai/src/microsoft/teams/ai/__init__.py
@@ -6,9 +6,9 @@ Licensed under the MIT License.
 from .agent import Agent
 from .ai_model import AIModel
 from .chat_prompt import ChatPrompt, ChatSendResult
-from .function import Function, FunctionCall
+from .function import DeferredResult, Function, FunctionCall
 from .memory import ListMemory, Memory
-from .message import FunctionMessage, Message, ModelMessage, SystemMessage, UserMessage
+from .message import DeferredMessage, FunctionMessage, Message, ModelMessage, SystemMessage, UserMessage
 
 __all__ = [
     "ChatSendResult",
@@ -19,8 +19,10 @@ __all__ = [
     "ModelMessage",
     "SystemMessage",
     "FunctionMessage",
+    "DeferredMessage",
     "Function",
     "FunctionCall",
+    "DeferredResult",
     "Memory",
     "ListMemory",
     "AIModel",

--- a/packages/ai/src/microsoft/teams/ai/ai_model.py
+++ b/packages/ai/src/microsoft/teams/ai/ai_model.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from .function import Function
 from .memory import Memory
-from .message import Message, ModelMessage, SystemMessage
+from .message import DeferredMessage, Message, ModelMessage, SystemMessage
 
 
 class AIModel(Protocol):
@@ -23,13 +23,13 @@ class AIModel(Protocol):
 
     async def generate_text(
         self,
-        input: Message,
+        input: Message | None,
         *,
         system: SystemMessage | None = None,
         memory: Memory | None = None,
         functions: dict[str, Function[BaseModel]] | None = None,
         on_chunk: Callable[[str], Awaitable[None]] | None = None,
-    ) -> ModelMessage:
+    ) -> ModelMessage | list[DeferredMessage]:
         """
         Generate a text response from the AI model.
 

--- a/packages/ai/src/microsoft/teams/ai/chat_prompt.py
+++ b/packages/ai/src/microsoft/teams/ai/chat_prompt.py
@@ -6,14 +6,16 @@ Licensed under the MIT License.
 import inspect
 from dataclasses import dataclass
 from inspect import isawaitable
+from logging import Logger
 from typing import Any, Awaitable, Callable, Self, TypeVar, cast
 
+from microsoft.teams.common.logging import ConsoleLogger
 from pydantic import BaseModel
 
 from .ai_model import AIModel
 from .function import Function, FunctionHandler
 from .memory import Memory
-from .message import Message, ModelMessage, SystemMessage, UserMessage
+from .message import DeferredMessage, FunctionMessage, Message, ModelMessage, SystemMessage, UserMessage
 from .plugin import AIPluginProtocol
 
 T = TypeVar("T", bound=BaseModel)
@@ -46,6 +48,9 @@ class ChatPrompt:
         *,
         functions: list[Function[Any]] | None = None,
         plugins: list[AIPluginProtocol] | None = None,
+        memory: Memory | None = None,
+        logger: Logger | None = None,
+        instructions: str | SystemMessage | None = None,
     ):
         """
         Initialize ChatPrompt with model and optional functions/plugins.
@@ -54,10 +59,16 @@ class ChatPrompt:
             model: AI model implementation for text generation
             functions: Optional list of functions the model can call
             plugins: Optional list of plugins for extending functionality
+            memory: Optional memory for conversation context and deferred state
+            logger: Optional logger for debugging and monitoring
+            instructions: Optional default system instructions for the model
         """
         self.model = model
         self.functions: dict[str, Function[Any]] = {func.name: func for func in functions} if functions else {}
         self.plugins: list[AIPluginProtocol] = plugins or []
+        self.memory = memory
+        self.logger = logger or ConsoleLogger().create_logger("@teams/ai/chat_prompt")
+        self.instructions = instructions
 
     def with_function(self, function: Function[T]) -> Self:
         """
@@ -85,6 +96,112 @@ class ChatPrompt:
         self.plugins.append(plugin)
         return self
 
+    async def requires_resuming(self) -> bool:
+        """
+        Check if there are any deferred functions that need resuming.
+
+        Returns:
+            True if there are DeferredMessage objects in memory that need resuming
+        """
+        if not self.memory:
+            return False
+
+        messages = await self.memory.get_all()
+        return any(isinstance(msg, DeferredMessage) for msg in messages)
+
+    async def resolve_deferred(self, activity: Any) -> list[str]:
+        """
+        Resolve deferred functions with the provided activity input.
+
+        Only attempts to resolve deferred functions whose resumers can handle
+        the provided activity type (determined by can_handle method).
+
+        Args:
+            activity: Activity data to use for resolving deferred functions
+
+        Returns:
+            List of resolution results from successfully resolved functions
+        """
+        if not self.memory:
+            return []
+
+        messages = await self.memory.get_all()
+        deferred_messages = [msg for msg in messages if isinstance(msg, DeferredMessage)]
+
+        if not deferred_messages:
+            return []
+
+        results: list[str] = []
+        updated_messages = messages.copy()  # Work with a copy
+
+        for i, msg in enumerate(updated_messages):
+            if not isinstance(msg, DeferredMessage):
+                continue
+
+            # Find the function from the deferred result's resumer_name
+            resumer_name = msg.function_name
+            associated_func = self.functions.get(resumer_name)
+            if not associated_func or associated_func.resumer is None:
+                raise ValueError(f"Expected a resumer for {resumer_name} but chat prompt was not set up with one")
+
+            # Use the resumer function directly from the function definition
+            # Check if the resumer can handle this type of activity
+            if not associated_func.resumer.can_handle(activity):
+                # Skip this deferred function - it can't handle this activity type
+                continue
+
+            try:
+                # Call the resumer with the activity and saved state
+                result = associated_func.resumer(activity, msg.deferred_result.state)
+                if isawaitable(result):
+                    result = await result
+
+                # Replace the DeferredMessage with FunctionMessage in-place
+                updated_messages[i] = FunctionMessage(content=result, function_id=msg.function_id)
+                results.append(result)
+
+            except Exception as e:
+                # Log error but continue with other deferred functions
+                error_msg = f"Error resolving {resumer_name}: {str(e)}"
+                results.append(error_msg)
+
+                # Replace with error FunctionMessage
+                updated_messages[i] = FunctionMessage(content=error_msg, function_id=msg.function_id)
+
+        # Update memory with resolved messages
+        if results:  # Only update if we actually resolved something
+            await self.memory.set_all(updated_messages)
+
+        return results
+
+    async def resume(self, activity: Any) -> ChatSendResult:
+        """
+        Resume deferred functions with the provided activity input.
+
+        If all deferred functions are resolved, automatically continues with
+        normal chat processing using the activity text as input.
+
+        Args:
+            activity: Activity data to use for resolving deferred functions
+
+        Returns:
+            ChatSendResult - either indicating still deferred or containing the chat response
+        """
+        await self.resolve_deferred(activity)
+
+        # If there are still deferred functions pending, return early
+        if await self.requires_resuming():
+            return ChatSendResult(response=None, is_deferred=True)
+
+        # All deferred functions resolved, continue with normal chat processing
+        # Use the activity text as input
+        input_text = getattr(activity, "text", None)
+        if input_text is None:
+            # No text to process, just return success
+            return ChatSendResult(response=None, is_deferred=False)
+
+        return await self.send(input=input_text)
+
     async def send(
         self,
         input: str | Message,
@@ -109,6 +226,10 @@ class ChatPrompt:
         if isinstance(input, str):
             input = UserMessage(content=input)
 
+        # Use constructor instructions as default if none provided
+        if instructions is None:
+            instructions = self.instructions
+
         # Convert string instructions to SystemMessage
         if isinstance(instructions, str):
             instructions = SystemMessage(content=instructions)
@@ -127,7 +248,7 @@ class ChatPrompt:
         response = await self.model.generate_text(
             current_input,
             system=current_system_message,
-            memory=memory,
+            memory=memory or self.memory,
             functions=wrapped_functions,
             on_chunk=on_chunk_fn if on_chunk else None,
         )
@@ -231,7 +352,7 @@ class ChatPrompt:
                 description=func.description,
                 parameter_schema=func.parameter_schema,
                 handler=self._wrap_function_handler(cast(FunctionHandler[BaseModel], func.handler), func.name)
-                if func.handler_type == "standard"
+                if func.resumer is None
                 else func.handler,
             )
 

--- a/packages/ai/src/microsoft/teams/ai/function.py
+++ b/packages/ai/src/microsoft/teams/ai/function.py
@@ -39,22 +39,6 @@ class FunctionHandler(Protocol[Params]):
         ...
 
 
-@dataclass
-class FunctionCall:
-    """
-    Represents a function call request from an AI model.
-
-    Contains the function name, unique call ID, and parsed arguments
-    that will be passed to the function handler.
-    """
-
-    id: str  # Unique identifier for this function call
-    name: str  # Name of the function to call
-    arguments: dict[str, Any]  # Parsed arguments for the function
-
-    resumable_state: Optional[dict[str, Any]] = None
-
-
 class DeferredFunctionResumer(Generic[Params, ResumableData]):
     """
     The resumable function returns the actual string
@@ -72,6 +56,22 @@ class DeferredResult:
     state: dict[str, Any]
     resumer_name: str
     type: Literal["deferred"] = "deferred"
+
+
+@dataclass
+class FunctionCall:
+    """
+    Represents a function call request from an AI model.
+
+    Contains the function name, unique call ID, and parsed arguments
+    that will be passed to the function handler.
+    """
+
+    id: str  # Unique identifier for this function call
+    name: str  # Name of the function to call
+    arguments: dict[str, Any]  # Parsed arguments for the function
+
+    resumable_state: Optional[DeferredResult] = None
 
 
 class DeferredFunctionHandler(Protocol[Params]):
@@ -101,3 +101,4 @@ class Function(Generic[Params]):
     description: str  # Human-readable description of what the function does
     parameter_schema: Union[type[Params], Dict[str, Any]]  # Pydantic model class or JSON schema dict
     handler: FunctionHandler[Params] | DeferredFunctionHandler[Params]  # Function implementation (sync or async)
+    handler_type: Literal["standard", "deferred"] = "standard"  # Type of function handler

--- a/packages/ai/src/microsoft/teams/ai/message.py
+++ b/packages/ai/src/microsoft/teams/ai/message.py
@@ -71,6 +71,7 @@ class DeferredMessage:
     """
 
     deferred_result: DeferredResult
+    function_name: str
     function_id: str
 
 

--- a/packages/ai/src/microsoft/teams/ai/message.py
+++ b/packages/ai/src/microsoft/teams/ai/message.py
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 from dataclasses import dataclass
 from typing import Literal, Union
 
-from .function import FunctionCall
+from .function import DeferredResult, FunctionCall
 
 
 @dataclass
@@ -64,7 +64,17 @@ class FunctionMessage:
     role: Literal["function"] = "function"  # Message type identifier
 
 
-Message = Union[UserMessage, ModelMessage, SystemMessage, FunctionMessage]
+@dataclass
+class DeferredMessage:
+    """
+    Represents a function call that is deferred
+    """
+
+    deferred_result: DeferredResult
+    function_id: str
+
+
+Message = Union[UserMessage, ModelMessage, SystemMessage, FunctionMessage, DeferredMessage]
 """
 Union type representing any message in a conversation.
 

--- a/packages/apps/src/microsoft/teams/apps/utils/retry.py
+++ b/packages/apps/src/microsoft/teams/apps/utils/retry.py
@@ -33,8 +33,10 @@ class RetryOptions:
         self.max_delay = max_delay
         self.jitter_type: JitterType = jitter_type
         # Use existing internal logger if provided, otherwise create child logger
-        self.logger = _internal_logger if _internal_logger else (
-            logger.getChild("@teams/retry") if logger else ConsoleLogger().create_logger("@teams/retry")
+        self.logger = (
+            _internal_logger
+            if _internal_logger
+            else (logger.getChild("@teams/retry") if logger else ConsoleLogger().create_logger("@teams/retry"))
         )
         self.previous_delay = previous_delay
         self.attempt_number = attempt_number
@@ -87,9 +89,7 @@ async def retry(factory: Callable[[], Awaitable[T]], options: Optional[RetryOpti
             # Apply jitter
             jittered_delay = _apply_jitter(capped_delay, jitter_type, previous_delay)
 
-            logger.debug(
-                f"Delaying {jittered_delay:.2f}s before retry (attempt {attempt_number})..."
-            )
+            logger.debug(f"Delaying {jittered_delay:.2f}s before retry (attempt {attempt_number})...")
             await asyncio.sleep(jittered_delay)
             logger.debug("Retrying...")
 

--- a/packages/apps/tests/test_retry.py
+++ b/packages/apps/tests/test_retry.py
@@ -3,7 +3,6 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,7 +11,7 @@ from microsoft.teams.apps.utils import RetryOptions, retry
 
 class TestRetryOptions:
     """Test RetryOptions functionality."""
-    
+
     def test_default_initialization(self):
         """Test that RetryOptions initializes with correct defaults."""
         options = RetryOptions()
@@ -22,7 +21,7 @@ class TestRetryOptions:
         assert options.jitter_type == "full"
         assert options.attempt_number == 1
         assert options.logger is not None
-    
+
     def test_custom_initialization(self):
         """Test that RetryOptions can be initialized with custom values."""
         mock_logger = MagicMock()
@@ -45,86 +44,86 @@ class TestRetryOptions:
 
 class TestRetry:
     """Test retry functionality."""
-    
+
     @pytest.mark.asyncio
     async def test_success_on_first_attempt(self):
         """Test that successful operations don't retry."""
         call_count = 0
-        
+
         async def success_factory():
             nonlocal call_count
             call_count += 1
             return "success"
-        
+
         result = await retry(success_factory)
         assert result == "success"
         assert call_count == 1
-    
+
     @pytest.mark.asyncio
     async def test_attempt_number_increments_correctly(self):
         """Test that attempt numbers increment correctly in log messages."""
         call_count = 0
         mock_logger = MagicMock()
         logged_messages = []
-        
+
         def capture_debug(msg):
             logged_messages.append(msg)
-        
+
         mock_child_logger = MagicMock()
         mock_child_logger.debug.side_effect = capture_debug
         mock_logger.getChild.return_value = mock_child_logger
-        
+
         async def failing_factory():
             nonlocal call_count
             call_count += 1
             if call_count < 3:  # Fail first 2 attempts
                 raise ValueError(f"Attempt {call_count} failed")
             return "success"
-        
+
         options = RetryOptions(max_attempts=3, delay=0.01, jitter_type="none", logger=mock_logger)
         result = await retry(failing_factory, options)
-        
+
         assert result == "success"
         assert call_count == 3
-        
+
         # Check that attempt numbers are logged correctly
         delay_messages = [msg for msg in logged_messages if "before retry (attempt" in msg]
         assert len(delay_messages) == 2  # Two retries (attempts 1 and 2 failed)
         assert "(attempt 1)" in delay_messages[0]  # First retry shows attempt 1 (which failed)
         assert "(attempt 2)" in delay_messages[1]  # Second retry shows attempt 2 (which failed)
-    
+
     @pytest.mark.asyncio
     async def test_exponential_backoff_increases(self):
         """Test that exponential backoff delays increase exponentially."""
         call_count = 0
         mock_logger = MagicMock()
         logged_delays = []
-        
+
         def capture_debug(msg):
             if "Delaying" in msg and "before retry" in msg:
                 # Extract delay value from message like "Delaying 1.00s before retry..."
                 delay_str = msg.split("Delaying ")[1].split("s")[0]
                 logged_delays.append(float(delay_str))
-        
+
         mock_child_logger = MagicMock()
         mock_child_logger.debug.side_effect = capture_debug
         mock_logger.getChild.return_value = mock_child_logger
-        
+
         async def failing_factory():
             nonlocal call_count
             call_count += 1
             if call_count < 4:  # Fail first 3 attempts
                 raise ValueError(f"Attempt {call_count} failed")
             return "success"
-        
+
         # Use no jitter to test pure exponential backoff
         options = RetryOptions(max_attempts=4, delay=1.0, jitter_type="none", logger=mock_logger)
         result = await retry(failing_factory, options)
-        
+
         assert result == "success"
         assert call_count == 4
         assert len(logged_delays) == 3  # Three retries
-        
+
         # Check exponential increase: base_delay * (2^(attempt_number - 1))
         # Attempt 1: 1.0 * (2^0) = 1.0
         # Attempt 2: 1.0 * (2^1) = 2.0
@@ -132,57 +131,57 @@ class TestRetry:
         assert logged_delays[0] == 1.0  # First retry (after attempt 1 failed)
         assert logged_delays[1] == 2.0  # Second retry (after attempt 2 failed)
         assert logged_delays[2] == 4.0  # Third retry (after attempt 3 failed)
-    
+
     @pytest.mark.asyncio
     async def test_logger_name_consistent(self):
         """Test that logger name doesn't keep growing with recursive calls."""
         call_count = 0
         mock_logger = MagicMock()
         mock_logger.name = "test_logger"
-        
+
         # Track how many times getChild is called
         child_call_count = 0
-        
+
         def track_get_child(child_name):
             nonlocal child_call_count
             child_call_count += 1
             child_mock = MagicMock()
             child_mock.name = f"{mock_logger.name}.{child_name}"
             return child_mock
-        
+
         mock_logger.getChild.side_effect = track_get_child
-        
+
         async def failing_factory():
             nonlocal call_count
             call_count += 1
             if call_count < 3:  # Fail first 2 attempts
                 raise ValueError(f"Attempt {call_count} failed")
             return "success"
-        
+
         options = RetryOptions(max_attempts=3, delay=0.01, logger=mock_logger)
         result = await retry(failing_factory, options)
-        
+
         assert result == "success"
         assert call_count == 3
-        
+
         # getChild should only be called once (for the initial RetryOptions)
         # Recursive calls should reuse the existing child logger
         assert child_call_count == 1
         mock_logger.getChild.assert_called_once_with("@teams/retry")
-    
+
     @pytest.mark.asyncio
     async def test_final_attempt_failure_raises(self):
         """Test that final attempt failures are raised."""
         call_count = 0
-        
+
         async def always_fail():
             nonlocal call_count
             call_count += 1
             raise ValueError(f"Always fails - attempt {call_count}")
-        
+
         options = RetryOptions(max_attempts=2, delay=0.01, jitter_type="none")
-        
+
         with pytest.raises(ValueError, match="Always fails - attempt 2"):
             await retry(always_fail, options)
-        
+
         assert call_count == 2  # Should attempt exactly max_attempts times

--- a/packages/openai/src/microsoft/teams/openai/completions_model.py
+++ b/packages/openai/src/microsoft/teams/openai/completions_model.py
@@ -195,7 +195,9 @@ class OpenAICompletionsAIModel(OpenAIBaseModel, AIModel):
                             fn_res = result
 
                         if isinstance(fn_res, DeferredResult):
-                            function_results.append(DeferredMessage(deferred_result=fn_res, function_id=call.id))
+                            function_results.append(
+                                DeferredMessage(deferred_result=fn_res, function_name=call.name, function_id=call.id)
+                            )
                         else:
                             # Create function result message
                             function_results.append(FunctionMessage(content=fn_res, function_id=call.id))

--- a/packages/openai/src/microsoft/teams/openai/completions_model.py
+++ b/packages/openai/src/microsoft/teams/openai/completions_model.py
@@ -20,6 +20,8 @@ from microsoft.teams.ai import (
     SystemMessage,
     UserMessage,
 )
+from microsoft.teams.ai.function import DeferredResult
+from microsoft.teams.ai.message import DeferredMessage
 from microsoft.teams.openai.common import OpenAIBaseModel
 from pydantic import BaseModel
 
@@ -67,13 +69,13 @@ class OpenAICompletionsAIModel(OpenAIBaseModel, AIModel):
 
     async def generate_text(
         self,
-        input: Message,
+        input: Message | None,
         *,
         system: SystemMessage | None = None,
         memory: Memory | None = None,
         functions: dict[str, Function[BaseModel]] | None = None,
         on_chunk: Callable[[str], Awaitable[None]] | None = None,
-    ) -> ModelMessage:
+    ) -> ModelMessage | list[DeferredMessage]:
         """
         Generate text using OpenAI Chat Completions API.
 
@@ -96,27 +98,35 @@ class OpenAICompletionsAIModel(OpenAIBaseModel, AIModel):
         if memory is None:
             memory = ListMemory()
 
-        # Execute any pending function calls first
-        function_results = await self._execute_functions(input, functions)
-
         # Get conversation history from memory (make a copy to avoid modifying memory's internal state)
         messages = list(await memory.get_all())
+
+        # Execute any pending function calls first
+        function_results = await self._execute_functions(input, messages, functions)
         self.logger.debug(f"Retrieved {len(messages)} messages from memory, {len(function_results)} function results")
 
         # Push current input to memory
-        await memory.push(input)
+        if input is not None:
+            await memory.push(input)
 
         # Push function results to memory and add to messages
+        deferred_messages: list[DeferredMessage] = []
         if function_results:
             # Add the original ModelMessage with function_calls to messages first
-            messages.append(input)
+            if input is not None:
+                messages.append(input)
             for result in function_results:
                 await memory.push(result)
                 messages.append(result)
+                if isinstance(result, DeferredMessage):
+                    deferred_messages.append(result)
             # Don't add input again at the end - Order matters here!
             input_to_send = None
         else:
             input_to_send = input
+
+        if len(deferred_messages) > 0:
+            return deferred_messages
 
         # Convert messages to OpenAI format
         openai_messages = self._convert_messages(input_to_send, system, messages)
@@ -152,15 +162,25 @@ class OpenAICompletionsAIModel(OpenAIBaseModel, AIModel):
         return model_response
 
     async def _execute_functions(
-        self, input: Message, functions: dict[str, Function[BaseModel]] | None
-    ) -> list[FunctionMessage]:
+        self, input: Message | None, memory_messages: list[Message], functions: dict[str, Function[BaseModel]] | None
+    ) -> list[FunctionMessage | DeferredMessage]:
         """Execute any pending function calls in the input message."""
-        function_results: list[FunctionMessage] = []
+        function_results: list[FunctionMessage | DeferredMessage] = []
 
         if isinstance(input, ModelMessage) and input.function_calls:
             # Execute any pending function calls
             self.logger.debug(f"Executing {len(input.function_calls)} function calls")
             for call in input.function_calls:
+                existing_function_result = next(
+                    (
+                        message
+                        for message in memory_messages
+                        if isinstance(message, FunctionMessage) and message.function_id == call.id
+                    ),
+                    None,
+                )
+                if existing_function_result is None:
+                    self.logger.debug(f"{call.name} already called. Skipping exeuction")
                 if functions and call.name in functions:
                     function = functions[call.name]
                     try:
@@ -174,8 +194,11 @@ class OpenAICompletionsAIModel(OpenAIBaseModel, AIModel):
                         else:
                             fn_res = result
 
-                        # Create function result message
-                        function_results.append(FunctionMessage(content=fn_res, function_id=call.id))
+                        if isinstance(fn_res, DeferredResult):
+                            function_results.append(DeferredMessage(deferred_result=fn_res, function_id=call.id))
+                        else:
+                            # Create function result message
+                            function_results.append(FunctionMessage(content=fn_res, function_id=call.id))
                     except Exception as e:
                         self.logger.error(e)
                         # Handle function execution errors
@@ -258,37 +281,43 @@ class OpenAICompletionsAIModel(OpenAIBaseModel, AIModel):
         return openai_messages
 
     def _convert_message_to_openai_format(self, message: Message) -> ChatCompletionMessageParam:
-        if isinstance(
-            message,
-            UserMessage,
-        ):
-            return ChatCompletionUserMessageParam(role=message.role, content=message.content)
-        if isinstance(message, SystemMessage):
-            return ChatCompletionSystemMessageParam(role=message.role, content=message.content)
-
-        elif isinstance(message, FunctionMessage):
-            return ChatCompletionToolMessageParam(
-                role="tool",
-                content=message.content or [],
-                tool_call_id=message.function_id,
-            )
-        elif isinstance(message, ModelMessage):  # pyright: ignore [reportUnnecessaryIsInstance]
-            if message.function_calls:
-                tool_calls = [
-                    ChatCompletionMessageFunctionToolCallParam(
-                        id=call.id,
-                        function={"name": call.name, "arguments": json.dumps(call.arguments)},
-                        type="function",
+        match message:
+            case UserMessage():
+                return ChatCompletionUserMessageParam(role=message.role, content=message.content)
+            case SystemMessage():
+                return ChatCompletionSystemMessageParam(role=message.role, content=message.content)
+            case FunctionMessage():
+                return ChatCompletionToolMessageParam(
+                    role="tool",
+                    content=message.content or [],
+                    tool_call_id=message.function_id,
+                )
+            case ModelMessage():
+                if message.function_calls:
+                    tool_calls = [
+                        ChatCompletionMessageFunctionToolCallParam(
+                            id=call.id,
+                            function={"name": call.name, "arguments": json.dumps(call.arguments)},
+                            type="function",
+                        )
+                        for call in message.function_calls
+                    ]
+                else:
+                    # we need to do this cast because Completions expects tool_calls to be >= 1,
+                    # but the type is not Optional
+                    tool_calls = cast(list[ChatCompletionMessageFunctionToolCallParam], None)
+                return ChatCompletionAssistantMessageParam(
+                    role="assistant", content=message.content, tool_calls=tool_calls
+                )
+            case DeferredMessage():
+                raise ValueError(
+                    (
+                        "A deferred_message should not be sent to OpenAI. It needs to be resolved "
+                        "and converted to a FunctionMessage."
                     )
-                    for call in message.function_calls
-                ]
-            else:
-                # we need to do this cast because Completions expects tool_calls to be >= 1,
-                # but the type is not Optional
-                tool_calls = cast(list[ChatCompletionMessageFunctionToolCallParam], None)
-            return ChatCompletionAssistantMessageParam(role="assistant", content=message.content, tool_calls=tool_calls)
-        else:
-            raise Exception(f"Message {message.role} not supported")
+                )
+            case _:
+                raise Exception(f"Message {message.role} not supported")
 
     def _convert_functions(self, functions: dict[str, Function[BaseModel]]) -> list[ChatCompletionToolUnionParam]:
         function_values = functions.values()

--- a/packages/openai/src/microsoft/teams/openai/responses_chat_model.py
+++ b/packages/openai/src/microsoft/teams/openai/responses_chat_model.py
@@ -20,6 +20,7 @@ from microsoft.teams.ai import (
     SystemMessage,
     UserMessage,
 )
+from microsoft.teams.ai.message import DeferredMessage
 from pydantic import BaseModel
 
 from openai import NOT_GIVEN
@@ -55,13 +56,13 @@ class OpenAIResponsesAIModel(OpenAIBaseModel, AIModel):
 
     async def generate_text(
         self,
-        input: Message,
+        input: Message | None,
         *,
         system: SystemMessage | None = None,
         memory: Memory | None = None,
         functions: dict[str, Function[BaseModel]] | None = None,
         on_chunk: Callable[[str], Awaitable[None]] | None = None,
-    ) -> ModelMessage:
+    ) -> ModelMessage | list[DeferredMessage]:
         """
         Generate text using OpenAI Responses API.
 

--- a/tests/defferred_ai/README.md
+++ b/tests/defferred_ai/README.md
@@ -1,0 +1,1 @@
+# defferred_ai

--- a/tests/defferred_ai/pyproject.toml
+++ b/tests/defferred_ai/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "defferred_ai"
+version = "0.1.0"
+description = "testing deferred tools"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "dotenv>=0.9.9",
+    "microsoft-teams-apps",
+]
+
+[tool.uv.sources]
+microsoft-teams-apps = { workspace = true }

--- a/tests/defferred_ai/src/approval.py
+++ b/tests/defferred_ai/src/approval.py
@@ -1,0 +1,165 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Any, Callable, Protocol, TypeVar
+
+from microsoft.teams.ai import DeferredResult, Function
+from microsoft.teams.ai.function import DeferredFunctionResumer
+from microsoft.teams.api import MessageActivityInput
+from microsoft.teams.api.activities.message.message import MessageActivity
+from pydantic import BaseModel
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class MessageSender(Protocol):
+    """Protocol for anything that can send messages."""
+
+    async def send(self, message: str | MessageActivityInput) -> Any:
+        """Send a message."""
+        ...
+
+
+class ApprovalParams(BaseModel):
+    query: str
+
+
+def create_approval_function(sender: MessageSender) -> Function[ApprovalParams]:
+    """Factory function to create an approval function with captured message sender."""
+
+    async def approval_handler(params: ApprovalParams) -> DeferredResult:
+        """Handler that defers execution and sends approval request."""
+        # Send the approval request message immediately
+        await sender.send(
+            "⏳ **Approval Required**\n\n"
+            f"**Query:** {params.query}\n\n"
+            "Please respond with:\n"
+            "• 'yes' or 'approve' to confirm\n"
+            "• 'no' or 'deny' to cancel"
+        )
+
+        return DeferredResult(
+            state={"query": params.query},
+        )
+
+    class HumanApprovalResumer(DeferredFunctionResumer[ApprovalParams, Any]):
+        """Resumer that handles human approval responses."""
+
+        def can_handle(self, activity: Any) -> bool:
+            """Check if this is a text message that looks like an approval response."""
+            if isinstance(activity, MessageActivity):
+                text = activity.text.lower().strip()
+                approval_keywords = ["yes", "no", "approve", "deny", "reject", "confirm", "cancel"]
+                return any(keyword in text for keyword in approval_keywords)
+            return False
+
+        async def __call__(self, activity: Any, resumable_data: dict[str, Any]) -> str:
+            """Process the human approval response."""
+            assert isinstance(activity, MessageActivity), "activity must be a MessageActivity"
+            user_response = activity.text.lower().strip()
+            query = resumable_data.get("query", "unknown query")
+
+            await sender.send("[DEBUG] got approval result from user")
+            if any(word in user_response for word in ["yes", "approve", "confirm"]):
+                return f"✅ Approved: {query}\nApproval granted by user."
+            else:
+                return f"❌ Denied: {query}\nApproval denied by user."
+
+    return Function(
+        name="get_human_approval",
+        description=(
+            "You must ALWAYS use this tool to get approvals. Do NOT ask for approvaldirectly without using this tool"
+        ),
+        parameter_schema=ApprovalParams,
+        handler=approval_handler,
+        resumer=HumanApprovalResumer(),
+    )
+
+
+def create_approval_wrapped_function[T: BaseModel](
+    sender: MessageSender, original_function: Function[T], create_approval_message: Callable[[T], str]
+) -> Function[T]:
+    """
+    Wrap an existing function with approval workflow.
+
+    Args:
+        sender: Message sender for approval requests
+        original_function: The function to wrap with approval
+        create_approval_message: Function to create approval message based on params
+
+    Returns:
+        A new function that requires approval before executing the original
+    """
+
+    async def wrapped_handler(params: T) -> DeferredResult:
+        """Handler that requests approval before executing the original function."""
+
+        # Create approval message using the provided callback
+        approval_message = create_approval_message(params)
+
+        print(f"[APPROVAL WRAPPER] Requesting approval for: {original_function.name}")
+
+        # Send the approval request message
+        await sender.send(approval_message)
+
+        # Save the call details in state for resume
+        return DeferredResult(
+            state={
+                "params": params.model_dump(),
+            },
+        )
+
+    class ApprovalWrappedResumer(DeferredFunctionResumer[T, Any]):
+        """Resumer that executes the original function after approval."""
+
+        def can_handle(self, activity: Any) -> bool:
+            """Check if this is a text message that looks like an approval response."""
+            if isinstance(activity, MessageActivity):
+                text = activity.text.lower().strip()
+                approval_keywords = ["yes", "no", "approve", "deny", "reject", "confirm", "cancel"]
+                return any(keyword in text for keyword in approval_keywords)
+            return False
+
+        async def __call__(self, activity: Any, resumable_data: dict[str, Any]) -> str:
+            """Process the approval response and execute original function if approved."""
+            assert isinstance(activity, MessageActivity), "expected activity to be a MessageActivity"
+            user_response = activity.text.lower().strip()
+            saved_params = resumable_data.get("params", {})
+
+            await sender.send("[DEBUG] Got approval result!")
+            if any(word in user_response for word in ["yes", "approve", "confirm"]):
+                print("[APPROVAL WRAPPER] Approved, executing original function")
+
+                try:
+                    # Recreate the params object and call original function
+                    # Cast parameter_schema to the type since we know it should be T for Function[T]
+                    schema_type = original_function.parameter_schema
+                    if not isinstance(schema_type, type):
+                        raise ValueError(f"Expected parameter_schema to be a type, got {type(schema_type)}")
+
+                    params_instance = schema_type(**saved_params)
+                    result = original_function.handler(params_instance)
+
+                    # Handle async results
+                    from inspect import isawaitable
+
+                    if isawaitable(result):
+                        result = await result
+
+                    return f"✅ **Approved and Executed**\n\n{result}"
+
+                except Exception as e:
+                    return f"❌ **Approved but Failed**\nError executing {original_function.name}: {str(e)}"
+            else:
+                return "❌ **Cancelled**\nExecution denied by user."
+
+    # Return wrapped function using original function's name, description, and param_schema
+    return Function[T](
+        name=original_function.name,
+        description=original_function.description,
+        parameter_schema=original_function.parameter_schema,
+        handler=wrapped_handler,
+        resumer=ApprovalWrappedResumer(),
+    )

--- a/tests/defferred_ai/src/main.py
+++ b/tests/defferred_ai/src/main.py
@@ -1,0 +1,205 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+import re
+from os import getenv
+from typing import Literal, cast
+
+from approval import create_approval_function, create_approval_wrapped_function
+from dotenv import find_dotenv, load_dotenv
+from microsoft.teams.ai import ChatPrompt, Function, ListMemory
+from microsoft.teams.api import MessageActivity, MessageActivityInput
+from microsoft.teams.apps import ActivityContext, App
+from microsoft.teams.devtools import DevToolsPlugin
+from microsoft.teams.openai import OpenAICompletionsAIModel
+from pydantic import BaseModel
+
+load_dotenv(find_dotenv(usecwd=True))
+
+
+app = App(plugins=[DevToolsPlugin()])
+
+
+def get_required_env(key: str) -> str:
+    value = getenv(key)
+    if not value:
+        raise ValueError(f"Required environment variable {key} is not set")
+    return value
+
+
+# Get OpenAI model (like in ai-test)
+AZURE_OPENAI_MODEL = get_required_env("AZURE_OPENAI_MODEL")
+ai_model = OpenAICompletionsAIModel(model=AZURE_OPENAI_MODEL)
+
+
+class BuyStockParams(BaseModel):
+    stock: str
+    quantity: int
+
+
+def create_buy_stock_function() -> Function[BuyStockParams]:
+    """Create a buy stock function."""
+    return Function(
+        name="buy_stock",
+        description="purchase stocks by specifying ticker symbol and quantity",
+        parameter_schema=BuyStockParams,
+        handler=lambda params: (
+            f"✅ Successfully purchased {params.quantity} shares of {params.stock}. Order executed at market price."
+        ),
+    )
+
+
+# Global memory instance
+memory = ListMemory()
+
+# Global mode flag
+current_mode: Literal["wrapped", "separate", "simple"] = "simple"  # "wrapped" or "separate" or "simple"
+
+
+# Handler for mode switching
+@app.on_message_pattern(re.compile(r"^set\s+(wrapped|separate|simple)$", re.IGNORECASE))
+async def handle_set_mode(ctx: ActivityContext[MessageActivity]) -> None:
+    """Handle 'set <mode>' commands."""
+    global current_mode
+    global memory
+    match = re.match(r"^set\s+(wrapped|separate|simple)$", ctx.activity.text, re.IGNORECASE)
+    if match:
+        mode = match.group(1).lower()
+        current_mode = cast(Literal["wrapped", "separate", "simple"], mode)
+        memory = ListMemory()
+        await ctx.send(f"🔄 Switched to **{mode} {'approval' if mode == 'wrapped' else 'tools'}** mode")
+
+
+@app.on_message_pattern(re.compile(r"^mode$", re.IGNORECASE))
+async def handle_check_mode(ctx: ActivityContext[MessageActivity]) -> None:
+    """Handle 'mode' command to check current mode."""
+    await ctx.send(f"📋 Current mode: **{current_mode}**")
+
+
+@app.on_message
+async def handle_simple(ctx: ActivityContext[MessageActivity]) -> None:
+    if current_mode != "simple":
+        await ctx.next()
+        return
+
+    print(f"[SIMPLE] Message received: {ctx.activity.text}")
+
+    stock_function = create_buy_stock_function()
+    chat_prompt = ChatPrompt(
+        instructions="You are a helpful assistant. Use the available stock trading tool when users want to buy stocks.",
+        model=ai_model,
+        functions=[stock_function],
+        memory=memory,
+    )
+    result = await chat_prompt.send(ctx.activity.text)
+    if result.response and result.response.content:
+        await ctx.send(result.response.content)
+
+
+# Handler for separate tools demo
+@app.on_message
+async def handle_separate_tools_demo(ctx: ActivityContext[MessageActivity]) -> None:
+    """Demo showing separate tools pattern - approval tool + weather tool."""
+    # Only handle if current mode is separate and this is a weather question
+    if current_mode != "separate":
+        await ctx.next()
+        return
+
+    print(f"[SEPARATE TOOLS] Message received: {ctx.activity.text}")
+
+    try:
+        # Create separate approval and stock functions
+        approval_function = create_approval_function(ctx)
+        stock_function = create_buy_stock_function()
+
+        chat_prompt = ChatPrompt(
+            instructions=(
+                "You are a helpful assistant who always asks for approval"
+                " before buying stocks. Use get_human_approval first, then use stock trading tools."
+            ),
+            model=ai_model,
+            functions=[approval_function, stock_function],  # Two separate tools
+            memory=memory,
+        )
+
+        # Handle deferred functions or normal chat
+        if await chat_prompt.requires_resuming():
+            chat_result = await chat_prompt.resume(ctx.activity)
+        else:
+            chat_result = await chat_prompt.send(input=ctx.activity.text)
+
+        if chat_result.response and chat_result.response.content:
+            message = MessageActivityInput(text=chat_result.response.content).add_ai_generated()
+            await ctx.send(message)
+        elif chat_result.is_deferred:
+            # Approval message already sent by the handler
+            pass
+
+    except Exception as e:
+        print(f"[SEPARATE TOOLS] Error: {str(e)}")
+        await ctx.send(f"❌ Error: {str(e)}")
+
+
+# Handler for wrapped approval demo
+@app.on_message
+async def handle_wrapped_approval_demo(ctx: ActivityContext[MessageActivity]) -> None:
+    """Demo showing wrapped approval pattern - simple tool that requires approval."""
+    # Only handle if current mode is wrapped and this is a weather question
+    if current_mode != "wrapped":
+        await ctx.next()
+        return
+
+    print(f"[WRAPPED APPROVAL] Message received: {ctx.activity.text}")
+
+    try:
+        # Create approval-wrapped stock function with custom approval message
+
+        def custom_stock_approval(params: BuyStockParams) -> str:
+            return (
+                "📈 **Stock Purchase Approval Required**\n\n"
+                "The agent wants to buy:\n"
+                f"• Stock: **{params.stock}**\n"
+                "• Quantity: **{params.quantity} shares**\n\n"
+                "⚠️ This will execute a market order which may"
+                "involve significant financial risk.\n\n"
+                "Approve this stock purchase? Say 'yes' or 'no'"
+            )
+
+        wrapped_stock_function = create_approval_wrapped_function(
+            sender=ctx,
+            original_function=create_buy_stock_function(),
+            create_approval_message=custom_stock_approval,
+        )
+
+        chat_prompt = ChatPrompt(
+            instructions=(
+                "You are a helpful assistant. Use the available stock tradingtool when users want to buy stocks."
+            ),
+            model=ai_model,
+            functions=[wrapped_stock_function],
+            memory=memory,
+        )
+
+        # Handle deferred functions or normal chat
+        if await chat_prompt.requires_resuming():
+            chat_result = await chat_prompt.resume(ctx.activity)
+        else:
+            chat_result = await chat_prompt.send(input=ctx.activity.text)
+
+        if chat_result.response and chat_result.response.content:
+            message = MessageActivityInput(text=chat_result.response.content).add_ai_generated()
+            await ctx.send(message)
+        elif chat_result.is_deferred:
+            # Approval message already sent by the handler
+            pass
+
+    except Exception as e:
+        print(f"[WRAPPED APPROVAL] Error: {str(e)}")
+        await ctx.send(f"❌ Error: {str(e)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(app.start())

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 members = [
     "ai-test",
     "cards",
+    "defferred-ai",
     "dialogs",
     "echo",
     "graph",
@@ -496,6 +497,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/7a/28b63c43d4c17d6587abcfef648841d39543158bcc47b5d40a03b8831f7a/cyclopts-3.23.1.tar.gz", hash = "sha256:ca6a5e9b326caf156d79f3932e2f88b95629e59fd371c0b3a89732b7619edacb", size = 75161, upload-time = "2025-08-30T17:40:34.396Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/67/ac57fbef5414ce84fe0bdeb497918ab2c781ff2cbf23c1bd91334b225669/cyclopts-3.23.1-py3-none-any.whl", hash = "sha256:8e57c6ea47d72b4b565c6a6c8a9fd56ed048ab4316627991230f4ad24ce2bc29", size = 85222, upload-time = "2025-08-30T17:40:33.005Z" },
+]
+
+[[package]]
+name = "defferred-ai"
+version = "0.1.0"
+source = { virtual = "tests/defferred_ai" }
+dependencies = [
+    { name = "dotenv" },
+    { name = "microsoft-teams-apps" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Deferred Function Calling

## Motivation

Normally, when a function call happens in an AI system, it looks like this:
```mermaid
sequenceDiagram
    participant CP as Chat Prompt
    participant LLM
    participant Fn as Function
    CP ->> LLM: Messages, system prompt<br/>function metadatas
    LLM ->> CP: Call Fn1 with arguments X
    CP ->> Fn: execute(X)
    Fn ->> CP: result (string)
    CP ->> LLM: Messages + Fn Result
```
This works for many use-cases. In this example, we're assuming F1 is some function that can be called and resolved in a reasonable amount of time (maybe a few seconds). 

However, there are some scenarios where the function cannot be easily (or quickly) be executed. Examples include:
* Requires human input or approval - Humans are slow. You might have gone to get coffee and your approval is sticking around forever. Here's an example from Claude Code:
<img width="562" height="205" alt="image" src="https://github.com/user-attachments/assets/33aa469d-1bb1-482d-b100-10fcf2054acd" />

* The function needs to execute in Business Hours, or next month, or next year! 
* The result of the function call can take time to execute. Consider having to send an order to a system that can take a day to process.

## Proposal
In this PR, I'm proposing the ability for functions to return a DeferredResult in addition to a string. The idea is that if the ChatPrompt sees "DeferredResult", it saves that state, and stops executing.
Then, when the system is ready (aka gets an external signal) to continue, then it "resumes" and continues the ChatPrompt. The updated sequence diagram for a Deferrable Function looks like so:
```mermaid
sequenceDiagram
    participant Teams
    participant CP as Chat Prompt
    participant LLM
    participant Fn as Deferrable Function
    Teams ->> CP: send("buy some stock") (via Message handler)
    CP ->> LLM: Messages, system prompt<br/>function metadatas
    LLM ->> CP: Call Fn1 with arguments X
    CP ->> Fn: execute(X)
    Fn ->> Teams: Ask for approval
    Fn ->> CP: DeferredResult(state)
    CP ->> Teams: No response
    break When signal is received
        Teams ->> CP: "yes" go ahead<br/>resume(input)
        CP ->> Fn: Can this resume using input?
        Fn ->> CP: true
        CP ->> Fn: Resume(input)
        Fn ->> CP: Result after resuming (string)<br/>"the user approved the buying of the stock"
    end
    CP ->> LLM: Messages + Fn Result
```
## Implementation

* We add a new type of Message that can be stored in Memory (which can store `Message` which is a union of different types of messages). This `DeferredMessage` basically stores the deferred state that the executable function can optionally return.
* A function can return `DeferredResult` now (on top of string)
* Added a "resume" function in ChatPrompt that can take in "Any" right now (Ideally I want to make this "Activity", but not totally sure). This resume function checks with memory if a what the deferred function is, then asks the deferred function if it can handle this incoming activity, and if it can, it converts this `DeferredMessage` with a `FunctionMessage` which is a normal function call result.

The sample currently shows an approval message that the LLM can invoke. It demonstrates two main scenarios:
1. In the first scenario, the LLM has access to `get_approval` and `buy_stock`. And then we _prompt_ the LLM to call approve before buy-stock. This showcases the raw calling of a Deferrable function, and how it can be resumed when the user replies. I use a normal message here to showcase this, but honestly, using an adaptive card would drive the point in better.
2. In the second scenario, I _wrap_ a normal function call (`buy_stock`) which is a regular function, _into_ a deferred function. After doing this, when `buy_stock` is called, the LLM actually defers the calling of the actual buy stock function by first asking for an approval. This way you can't really fool the LLM by clever prompting.

I'm planning on moving some of the examples in the Sample to the main library as utilities.

