### PR TITLE
fix: include devtools package in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -20,7 +20,7 @@ parameters:
 variables:
 - group: TeamsSDK-Release
 - name: ExcludePackageFolders
-  value: 'devtools'  # Space-separated list of distribution name fragments to exclude (matched as microsoft_teams_<value>*)
+  value: ''  # Space-separated list of distribution name fragments to exclude (matched as microsoft_teams_<value>*)
 
 resources:
   repositories:


### PR DESCRIPTION
## Summary
- The `devtools` package was accidentally left in the `ExcludePackageFolders` variable in the publish pipeline, preventing it from being published
- Clears the exclusion list so all packages are included in both internal and public releases

Fixes #329 