### PR TITLE
Release 2.0.0a9

### DIFF
--- a/packages/a2aprotocol/pyproject.toml
+++ b/packages/a2aprotocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-a2a"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "plugin that enables your teams agent to be used as an a2a agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/ai/pyproject.toml
+++ b/packages/ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-ai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "package to handle interacting with ai or llms"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-api"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "API package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-apps"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "The app package for a Microsoft Teams agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/botbuilder/pyproject.toml
+++ b/packages/botbuilder/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "BotBuilder plugin for Microsoft Teams"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/cards/pyproject.toml
+++ b/packages/cards/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-cards"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "Cards package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-common"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "Common package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-devtools"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "Local tool to streamline testing and development"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/graph/pyproject.toml
+++ b/packages/graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-graph"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "The Graph package for a Microsoft Teams agent"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/mcpplugin/pyproject.toml
+++ b/packages/mcpplugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "library for handling mcp with teams sdk"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/openai/pyproject.toml
+++ b/packages/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-openai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "model package for enabling chat experiences with openai"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "microsoft-teams-a2a"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/a2aprotocol" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -1484,7 +1484,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-ai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/ai" }
 dependencies = [
     { name = "microsoft-teams-common" },
@@ -1495,7 +1495,7 @@ requires-dist = [{ name = "microsoft-teams-common", editable = "packages/common"
 
 [[package]]
 name = "microsoft-teams-api"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "microsoft-teams-cards" },
@@ -1528,7 +1528,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-apps"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/apps" }
 dependencies = [
     { name = "cryptography" },
@@ -1578,7 +1578,7 @@ test = [
 
 [[package]]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/botbuilder" }
 dependencies = [
     { name = "botbuilder-core" },
@@ -1599,7 +1599,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-cards"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/cards" }
 dependencies = [
     { name = "coverage" },
@@ -1616,7 +1616,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-common"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/common" }
 dependencies = [
     { name = "coverage" },
@@ -1647,7 +1647,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-devtools"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/devtools" }
 dependencies = [
     { name = "fastapi" },
@@ -1668,7 +1668,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-graph"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/graph" }
 dependencies = [
     { name = "azure-core" },
@@ -1699,7 +1699,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/mcpplugin" }
 dependencies = [
     { name = "fastmcp" },
@@ -1720,7 +1720,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-openai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "microsoft-teams-ai" },


### PR DESCRIPTION
## Release 2.0.0a9

### Changes

- fix meetingStart and meetingEnd casing bug & add meetings sample (#246)
- Remove jitter during streaming (#248)
- Add SERVICE_URL to override default service_url for Teams (#247)
- [Fix] streaming: do not reset timeout for each emit, do not wait forever on close stream (#197)