### PR TITLE
Updating mcpplugin reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A comprehensive SDK for building Microsoft Teams applications, bots, and AI agen
 
 > external packages to integrate with external protocols and microsoft-teams-cards
 
-- [`microsoft-teams-mcpplugin`](./packages/mcp/README.md)
+- [`microsoft-teams-mcpplugin`](./packages/mcpplugin/README.md)
 - [`microsoft-teams-a2a`](./packages/a2aprotocol/README.md)
 
 ### Create a New Package


### PR DESCRIPTION
To resolve issue #228, updating README.md. 
This fix resolved broken reference with expected one. 
Previous behavior, 
<img width="953" height="488" alt="image" src="https://github.com/user-attachments/assets/a4b908fd-c7e3-4068-ad51-77b6d0e67c4b" />

After fix, 
<img width="956" height="930" alt="image" src="https://github.com/user-attachments/assets/fe66dd5b-94d0-4e3c-9542-b5c32d9ce0cb" />

