### PR TITLE
Temporary: skip streaming tests 

### DIFF
--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -20,6 +20,7 @@ from microsoft.teams.api import (
 from microsoft.teams.apps import HttpStream
 
 
+@pytest.mark.skip(reason="introduces delays in CI pipeline")
 class TestHttpStream:
     @pytest.fixture
     def mock_logger(self):


### PR DESCRIPTION
Temporarily removing streaming tests while we rewrite to make them spontaneous (remove all real time delays )