### PR TITLE
fix: get_participant in meetings client to include tenantId

### DIFF
--- a/packages/api/src/microsoft_teams/api/clients/meeting/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/meeting/client.py
@@ -45,16 +45,19 @@ class MeetingClient(BaseClient):
         response = await self.http.get(f"{self.service_url}/v1/meetings/{id}")
         return MeetingInfo.model_validate(response.json())
 
-    async def get_participant(self, meeting_id: str, id: str) -> MeetingParticipant:
+    async def get_participant(self, meeting_id: str, id: str, tenant_id: str) -> MeetingParticipant:
         """
         Get meeting participant information.
 
         Args:
             meeting_id: The meeting ID.
             id: The participant ID.
+            tenant_id: The tenant ID.
 
         Returns:
             The meeting participant information.
         """
-        response = await self.http.get(f"{self.service_url}/v1/meetings/{meeting_id}/participants/{id}")
+
+        url = f"{self.service_url}/v1/meetings/{meeting_id}/participants/{id}?tenantId={tenant_id}"
+        response = await self.http.get(url)
         return MeetingParticipant.model_validate(response.json())

--- a/packages/api/tests/unit/test_meeting_client.py
+++ b/packages/api/tests/unit/test_meeting_client.py
@@ -32,8 +32,9 @@ class TestMeetingClient:
         client = MeetingClient(service_url, mock_http_client)
         meeting_id = "test_meeting_id"
         participant_id = "test_participant_id"
+        tenant_id = "tenant-id"
 
-        result = await client.get_participant(meeting_id, participant_id)
+        result = await client.get_participant(meeting_id, participant_id, tenant_id)
 
         assert isinstance(result, MeetingParticipant)
 

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -54,8 +54,7 @@ def _get_graph_client(token: Token):
         return get_graph_client(token)
     except ImportError as exc:
         raise ImportError(
-            "Graph functionality not available. "
-            "Install with 'pip install microsoft-teams-apps[graph]'"
+            "Graph functionality not available. Install with 'pip install microsoft-teams-apps[graph]'"
         ) from exc
 
 


### PR DESCRIPTION
original issue in https://github.com/microsoft/teams.net/issues/276
similiar fix to https://github.com/microsoft/teams.net/pull/277

locally tested:
<img width="1062" height="206" alt="image" src="https://github.com/user-attachments/assets/6a75c516-504e-4d2d-a7ac-c63c33005f20" />
