### PR TITLE
Set nbgv cloud build version variable in publish script

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -64,7 +64,7 @@ extends:
             version: '8.x'
 
         - task: PowerShell@2
-          displayName: 'Install uv and nbgv'
+          displayName: 'Install uv, nbgv and set cloud build version'
           inputs:
             targetType: inline
             script: |
@@ -79,6 +79,9 @@ extends:
               dotnet tool install -g nbgv
               Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
               nbgv --version
+
+              # Set cloud build number and variables (resolves detached HEAD in ADO)
+              nbgv cloud
 
         - powershell: |
             Write-Host "Getting version from nbgv..."

--- a/version.json
+++ b/version.json
@@ -5,9 +5,5 @@
   "publicReleaseRefSpec": [
     "^refs/heads/alpha/v\\d+\\.\\d+\\.\\d+$",
     "^refs/heads/release/v\\d+\\.\\d+\\.\\d+$"
-  ],
-  "pathFilters": [
-    "./packages/*/src",
-    "./packages/*/pyproject.toml"
   ]
 }


### PR DESCRIPTION
- Set upcoming version number to be in ADO build run's title
- Remove non-working pathFilters from version.json
    - Wildcards do not work in glob