### PR TITLE
Message default message str to empty

### DIFF
--- a/packages/api/src/microsoft/teams/api/activities/message/message.py
+++ b/packages/api/src/microsoft/teams/api/activities/message/message.py
@@ -79,7 +79,7 @@ class _MessageBase(CustomBaseModel):
 class MessageActivity(_MessageBase, ActivityBase):
     """Output model for received message activities with required fields and read-only properties."""
 
-    text: str  # pyright: ignore [reportGeneralTypeIssues, reportIncompatibleVariableOverride]
+    text: str = ""  # pyright: ignore [reportGeneralTypeIssues, reportIncompatibleVariableOverride]
     """The text content of the message."""
 
     def is_recipient_mentioned(self) -> bool:

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -62,6 +62,21 @@ class TestMessageActivity:
         activity = self.create_message_activity()
         assert activity.type == "message"
 
+    def test_message_activity_text_defaults_to_empty_string(self):
+        """Test that text field defaults to empty string in MessageActivity"""
+        from_account = Account(id="bot-123", name="Test Bot", role="bot")
+        recipient = Account(id="user-456", name="Test User", role="user")
+        conversation = ConversationAccount(id="conv-789", conversation_type="personal")
+
+        activity = MessageActivity(
+            id="msg-123",
+            from_=from_account,
+            conversation=conversation,
+            recipient=recipient,
+        )
+
+        assert activity.text == ""
+
     def test_add_text_method(self):
         """Test adding text to the message"""
         activity = self.create_message_activity("Hello")


### PR DESCRIPTION
Messages don't necessarily have a text field (i.e. card-only messages). This PR defaults those messages to empty string (following what's there in TS)