### PR TITLE
chore: remove dead *ActivityInput classes for inbound-only types

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/command/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/command/__init__.py
@@ -7,17 +7,15 @@ from typing import Annotated, Union
 
 from pydantic import Field
 
-from .command_result import CommandResultActivity, CommandResultActivityInput, CommandResultValue
-from .command_send import CommandSendActivity, CommandSendActivityInput, CommandSendValue
+from .command_result import CommandResultActivity, CommandResultValue
+from .command_send import CommandSendActivity, CommandSendValue
 
 CommandActivity = Annotated[Union[CommandSendActivity, CommandResultActivity], Field(discriminator="type")]
 
 __all__ = [
     "CommandResultValue",
     "CommandResultActivity",
-    "CommandResultActivityInput",
     "CommandSendValue",
     "CommandSendActivity",
-    "CommandSendActivityInput",
     "CommandActivity",
 ]

--- a/packages/api/src/microsoft_teams/api/activities/command/command_result.py
+++ b/packages/api/src/microsoft_teams/api/activities/command/command_result.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from typing import Any, Literal, Optional
 
-from ...models import ActivityBase, ActivityInputBase, CustomBaseModel
+from ...models import ActivityBase, CustomBaseModel
 
 
 class CommandResultValue(CustomBaseModel):
@@ -47,7 +47,3 @@ class CommandResultActivity(_CommandResultBase, ActivityBase):
     """The name of the event."""
 
 
-class CommandResultActivityInput(_CommandResultBase, ActivityInputBase):
-    """Input model for creating command result activities with builder methods."""
-
-    pass

--- a/packages/api/src/microsoft_teams/api/activities/command/command_send.py
+++ b/packages/api/src/microsoft_teams/api/activities/command/command_send.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from typing import Any, Literal, Optional
 
-from ...models import ActivityBase, ActivityInputBase, CustomBaseModel
+from ...models import ActivityBase, CustomBaseModel
 
 
 class CommandSendValue(CustomBaseModel):
@@ -43,7 +43,3 @@ class CommandSendActivity(_CommandSendBase, ActivityBase):
     """The name of the event."""
 
 
-class CommandSendActivityInput(_CommandSendBase, ActivityInputBase):
-    """Input model for creating command send activities with builder methods."""
-
-    pass

--- a/packages/api/src/microsoft_teams/api/activities/conversation/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/conversation/__init__.py
@@ -7,7 +7,6 @@ from .conversation_update import (
     ConversationChannelData,
     ConversationEventType,
     ConversationUpdateActivity,
-    ConversationUpdateActivityInput,
 )
 
 ConversationActivity = ConversationUpdateActivity
@@ -16,6 +15,5 @@ __all__ = [
     "ConversationEventType",
     "ConversationChannelData",
     "ConversationUpdateActivity",
-    "ConversationUpdateActivityInput",
     "ConversationActivity",
 ]

--- a/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from typing import List, Literal, Optional
 
-from ...models import Account, ActivityBase, ActivityInputBase, ChannelData, CustomBaseModel
+from ...models import Account, ActivityBase, ChannelData, CustomBaseModel
 
 ConversationEventType = Literal[
     "channelCreated",
@@ -55,7 +55,3 @@ class ConversationUpdateActivity(_ConversationUpdateBase, ActivityBase):
     """Channel data with event type information."""
 
 
-class ConversationUpdateActivityInput(_ConversationUpdateBase, ActivityInputBase):
-    """Input model for creating conversation update activities with builder methods."""
-
-    pass

--- a/packages/api/src/microsoft_teams/api/activities/handoff.py
+++ b/packages/api/src/microsoft_teams/api/activities/handoff.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from typing import Literal
 
-from ..models import ActivityBase, ActivityInputBase, CustomBaseModel
+from ..models import ActivityBase, CustomBaseModel
 
 
 class _HandoffBase(CustomBaseModel):
@@ -18,5 +18,3 @@ class HandoffActivity(_HandoffBase, ActivityBase):
     """Output model for received handoff activities with required fields and read-only properties."""
 
 
-class HandoffActivityInput(_HandoffBase, ActivityInputBase):
-    """Input model for creating handoff activities with builder methods."""

--- a/packages/api/src/microsoft_teams/api/activities/message/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/__init__.py
@@ -8,12 +8,11 @@ from typing import Annotated, Union
 from pydantic import Field
 
 from .message import MessageActivity, MessageActivityInput
-from .message_delete import MessageDeleteActivity, MessageDeleteActivityInput, MessageDeleteChannelData
+from .message_delete import MessageDeleteActivity, MessageDeleteChannelData
 from .message_reaction import MessageReactionActivity, MessageReactionActivityInput
 from .message_update import (
     MessageEventType,
     MessageUpdateActivity,
-    MessageUpdateActivityInput,
     MessageUpdateChannelData,
 )
 
@@ -32,12 +31,10 @@ __all__ = [
     "MessageActivity",
     "MessageActivityInput",
     "MessageDeleteActivity",
-    "MessageDeleteActivityInput",
     "MessageDeleteChannelData",
     "MessageReactionActivity",
     "MessageReactionActivityInput",
     "MessageUpdateActivity",
-    "MessageUpdateActivityInput",
     "MessageUpdateChannelData",
     "MessageEventType",
 ]

--- a/packages/api/src/microsoft_teams/api/activities/message/message_delete.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message_delete.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from typing import Literal, Optional
 
-from ...models import ActivityBase, ActivityInputBase, ChannelData
+from ...models import ActivityBase, ChannelData
 from ...models.custom_base_model import CustomBaseModel
 
 
@@ -30,7 +30,3 @@ class MessageDeleteActivity(_MessageDeleteBase, ActivityBase):
 
     channel_data: MessageDeleteChannelData  # pyright: ignore [reportGeneralTypeIssues]
     """Channel-specific data for message delete events."""
-
-
-class MessageDeleteActivityInput(_MessageDeleteBase, ActivityInputBase):
-    """Input model for creating message delete activities with builder methods."""

--- a/packages/api/src/microsoft_teams/api/activities/message/message_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message_update.py
@@ -4,9 +4,9 @@ Licensed under the MIT License.
 """
 
 from datetime import datetime
-from typing import Any, Literal, Optional, Self
+from typing import Any, Literal, Optional
 
-from ...models import ActivityBase, ActivityInputBase, ChannelData
+from ...models import ActivityBase, ChannelData
 from ...models.custom_base_model import CustomBaseModel
 
 MessageEventType = Literal["undeleteMessage", "editMessage"]
@@ -56,57 +56,3 @@ class MessageUpdateActivity(_MessageUpdateBase, ActivityBase):
     """Channel-specific data for message update events."""
 
 
-class MessageUpdateActivityInput(_MessageUpdateBase, ActivityInputBase):
-    """Input model for creating message update activities with builder methods."""
-
-    def with_text(self, text: str) -> Self:
-        """
-        Set the text content of the message.
-
-        Args:
-            text: The text content to set
-
-        Returns:
-            Self for method chaining
-        """
-        self.text = text
-        return self
-
-    def with_speak(self, speak: str) -> Self:
-        """
-        Set the text to speak.
-
-        Args:
-            speak: The text to speak
-
-        Returns:
-            Self for method chaining
-        """
-        self.speak = speak
-        return self
-
-    def with_summary(self, summary: str) -> Self:
-        """
-        Set the summary text.
-
-        Args:
-            summary: The summary text to set
-
-        Returns:
-            Self for method chaining
-        """
-        self.summary = summary
-        return self
-
-    def with_expiration(self, expiration: datetime) -> Self:
-        """
-        Set the expiration time for the activity.
-
-        Args:
-            expiration: The expiration datetime to set
-
-        Returns:
-            Self for method chaining
-        """
-        self.expiration = expiration
-        return self

--- a/packages/api/src/microsoft_teams/api/activities/trace.py
+++ b/packages/api/src/microsoft_teams/api/activities/trace.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from typing import Any, Literal, Optional
 
-from ..models import ActivityBase, ActivityInputBase, CustomBaseModel
+from ..models import ActivityBase, CustomBaseModel
 
 
 class _TraceBase(CustomBaseModel):
@@ -48,5 +48,3 @@ class TraceActivity(_TraceBase, ActivityBase):
     """
 
 
-class TraceActivityInput(_TraceBase, ActivityInputBase):
-    """Input model for creating trace activities with builder methods."""


### PR DESCRIPTION
## Summary
Follow-up to #340. Deletes 7 `*ActivityInput` classes that were removed from the `ActivityParams` union and have zero references anywhere in the codebase.

**Deleted classes:**
- `MessageDeleteActivityInput`
- `MessageUpdateActivityInput`
- `ConversationUpdateActivityInput`
- `HandoffActivityInput`
- `TraceActivityInput`
- `CommandSendActivityInput`
- `CommandResultActivityInput`

The corresponding `*Activity` classes (used as handler type hints for incoming events) are preserved.

### Why
These classes existed for model symmetry (every Activity type had an Input counterpart) but represented inbound-only event types. They had no valid outbound send path and no references outside their own definitions and `__init__.py` exports. Removing them eliminates the suggestion that these types are constructible for any purpose.

## Test plan

### Automated
- [x] CI passes: build, lint (ruff + pyright), and unit tests on Python 3.12/3.13/3.14
- [x] Local: 552 tests pass on Python 3.13

### Verification
- [x] `from microsoft_teams.api.activities import MessageDeleteActivityInput` raises `ImportError`
- [x] `from microsoft_teams.api.activities import MessageDeleteActivity` still works
- [x] All handler decorators (`@app.on_message_delete`, `@app.on_message_update`, etc.) still work with incoming Activity types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
