### PR TITLE
Add is_targeted field to Activity class for incoming messages

### DIFF
--- a/packages/api/src/microsoft_teams/api/models/activity.py
+++ b/packages/api/src/microsoft_teams/api/models/activity.py
@@ -328,6 +328,14 @@ class Activity(_ActivityBase):
     recipient: Account
     """Identifies the recipient of the message."""
 
+    is_targeted: Optional[bool] = None
+    """Indicates if this is a targeted message visible only to a specific recipient.
+
+    .. warning:: Preview
+        This field is in preview and may change in the future.
+        Diagnostic: ExperimentalTeamsTargeted
+    """
+
     @property
     def channel(self) -> Optional[ChannelInfo]:
         """Information about the channel in which the message was sent."""

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -806,3 +806,63 @@ class TestMessageActivityIntegration:
         assert activity.is_targeted is True
         assert activity.recipient is not None
         assert activity.recipient.id == "user-123"
+
+
+class TestMessageActivityIsTargeted:
+    """Tests for is_targeted field on incoming MessageActivity (issue #320)."""
+
+    def test_message_activity_has_is_targeted_field(self):
+        """Verify MessageActivity (incoming) supports the is_targeted field."""
+        activity = MessageActivity(
+            id="test-1",
+            type="message",
+            text="Hello",
+            from_=Account(id="user-123", name="Test User"),
+            conversation=ConversationAccount(id="conv-123"),
+            recipient=Account(id="bot-123", name="Bot"),
+            is_targeted=True,
+        )
+        assert activity.is_targeted is True
+
+    def test_message_activity_is_targeted_defaults_to_none(self):
+        """Verify is_targeted defaults to None when not provided."""
+        activity = MessageActivity(
+            id="test-1",
+            type="message",
+            text="Hello",
+            from_=Account(id="user-123", name="Test User"),
+            conversation=ConversationAccount(id="conv-123"),
+            recipient=Account(id="bot-123", name="Bot"),
+        )
+        assert activity.is_targeted is None
+
+    def test_message_activity_is_targeted_round_trip(self):
+        """Verify is_targeted survives model_dump/model_validate round-trip."""
+        activity = MessageActivity(
+            id="test-1",
+            type="message",
+            text="Hello",
+            from_=Account(id="user-123", name="Test User"),
+            conversation=ConversationAccount(id="conv-123"),
+            recipient=Account(id="bot-123", name="Bot"),
+            is_targeted=True,
+        )
+        dumped = activity.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["isTargeted"] is True
+
+        restored = MessageActivity.model_validate(dumped)
+        assert restored.is_targeted is True
+
+    def test_message_activity_deserialize_with_is_targeted(self):
+        """Verify MessageActivity can deserialize JSON payload containing isTargeted."""
+        payload = {
+            "id": "test-1",
+            "type": "message",
+            "text": "Hello",
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-123"},
+            "recipient": {"id": "bot-123", "name": "Bot"},
+            "isTargeted": True,
+        }
+        activity = MessageActivity.model_validate(payload)
+        assert activity.is_targeted is True


### PR DESCRIPTION
## Summary
- Adds `is_targeted: Optional[bool] = None` to the `Activity` class (incoming/received model) to match `ActivityInput` (outgoing model) which already has this field
- Fixes `AttributeError` when accessing `is_targeted` on incoming `MessageActivity` instances (e.g. during `sign_in()` flows with targeted messages)
- Adds tests for field access, default value, JSON deserialization, and round-trip serialization

## Details
The `Activity` class at `packages/api/src/microsoft_teams/api/models/activity.py` was missing the `is_targeted` field that `ActivityInput` already declared at line 99. When Teams sends a targeted message, the `isTargeted` field in the payload was silently dropped during deserialization, and downstream code accessing `activity.is_targeted` on an incoming `MessageActivity` would raise `AttributeError`.

The fix adds the field with the same type signature (`Optional[bool] = None`) and preview warning as `ActivityInput`. Since `MessageActivity` inherits from `Activity` via `ActivityBase`, it automatically gets the field.

Fully backwards compatible — optional field with `None` default.

## Test plan
- [x] `test_message_activity_has_is_targeted_field` — field access with `is_targeted=True`
- [x] `test_message_activity_is_targeted_defaults_to_none` — default value when not provided
- [x] `test_message_activity_is_targeted_round_trip` — `model_dump`/`model_validate` cycle
- [x] `test_message_activity_deserialize_with_is_targeted` — JSON payload with `isTargeted`

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)