### PR TITLE
fix: allow for empty parameters for AI functions

### DIFF
--- a/packages/ai/src/microsoft/teams/ai/__init__.py
+++ b/packages/ai/src/microsoft/teams/ai/__init__.py
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 from .agent import Agent
 from .ai_model import AIModel
 from .chat_prompt import ChatPrompt, ChatSendResult
-from .function import Function, FunctionCall
+from .function import Function, FunctionCall, FunctionHandler, FunctionHandlers, FunctionHandlerWithNoParams
 from .memory import ListMemory, Memory
 from .message import FunctionMessage, Message, ModelMessage, SystemMessage, UserMessage
 
@@ -24,4 +24,7 @@ __all__ = [
     "Memory",
     "ListMemory",
     "AIModel",
+    "FunctionHandler",
+    "FunctionHandlerWithNoParams",
+    "FunctionHandlers",
 ]

--- a/packages/ai/src/microsoft/teams/ai/plugin.py
+++ b/packages/ai/src/microsoft/teams/ai/plugin.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 from abc import abstractmethod
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Optional, Protocol, TypeVar, runtime_checkable
 
 from pydantic import BaseModel
 
@@ -61,23 +61,25 @@ class AIPluginProtocol(Protocol):
         """
         ...
 
-    async def on_before_function_call(self, function_name: str, args: BaseModel) -> None:
+    async def on_before_function_call(self, function_name: str, args: Optional[BaseModel] = None) -> None:
         """
         Called before a function is executed.
 
         Args:
             function_name: Name of the function being called
-            args: Validated function arguments
+            args: Validated function arguments, if any.
         """
         ...
 
-    async def on_after_function_call(self, function_name: str, args: BaseModel, result: str) -> str | None:
+    async def on_after_function_call(
+        self, function_name: str, result: str, args: Optional[BaseModel] = None
+    ) -> str | None:
         """
         Called after a function is executed.
 
         Args:
             function_name: Name of the function that was called
-            args: Function arguments that were used
+            args: Function arguments that were used, if any.
             result: Function execution result
 
         Returns:
@@ -146,11 +148,13 @@ class BaseAIPlugin:
         """Modify response after receiving from model."""
         return response
 
-    async def on_before_function_call(self, function_name: str, args: BaseModel) -> None:
+    async def on_before_function_call(self, function_name: str, args: Optional[BaseModel] = None) -> None:
         """Called before a function is executed."""
         pass
 
-    async def on_after_function_call(self, function_name: str, args: BaseModel, result: str) -> str | None:
+    async def on_after_function_call(
+        self, function_name: str, result: str, args: Optional[BaseModel] = None
+    ) -> str | None:
         """Called after a function is executed."""
         return result
 

--- a/packages/apps/src/microsoft/teams/apps/utils/retry.py
+++ b/packages/apps/src/microsoft/teams/apps/utils/retry.py
@@ -33,8 +33,10 @@ class RetryOptions:
         self.max_delay = max_delay
         self.jitter_type: JitterType = jitter_type
         # Use existing internal logger if provided, otherwise create child logger
-        self.logger = _internal_logger if _internal_logger else (
-            logger.getChild("@teams/retry") if logger else ConsoleLogger().create_logger("@teams/retry")
+        self.logger = (
+            _internal_logger
+            if _internal_logger
+            else (logger.getChild("@teams/retry") if logger else ConsoleLogger().create_logger("@teams/retry"))
         )
         self.previous_delay = previous_delay
         self.attempt_number = attempt_number
@@ -87,9 +89,7 @@ async def retry(factory: Callable[[], Awaitable[T]], options: Optional[RetryOpti
             # Apply jitter
             jittered_delay = _apply_jitter(capped_delay, jitter_type, previous_delay)
 
-            logger.debug(
-                f"Delaying {jittered_delay:.2f}s before retry (attempt {attempt_number})..."
-            )
+            logger.debug(f"Delaying {jittered_delay:.2f}s before retry (attempt {attempt_number})...")
             await asyncio.sleep(jittered_delay)
             logger.debug("Retrying...")
 

--- a/packages/apps/tests/test_retry.py
+++ b/packages/apps/tests/test_retry.py
@@ -3,16 +3,17 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-import asyncio
 from unittest.mock import MagicMock
 
 import pytest
 from microsoft.teams.apps.utils import RetryOptions, retry
 
+# pyright: basic
+
 
 class TestRetryOptions:
     """Test RetryOptions functionality."""
-    
+
     def test_default_initialization(self):
         """Test that RetryOptions initializes with correct defaults."""
         options = RetryOptions()
@@ -22,7 +23,7 @@ class TestRetryOptions:
         assert options.jitter_type == "full"
         assert options.attempt_number == 1
         assert options.logger is not None
-    
+
     def test_custom_initialization(self):
         """Test that RetryOptions can be initialized with custom values."""
         mock_logger = MagicMock()
@@ -45,86 +46,86 @@ class TestRetryOptions:
 
 class TestRetry:
     """Test retry functionality."""
-    
+
     @pytest.mark.asyncio
     async def test_success_on_first_attempt(self):
         """Test that successful operations don't retry."""
         call_count = 0
-        
+
         async def success_factory():
             nonlocal call_count
             call_count += 1
             return "success"
-        
+
         result = await retry(success_factory)
         assert result == "success"
         assert call_count == 1
-    
+
     @pytest.mark.asyncio
     async def test_attempt_number_increments_correctly(self):
         """Test that attempt numbers increment correctly in log messages."""
         call_count = 0
         mock_logger = MagicMock()
         logged_messages = []
-        
+
         def capture_debug(msg):
             logged_messages.append(msg)
-        
+
         mock_child_logger = MagicMock()
         mock_child_logger.debug.side_effect = capture_debug
         mock_logger.getChild.return_value = mock_child_logger
-        
+
         async def failing_factory():
             nonlocal call_count
             call_count += 1
             if call_count < 3:  # Fail first 2 attempts
                 raise ValueError(f"Attempt {call_count} failed")
             return "success"
-        
+
         options = RetryOptions(max_attempts=3, delay=0.01, jitter_type="none", logger=mock_logger)
         result = await retry(failing_factory, options)
-        
+
         assert result == "success"
         assert call_count == 3
-        
+
         # Check that attempt numbers are logged correctly
         delay_messages = [msg for msg in logged_messages if "before retry (attempt" in msg]
         assert len(delay_messages) == 2  # Two retries (attempts 1 and 2 failed)
         assert "(attempt 1)" in delay_messages[0]  # First retry shows attempt 1 (which failed)
         assert "(attempt 2)" in delay_messages[1]  # Second retry shows attempt 2 (which failed)
-    
+
     @pytest.mark.asyncio
     async def test_exponential_backoff_increases(self):
         """Test that exponential backoff delays increase exponentially."""
         call_count = 0
         mock_logger = MagicMock()
         logged_delays = []
-        
+
         def capture_debug(msg):
             if "Delaying" in msg and "before retry" in msg:
                 # Extract delay value from message like "Delaying 1.00s before retry..."
                 delay_str = msg.split("Delaying ")[1].split("s")[0]
                 logged_delays.append(float(delay_str))
-        
+
         mock_child_logger = MagicMock()
         mock_child_logger.debug.side_effect = capture_debug
         mock_logger.getChild.return_value = mock_child_logger
-        
+
         async def failing_factory():
             nonlocal call_count
             call_count += 1
             if call_count < 4:  # Fail first 3 attempts
                 raise ValueError(f"Attempt {call_count} failed")
             return "success"
-        
+
         # Use no jitter to test pure exponential backoff
         options = RetryOptions(max_attempts=4, delay=1.0, jitter_type="none", logger=mock_logger)
         result = await retry(failing_factory, options)
-        
+
         assert result == "success"
         assert call_count == 4
         assert len(logged_delays) == 3  # Three retries
-        
+
         # Check exponential increase: base_delay * (2^(attempt_number - 1))
         # Attempt 1: 1.0 * (2^0) = 1.0
         # Attempt 2: 1.0 * (2^1) = 2.0
@@ -132,57 +133,57 @@ class TestRetry:
         assert logged_delays[0] == 1.0  # First retry (after attempt 1 failed)
         assert logged_delays[1] == 2.0  # Second retry (after attempt 2 failed)
         assert logged_delays[2] == 4.0  # Third retry (after attempt 3 failed)
-    
+
     @pytest.mark.asyncio
     async def test_logger_name_consistent(self):
         """Test that logger name doesn't keep growing with recursive calls."""
         call_count = 0
         mock_logger = MagicMock()
         mock_logger.name = "test_logger"
-        
+
         # Track how many times getChild is called
         child_call_count = 0
-        
+
         def track_get_child(child_name):
             nonlocal child_call_count
             child_call_count += 1
             child_mock = MagicMock()
             child_mock.name = f"{mock_logger.name}.{child_name}"
             return child_mock
-        
+
         mock_logger.getChild.side_effect = track_get_child
-        
+
         async def failing_factory():
             nonlocal call_count
             call_count += 1
             if call_count < 3:  # Fail first 2 attempts
                 raise ValueError(f"Attempt {call_count} failed")
             return "success"
-        
+
         options = RetryOptions(max_attempts=3, delay=0.01, logger=mock_logger)
         result = await retry(failing_factory, options)
-        
+
         assert result == "success"
         assert call_count == 3
-        
+
         # getChild should only be called once (for the initial RetryOptions)
         # Recursive calls should reuse the existing child logger
         assert child_call_count == 1
         mock_logger.getChild.assert_called_once_with("@teams/retry")
-    
+
     @pytest.mark.asyncio
     async def test_final_attempt_failure_raises(self):
         """Test that final attempt failures are raised."""
         call_count = 0
-        
+
         async def always_fail():
             nonlocal call_count
             call_count += 1
             raise ValueError(f"Always fails - attempt {call_count}")
-        
+
         options = RetryOptions(max_attempts=2, delay=0.01, jitter_type="none")
-        
+
         with pytest.raises(ValueError, match="Always fails - attempt 2"):
             await retry(always_fail, options)
-        
+
         assert call_count == 2  # Should attempt exactly max_attempts times

--- a/packages/openai/src/microsoft/teams/openai/function_utils.py
+++ b/packages/openai/src/microsoft/teams/openai/function_utils.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from microsoft.teams.ai import Function
 from pydantic import BaseModel, create_model
@@ -22,6 +22,10 @@ def get_function_schema(func: Function[BaseModel]) -> Dict[str, Any]:
     Returns:
         Dictionary containing JSON schema for the function parameters
     """
+    if not func.parameter_schema:
+        # No parameters case
+        return {}
+
     if isinstance(func.parameter_schema, dict):
         # Raw JSON schema - use as-is
         return func.parameter_schema.copy()
@@ -30,7 +34,7 @@ def get_function_schema(func: Function[BaseModel]) -> Dict[str, Any]:
         return func.parameter_schema.model_json_schema()
 
 
-def parse_function_arguments(func: Function[BaseModel], arguments: Dict[str, Any]) -> BaseModel:
+def parse_function_arguments(func: Function[BaseModel], arguments: Dict[str, Any]) -> Optional[BaseModel]:
     """
     Parse function arguments into a BaseModel instance.
 
@@ -44,6 +48,9 @@ def parse_function_arguments(func: Function[BaseModel], arguments: Dict[str, Any
     Returns:
         BaseModel instance with validated and parsed arguments
     """
+    if not func.parameter_schema:
+        return None
+
     if isinstance(func.parameter_schema, dict):
         # For dict schemas, create a simple BaseModel dynamically
         DynamicModel = create_model("DynamicParams")

--- a/tests/ai-test/src/handlers/plugins.py
+++ b/tests/ai-test/src/handlers/plugins.py
@@ -3,6 +3,8 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from typing import Optional
+
 from microsoft.teams.ai.message import Message
 from microsoft.teams.ai.plugin import BaseAIPlugin
 from pydantic import BaseModel
@@ -15,11 +17,13 @@ class LoggingAIPlugin(BaseAIPlugin):
         super().__init__("logging_plugin")
         self.function_calls: list[str] = []
 
-    async def on_before_function_call(self, function_name: str, args: BaseModel) -> None:
+    async def on_before_function_call(self, function_name: str, args: Optional[BaseModel] = None) -> None:
         print(f"[PLUGIN] About to call function: {function_name} with args: {args}")
         self.function_calls.append(function_name)
 
-    async def on_after_function_call(self, function_name: str, args: BaseModel, result: str) -> str | None:
+    async def on_after_function_call(
+        self, function_name: str, result: str, args: Optional[BaseModel] = None
+    ) -> str | None:
         print(f"[PLUGIN] Function {function_name} returned: {result}")
         return f"{result} (verified by logging plugin)"
 


### PR DESCRIPTION
resolves: #138

originally tackled by copilot in #152 except it didnt go too hot haha, liked the idea that they introduced `FunctionHandlersWithNoParams`, so kept that, and made a union type `FunctionHandlers`