### PR TITLE
Fix ADO pipeline test failures for pytest-asyncio configuration

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -126,11 +126,9 @@ extends:
               Write-Host "Running tests..."
               $publishType = '${{ parameters.publishType }}'
               if ($publishType -eq 'Internal') {
-                $indexUrl = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
-                uv pip install --index-url $indexUrl pytest pytest-asyncio
-              } else {
-                uv pip install pytest pytest-asyncio
+                $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
               }
+              uv pip install pytest pytest-asyncio
               .venv\Scripts\Activate.ps1
               pytest packages --junitxml=test-results.xml
           env:


### PR DESCRIPTION
## Summary
- Routes `pytest`/`pytest-asyncio` install through the internal Azure Artifacts feed on Internal builds to avoid firewall-blocked PyPI access

## Problem

1. **PREVIOUS: Missing pytest-asyncio config**: The pipeline runs `pytest packages` from the repo root, but no root-level `asyncio_mode` was configured. Without `asyncio_mode = "auto"`, pytest-asyncio's default `strict` mode prevents async test coroutines from being properly executed.
2. **Firewall-blocked PyPI access**: `uv pip install pytest pytest-asyncio` hit public PyPI directly, but the Internal build agent blocks outbound connections to `pypi.org` (socket error 10013). The fix routes this install through the same authenticated Azure Artifacts feed used by the dependency install step.
