### PR TITLE
Fix async test failures by adding pytest asyncio_mode configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ select = ["E", "F", "W", "B", "Q", "I", "ASYNC"]
 "packages/cards/**/*.py" = ["E501"]
 "packages/cards/**/__init__.py" = ["F403"]
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.poe.tasks]
 fmt = "ruff format"
 lint = "ruff check"


### PR DESCRIPTION
## Summary
- Adds `asyncio_mode = "auto"` to the root `pyproject.toml` pytest config so that `pytest-asyncio` properly executes all `@pytest.mark.asyncio` tests across every package.

## Problem
The ADO pipeline runs `pytest packages` from the repo root, but there was no root-level `[tool.pytest.ini_options]` setting `asyncio_mode`. Only the `graph` package had this configured locally. Without it, `pytest-asyncio` (v1.0+) defaults to `strict` mode, which causes async test coroutines to not be properly awaited — resulting in 51 test failures across `common`, `openai`, `mcpplugin`, and `graph`.
