### PR TITLE
make a2a private for now

### DIFF
--- a/packages/a2aprotocol/pyproject.toml
+++ b/packages/a2aprotocol/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.12"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"
+classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "a2a-sdk[all]>=0.3.7",
     "microsoft-teams-common",


### PR DESCRIPTION
This package isn't ready to be released. Marking as private for now.