### PR TITLE
Add SERVICE_URL to override default service_url for Teams

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -98,8 +98,12 @@ class App(ActivityHandlerMixin):
         self.container.set_provider("storage", providers.Object(self.storage))
         self.container.set_provider(self.http_client.__class__.__name__, providers.Factory(lambda: self.http_client))
 
+        service_url = (
+            self.options.service_url or os.getenv("SERVICE_URL") or "https://smba.trafficmanager.net/teams"
+        ).rstrip("/")
+
         self.api = ApiClient(
-            "https://smba.trafficmanager.net/teams",
+            service_url,
             self.http_client.clone(ClientOptions(token=self._get_bot_token)),
             self.options.api_client_settings,
         )

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -50,6 +50,14 @@ class AppOptions(TypedDict, total=False):
     api_client_settings: Optional[ApiClientSettings]
     """API client settings used for overriding."""
 
+    # Service URL
+    service_url: Optional[str]
+    """
+    Base Service URL for BotBackend.
+    Uses environment variable SERVICE_URL if not provided
+    and defaults to https://smba.trafficmanager.net/teams
+    """
+
 
 @dataclass
 class InternalAppOptions:
@@ -81,6 +89,12 @@ class InternalAppOptions:
     """
     logger: Optional[Logger] = None
     storage: Optional[Storage[str, Any]] = None
+    service_url: Optional[str] = None
+    """
+    Base Service URL for BotBackend.
+    Uses environment variable SERVICE_URL if not provided
+    and defaults to https://smba.trafficmanager.net/teams
+    """
 
     @classmethod
     def from_typeddict(cls, options: AppOptions) -> "InternalAppOptions":


### PR DESCRIPTION
Similar to https://github.com/microsoft/teams.ts/pull/435. Need a way to override base URLs for the Teams backend.