### PR TITLE
[Bug] Skip checking token when app id is missing or skip auth is true

### DIFF
--- a/packages/apps/src/microsoft/teams/apps/app.py
+++ b/packages/apps/src/microsoft/teams/apps/app.py
@@ -111,7 +111,7 @@ class App(ActivityHandlerMixin):
             if self.credentials and hasattr(self.credentials, "client_id"):
                 app_id = self.credentials.client_id
 
-            http_plugin = HttpPlugin(app_id, self.log, self.options.enable_token_validation)
+            http_plugin = HttpPlugin(app_id, self.log, self.options.skip_auth)
 
         plugins.insert(0, http_plugin)
         self.http = cast(HttpPlugin, http_plugin)

--- a/packages/apps/src/microsoft/teams/apps/options.py
+++ b/packages/apps/src/microsoft/teams/apps/options.py
@@ -27,7 +27,7 @@ class AppOptions(TypedDict, total=False):
     logger: Optional[Logger]
     storage: Optional[Storage[str, Any]]
     plugins: Optional[List[PluginBase]]
-    enable_token_validation: Optional[bool]
+    skip_auth: Optional[bool]
 
     # Oauth
     default_connection_name: Optional[str]
@@ -38,7 +38,7 @@ class InternalAppOptions:
     """Internal dataclass for AppOptions with defaults and non-nullable fields."""
 
     # Fields with defaults
-    enable_token_validation: bool = True
+    skip_auth: bool = False
     default_connection_name: str = "graph"
     plugins: List[PluginBase] = field(default_factory=lambda: [])
 
@@ -76,7 +76,7 @@ def merge_app_options_with_defaults(**options: Unpack[AppOptions]) -> AppOptions
         AppOptions with defaults applied
     """
     defaults: AppOptions = {
-        "enable_token_validation": True,
+        "skip_auth": False,
         "default_connection_name": "graph",
         "plugins": [],
     }


### PR DESCRIPTION
<img width="744" height="543" alt="agents_playground_py" src="https://github.com/user-attachments/assets/fae15158-2140-4547-8fed-6a20e915ef73" />

Change : If we pass the auth layer successfully and token is missing, create dummy token

Rename `enable_token_validation` to `skip_auth` for parity with typescript and dotnet