### PR TITLE
Release 2.0.0a6

### DIFF
--- a/packages/a2aprotocol/pyproject.toml
+++ b/packages/a2aprotocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-a2a"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "plugin that enables your teams agent to be used as an a2a agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/ai/pyproject.toml
+++ b/packages/ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-ai"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "package to handle interacting with ai or llms"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-api"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "API package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-apps"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "The app package for a Microsoft Teams agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/botbuilder/pyproject.toml
+++ b/packages/botbuilder/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "BotBuilder plugin for Microsoft Teams"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/cards/pyproject.toml
+++ b/packages/cards/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-cards"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "Cards package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-common"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "Common package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-devtools"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "Local tool to streamline testing and development"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/graph/pyproject.toml
+++ b/packages/graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-graph"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "The Graph package for a Microsoft Teams agent"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/mcpplugin/pyproject.toml
+++ b/packages/mcpplugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "library for handling mcp with teams sdk"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/openai/pyproject.toml
+++ b/packages/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-openai"
-version = "2.0.0a5"
+version = "2.0.0a6"
 description = "model package for enabling chat experiences with openai"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1421,7 +1421,7 @@ wheels = [
 
 [[package]]
 name = "microsoft-teams-a2a"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/a2aprotocol" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -1442,7 +1442,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-ai"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/ai" }
 dependencies = [
     { name = "microsoft-teams-common" },
@@ -1453,7 +1453,7 @@ requires-dist = [{ name = "microsoft-teams-common", editable = "packages/common"
 
 [[package]]
 name = "microsoft-teams-api"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "microsoft-teams-cards" },
@@ -1486,7 +1486,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-apps"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/apps" }
 dependencies = [
     { name = "cryptography" },
@@ -1536,7 +1536,7 @@ test = [
 
 [[package]]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/botbuilder" }
 dependencies = [
     { name = "botbuilder-core" },
@@ -1557,7 +1557,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-cards"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/cards" }
 dependencies = [
     { name = "coverage" },
@@ -1576,7 +1576,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-common"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/common" }
 dependencies = [
     { name = "coverage" },
@@ -1607,7 +1607,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-devtools"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/devtools" }
 dependencies = [
     { name = "fastapi" },
@@ -1628,7 +1628,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-graph"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/graph" }
 dependencies = [
     { name = "azure-core" },
@@ -1659,7 +1659,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/mcpplugin" }
 dependencies = [
     { name = "fastmcp" },
@@ -1680,7 +1680,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-openai"
-version = "2.0.0a5"
+version = "2.0.0a6"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "microsoft-teams-ai" },


### PR DESCRIPTION
## Release 2.0.0a6

### Changes

- Make images required for Thumbnail (#216)
- Revert "Add comment"
- Add comment
- Move tests to examples (#199)
- Bump glob from 11.0.3 to 11.1.0 in /tests/tab/Web (#215)
- Remove Agents class (#213)
- Add signin/failure invoke activity support (#206)
- Update config.yml (#214)
- Adds a github template when New issues are created  (#212)
- feat: add OAuth support for regional bots (#209)
- [feat] Add BotBuilder Plugin package, sample and tests (#190)