### PR TITLE
[docs] botbuilder package README fixes

### DIFF
--- a/packages/botbuilder/README.md
+++ b/packages/botbuilder/README.md
@@ -9,9 +9,9 @@
     </a>
 </p>
 
-A package used to make the `@microsoft/teams.apps` package backwards compatible with legacy bots built using
+A package used to make the `microsoft-teams-apps` package backwards compatible with legacy bots built using
 `BotBuilder`.
 
-<a href="https://microsoft.github.io/teams-ai" target="_blank">
+<a href="https://microsoft.github.io/teams-sdk" target="_blank">
     <img src="https://img.shields.io/badge/📖 Getting Started-blue?style=for-the-badge" />
 </a>


### PR DESCRIPTION
- incorrect package name, referring to TS instead of python
- incorrect docs link, was our previous docs