### PR TITLE
feat: GitHub issue analysis → Teams notification workflow

### DIFF
--- a/.github/scripts/analyze_issue.py
+++ b/.github/scripts/analyze_issue.py
@@ -116,7 +116,24 @@ def _issue_as_user_message(issue: dict) -> str:
 def triage_issue(issue: dict) -> dict:
     """Triage the issue: category, severity, summary, etc."""
     content = _call_model(TRIAGE_PROMPT, _issue_as_user_message(issue))
-    return json.loads(content)
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        # Model may wrap JSON in markdown fences — try extracting it
+        start = content.find("{")
+        end = content.rfind("}")
+        if start != -1 and end > start:
+            try:
+                return json.loads(content[start : end + 1])
+            except json.JSONDecodeError:
+                pass
+        return {
+            "category": "question",
+            "severity": "info",
+            "summary": f"Automated triage failed to parse model response. Review issue #{issue['number']} manually.",
+            "affected_packages": [],
+            "suggested_labels": [],
+        }
 
 
 def load_copilot_analysis() -> str:

--- a/.github/workflows/issue-analysis.yml
+++ b/.github/workflows/issue-analysis.yml
@@ -63,26 +63,34 @@ jobs:
           EVENT_ISSUE_LABELS: ${{ toJSON(github.event.issue.labels) }}
           EVENT_ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
+          # Use heredoc form for all fields to prevent output injection
+          # (issue titles/authors could contain newlines or %)
+          write_output() {
+            local name="$1"
+            local value="$2"
+            local delimiter="EOF_${name}_$$"
+            {
+              printf '%s<<%s\n' "$name" "$delimiter"
+              printf '%s\n' "$value"
+              printf '%s\n' "$delimiter"
+            } >> "$GITHUB_OUTPUT"
+          }
+
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             ISSUE=$(gh api repos/microsoft/teams.py/issues/"$INPUT_NUMBER")
-            echo "number=$(echo "$ISSUE" | jq -r '.number')" >> "$GITHUB_OUTPUT"
-            echo "title=$(echo "$ISSUE" | jq -r '.title')" >> "$GITHUB_OUTPUT"
-            echo "author=$(echo "$ISSUE" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
-            echo "html_url=$(echo "$ISSUE" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
-            echo "labels=$(echo "$ISSUE" | jq -r '[.labels[].name] | join(",")')" >> "$GITHUB_OUTPUT"
-            echo "body<<BODY_EOF" >> "$GITHUB_OUTPUT"
-            echo "$ISSUE" | jq -r '.body // ""' >> "$GITHUB_OUTPUT"
-            echo "BODY_EOF" >> "$GITHUB_OUTPUT"
+            write_output "number" "$(echo "$ISSUE" | jq -r '.number')"
+            write_output "title" "$(echo "$ISSUE" | jq -r '.title')"
+            write_output "author" "$(echo "$ISSUE" | jq -r '.user.login')"
+            write_output "html_url" "$(echo "$ISSUE" | jq -r '.html_url')"
+            write_output "labels" "$(echo "$ISSUE" | jq -r '[.labels[].name] | join(",")')"
+            write_output "body" "$(echo "$ISSUE" | jq -r '.body // ""')"
           else
-            echo "number=$EVENT_ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "title=$EVENT_ISSUE_TITLE" >> "$GITHUB_OUTPUT"
-            echo "author=$EVENT_ISSUE_AUTHOR" >> "$GITHUB_OUTPUT"
-            echo "html_url=$EVENT_ISSUE_URL" >> "$GITHUB_OUTPUT"
-            echo "labels=$(echo "$EVENT_ISSUE_LABELS" | jq -r '[.[].name] | join(",")')" >> "$GITHUB_OUTPUT"
-            echo "body<<BODY_EOF" >> "$GITHUB_OUTPUT"
-            printf '%s' "$EVENT_ISSUE_BODY" >> "$GITHUB_OUTPUT"
-            echo "" >> "$GITHUB_OUTPUT"
-            echo "BODY_EOF" >> "$GITHUB_OUTPUT"
+            write_output "number" "$EVENT_ISSUE_NUMBER"
+            write_output "title" "$EVENT_ISSUE_TITLE"
+            write_output "author" "$EVENT_ISSUE_AUTHOR"
+            write_output "html_url" "$EVENT_ISSUE_URL"
+            write_output "labels" "$(echo "$EVENT_ISSUE_LABELS" | jq -r '[.[].name] | join(",")')"
+            write_output "body" "$EVENT_ISSUE_BODY"
           fi
 
       - name: Analyze issue with Copilot CLI


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically analyzes new issues and sends results to a Teams channel
- Uses GitHub Models API (GPT-4o) for quick triage → Adaptive Card summary
- Uses GitHub Copilot CLI with full repo context for deep analysis → threaded markdown reply
- Supports manual trigger via `workflow_dispatch` for any issue number

## How it works
1. **Triage** (GPT-4o, free): Categorizes the issue (bug/feature/question), assigns severity, identifies affected packages
2. **Analysis** (Copilot CLI): Reads the actual codebase to produce root cause, files to investigate, proposed approach, and complexity estimate
3. **Teams notification**: Sends triage as an Adaptive Card, then threads the Copilot analysis as a reply

## Files
- `.github/workflows/issue-analysis.yml` — workflow definition
- `.github/scripts/analyze_issue.py` — triage, card building, and Teams messaging

## Required secrets
| Secret | Purpose |
|---|---|
| `TEAMS_CLIENT_ID` | Azure AD app client ID |
| `TEAMS_CLIENT_SECRET` | Azure AD app client secret |
| `TEAMS_TENANT_ID` | Azure AD tenant ID |
| `TEAMS_CONVERSATION_ID` | Teams channel/chat ID |
| `COPILOT_PAT` | PAT with Copilot Requests permission |

`GITHUB_TOKEN` is automatic (provides GitHub Models API access).

## Test plan
- Tested successfully in a fork