### PR TITLE
Release version 2.0.0a9

### DIFF
--- a/packages/a2aprotocol/pyproject.toml
+++ b/packages/a2aprotocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-a2a"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "plugin that enables your teams agent to be used as an a2a agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/ai/pyproject.toml
+++ b/packages/ai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-ai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "package to handle interacting with ai or llms"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-api"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "API package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-apps"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "The app package for a Microsoft Teams agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/botbuilder/pyproject.toml
+++ b/packages/botbuilder/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "BotBuilder plugin for Microsoft Teams"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/cards/pyproject.toml
+++ b/packages/cards/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-cards"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "Cards package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-common"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "Common package for Microsoft Teams"
 readme = "README.md"
 repository = "https://github.com/microsoft/teams.py"

--- a/packages/devtools/pyproject.toml
+++ b/packages/devtools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-devtools"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "Local tool to streamline testing and development"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/graph/pyproject.toml
+++ b/packages/graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-graph"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "The Graph package for a Microsoft Teams agent"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/mcpplugin/pyproject.toml
+++ b/packages/mcpplugin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "library for handling mcp with teams sdk"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/packages/openai/pyproject.toml
+++ b/packages/openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microsoft-teams-openai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 description = "model package for enabling chat experiences with openai"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1798,7 +1798,7 @@ wheels = [
 
 [[package]]
 name = "microsoft-teams-a2a"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/a2aprotocol" }
 dependencies = [
     { name = "a2a-sdk", extra = ["http-server"] },
@@ -1819,7 +1819,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-ai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/ai" }
 dependencies = [
     { name = "microsoft-teams-common" },
@@ -1830,7 +1830,7 @@ requires-dist = [{ name = "microsoft-teams-common", editable = "packages/common"
 
 [[package]]
 name = "microsoft-teams-api"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "microsoft-teams-cards" },
@@ -1863,7 +1863,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-apps"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/apps" }
 dependencies = [
     { name = "cryptography" },
@@ -1913,7 +1913,7 @@ test = [
 
 [[package]]
 name = "microsoft-teams-botbuilder"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/botbuilder" }
 dependencies = [
     { name = "botbuilder-core" },
@@ -1934,7 +1934,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-cards"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/cards" }
 dependencies = [
     { name = "coverage" },
@@ -1951,7 +1951,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-common"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/common" }
 dependencies = [
     { name = "coverage" },
@@ -1982,7 +1982,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-devtools"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/devtools" }
 dependencies = [
     { name = "fastapi" },
@@ -2003,7 +2003,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-graph"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/graph" }
 dependencies = [
     { name = "azure-core" },
@@ -2034,7 +2034,7 @@ dev = [
 
 [[package]]
 name = "microsoft-teams-mcpplugin"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/mcpplugin" }
 dependencies = [
     { name = "fastmcp" },
@@ -2055,7 +2055,7 @@ requires-dist = [
 
 [[package]]
 name = "microsoft-teams-openai"
-version = "2.0.0a8"
+version = "2.0.0a9"
 source = { editable = "packages/openai" }
 dependencies = [
     { name = "microsoft-teams-ai" },


### PR DESCRIPTION
# Release version 2.0.0a9

Commits since v2.0.0a8:
  - Add support for Python 3.14 (#259)
  - Bump qs from 6.14.0 to 6.14.1 in /examples/tab/Web (#240)
  - Bump urllib3 from 2.5.0 to 2.6.3 (#251)
  - Bump authlib from 1.6.5 to 1.6.6 (#252)
  - Bump starlette from 0.48.0 to 0.49.1 (#261)
  - Bump fastmcp from 2.12.4 to 2.14.0 (#260)
  - Bump python-multipart from 0.0.20 to 0.0.22 (#254)
  - Bump virtualenv from 20.35.3 to 20.36.1 (#256)
  - Bump pyasn1 from 0.6.1 to 0.6.2 (#255)
  - Bump azure-core from 1.36.0 to 1.38.0 (#257)
  - Bump aiohttp from 3.13.0 to 3.13.3 (#258)
  - fix meetingStart and meetingEnd casing bug & add meetings sample (#246)
  - Remove jitter during streaming (#248)
  - Add SERVICE_URL to override default service_url for Teams (#247)
  - [Fix] streaming: do not reset timeout for each emit, do not wait forever on close stream (#197)