### PR TITLE
Release 2.0.0a7

### DIFF
--- a/packages/a2aprotocol/pyproject.toml
+++ b/packages/a2aprotocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-a2a"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "plugin that enables your teams agent to be used as an a2a agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/ai/pyproject.toml
+++ b/packages/ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-ai"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "package to handle interacting with ai or llms"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-api"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "API package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-apps"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "The app package for a Microsoft Teams agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/botbuilder/pyproject.toml
+++ b/packages/botbuilder/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "BotBuilder plugin for Microsoft Teams"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/cards/pyproject.toml
+++ b/packages/cards/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-cards"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "Cards package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-common"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "Common package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-devtools"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "Local tool to streamline testing and development"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/graph/pyproject.toml
+++ b/packages/graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-graph"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "The Graph package for a Microsoft Teams agent"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/mcpplugin/pyproject.toml
+++ b/packages/mcpplugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "library for handling mcp with teams sdk"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/openai/pyproject.toml
+++ b/packages/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-openai"
-version = "2.0.0a6"
+version = "2.0.0a7"
 description = "model package for enabling chat experiences with openai"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1443,7 +1443,7 @@ wheels = [
 
 [[package]]
 name = "microsoft-teams-a2a"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/a2aprotocol" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -1464,7 +1464,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-ai"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/ai" }
 dependencies = [
     { name = "microsoft-teams-common" },
@@ -1475,7 +1475,7 @@ requires-dist = [{ name = "microsoft-teams-common", editable = "packages/common"
 
 [[package]]
 name = "microsoft-teams-api"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "microsoft-teams-cards" },
@@ -1508,7 +1508,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-apps"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/apps" }
 dependencies = [
     { name = "cryptography" },
@@ -1558,7 +1558,7 @@ test = [
 
 [[package]]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/botbuilder" }
 dependencies = [
     { name = "botbuilder-core" },
@@ -1579,7 +1579,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-cards"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/cards" }
 dependencies = [
     { name = "coverage" },
@@ -1596,7 +1596,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-common"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/common" }
 dependencies = [
     { name = "coverage" },
@@ -1627,7 +1627,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-devtools"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/devtools" }
 dependencies = [
     { name = "fastapi" },
@@ -1648,7 +1648,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-graph"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/graph" }
 dependencies = [
     { name = "azure-core" },
@@ -1679,7 +1679,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/mcpplugin" }
 dependencies = [
     { name = "fastmcp" },
@@ -1700,7 +1700,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-openai"
-version = "2.0.0a6"
+version = "2.0.0a7"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "microsoft-teams-ai" },


### PR DESCRIPTION
## Release 2.0.0a7

### Changes

- update react and react-dom to 19.2.1 (#233)
- Move to microsoft_teams namespace (#226)
- Simplify setting http response after activity processing  (#218)
- Add TeamsChannelAccount type for Teams-specific APIs (#230)
- Updating mcpplugin reference in README.md (#229)
- Bring back bot builder example (#225)
- Fix choices_data alias to use "choices.data" instead of "choicesData" (#224)
- [docs] botbuilder package README fixes (#223)
- Fix calling AI functions with no parameters (#221)