### PR TITLE
Rename CUSTOM_VERSION variable to VersionNumber in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -84,7 +84,7 @@ extends:
             Write-Host "Getting version from nbgv..."
             $version = (nbgv get-version -v SemVer2).Trim()
             Write-Host "Version from nbgv: $version"
-            Write-Host "##vso[task.setvariable variable=CUSTOM_VERSION]$version"
+            Write-Host "##vso[task.setvariable variable=VersionNumber]$version"
 
             # If version contains '-' it's a prerelease, use 'next' tag; otherwise 'latest'
             if ($version -match '-') {
@@ -97,12 +97,6 @@ extends:
           displayName: 'Get version from nbgv'
           env:
             PublicRelease: 'true'
-
-        - task: onebranch.pipeline.version@1
-          displayName: 'Set pipeline version'
-          inputs:
-            system: 'Custom'
-            customVersion: '$(CUSTOM_VERSION)'
 
         - task: PowerShell@2
           displayName: 'Install dependencies'


### PR DESCRIPTION
Pipeline variable update:

Changed the name of the variable set for the version number from CUSTOM_VERSION to VersionNumber to standardize variable naming.
Pipeline task cleanup:

Removed the onebranch.pipeline.version@1 task and its associated inputs, as it is no longer needed for setting the pipeline version.
