### PR TITLE
Make Adaptive Cards version number required and set to 1.5

### DIFF
--- a/packages/cards/src/microsoft_teams/cards/core.py
+++ b/packages/cards/src/microsoft_teams/cards/core.py
@@ -628,8 +628,8 @@ class AdaptiveCard(CardElement):
     ac_schema: Optional[str] = Field(default=None, alias="schema")
     """ A URL to the Adaptive Card schema the card is authored against. """
 
-    version: Optional[Version] = None
-    """ The Adaptive Card schema version the card is authored against. """
+    version: Optional[Version] = "1.5"
+    """ The Adaptive Card schema version the card is authored against. Defaults to '1.5'. The version field is required for Adaptive Cards to render on Teams mobile clients. """
 
     fallback_text: Optional[str] = None
     """ The text that should be displayed if the client is not able to render the card. """

--- a/packages/cards/tests/test_core_serialization.py
+++ b/packages/cards/tests/test_core_serialization.py
@@ -171,6 +171,26 @@ def test_single_object_fallback_serialization():
     assert parsed["fallback"]["title"] == "Fallback Submit"
 
 
+def test_adaptive_card_defaults_version_to_1_5():
+    """Test AdaptiveCard defaults version to '1.5'."""
+    card = AdaptiveCard(body=[])
+    assert card.version == "1.5"
+
+
+def test_adaptive_card_includes_version_in_serialized_json():
+    """Test AdaptiveCard includes version in serialized JSON."""
+    card = AdaptiveCard(body=[TextBlock(text="Hello")])
+    json_str = card.model_dump_json(exclude_none=True, by_alias=True)
+    parsed = json.loads(json_str)
+    assert parsed["version"] == "1.5"
+
+
+def test_adaptive_card_allows_overriding_version():
+    """Test AdaptiveCard allows overriding the default version."""
+    card = AdaptiveCard(version="1.4", body=[])
+    assert card.version == "1.4"
+
+
 def test_ms_teams_serializes_to_msteams():
     """Test that ms_teams field serializes to 'msteams' instead of 'msTeams'."""
     # Test AdaptiveCard.ms_teams serialization


### PR DESCRIPTION
It appears that mobile has a verification step on the Adaptive Cards version being set, despite desktop not having that check. This causes cards not to render if the card does not have a version. Setting a versions fixes rendering on mobile.