### PR TITLE
refactor: rename ActivityParams → SendableActivity

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/__init__.py
@@ -8,7 +8,7 @@ from typing import Annotated, Union
 from pydantic import Field, TypeAdapter
 
 from . import event, install_update, invoke, message
-from .activity_params import ActivityParams
+from .sendable_activity import SendableActivity
 from .command import CommandActivity, CommandResultActivity, CommandResultValue, CommandSendActivity, CommandSendValue
 from .conversation import (
     ConversationActivity,
@@ -68,7 +68,7 @@ __all__: list[str] = [
     "ConversationEventType",
     "InvokeActivity",
     "TraceActivity",
-    "ActivityParams",
+    "SendableActivity",
     "SentActivity",
 ]
 __all__.extend(event.__all__)

--- a/packages/api/src/microsoft_teams/api/activities/sendable_activity.py
+++ b/packages/api/src/microsoft_teams/api/activities/sendable_activity.py
@@ -20,7 +20,7 @@ from .message import (
 )
 from .typing import TypingActivityInput
 
-ActivityParams = Annotated[
+SendableActivity = Annotated[
     Union[
         MessageActivityInput,
         MessageReactionActivityInput,

--- a/packages/api/src/microsoft_teams/api/activities/sent_activity.py
+++ b/packages/api/src/microsoft_teams/api/activities/sent_activity.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 from ..models import CustomBaseModel
-from . import ActivityParams
+from . import SendableActivity
 
 
 class SentActivity(CustomBaseModel):
@@ -13,10 +13,10 @@ class SentActivity(CustomBaseModel):
     id: str
     """Id of the activity."""
 
-    activity_params: ActivityParams
+    activity_params: SendableActivity
     """Additional parameters for the activity."""
 
     @classmethod
-    def merge(cls, activity_params: ActivityParams, curr_activity: "SentActivity") -> "SentActivity":
+    def merge(cls, activity_params: SendableActivity, curr_activity: "SentActivity") -> "SentActivity":
         merged_data = {**activity_params.model_dump(), **curr_activity.model_dump()}
         return cls(**merged_data)

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from microsoft_teams.common.experimental import experimental
 from microsoft_teams.common.http import Client
 
-from ...activities import ActivityParams, SentActivity
+from ...activities import SendableActivity, SentActivity
 from ...models import TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -38,7 +38,7 @@ class ConversationActivityClient(BaseClient):
         super().__init__(http_client, api_client_settings)
         self.service_url = service_url.rstrip("/")
 
-    async def create(self, conversation_id: str, activity: ActivityParams) -> SentActivity:
+    async def create(self, conversation_id: str, activity: SendableActivity) -> SentActivity:
         """
         Create a new activity in a conversation.
 
@@ -61,7 +61,7 @@ class ConversationActivityClient(BaseClient):
         id = response.json().get("id", _PLACEHOLDER_ACTIVITY_ID)
         return SentActivity(id=id, activity_params=activity)
 
-    async def update(self, conversation_id: str, activity_id: str, activity: ActivityParams) -> SentActivity:
+    async def update(self, conversation_id: str, activity_id: str, activity: SendableActivity) -> SentActivity:
         """
         Update an existing activity in a conversation.
 
@@ -80,7 +80,7 @@ class ConversationActivityClient(BaseClient):
         id = response.json()["id"]
         return SentActivity(id=id, activity_params=activity)
 
-    async def reply(self, conversation_id: str, activity_id: str, activity: ActivityParams) -> SentActivity:
+    async def reply(self, conversation_id: str, activity_id: str, activity: SendableActivity) -> SentActivity:
         """
         Reply to an activity in a conversation.
 
@@ -128,7 +128,7 @@ class ConversationActivityClient(BaseClient):
         return [TeamsChannelAccount.model_validate(member) for member in response.json()]
 
     @experimental("ExperimentalTeamsTargeted")
-    async def create_targeted(self, conversation_id: str, activity: ActivityParams) -> SentActivity:
+    async def create_targeted(self, conversation_id: str, activity: SendableActivity) -> SentActivity:
         """
         Create a new targeted activity in a conversation.
 
@@ -153,7 +153,7 @@ class ConversationActivityClient(BaseClient):
         return SentActivity(id=id, activity_params=activity)
 
     @experimental("ExperimentalTeamsTargeted")
-    async def update_targeted(self, conversation_id: str, activity_id: str, activity: ActivityParams) -> SentActivity:
+    async def update_targeted(self, conversation_id: str, activity_id: str, activity: SendableActivity) -> SentActivity:
         """
         Update an existing targeted activity in a conversation.
 

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -10,7 +10,7 @@ from microsoft_teams.common.http import Client, ClientOptions
 from ...models import ConversationResource
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
-from .activity import ActivityParams, ConversationActivityClient
+from .activity import SendableActivity, ConversationActivityClient
 from .member import ConversationMemberClient
 from .params import CreateConversationParams
 
@@ -26,13 +26,13 @@ class ConversationOperations:
 class ActivityOperations(ConversationOperations):
     """Operations for managing activities in a conversation."""
 
-    async def create(self, activity: ActivityParams):
+    async def create(self, activity: SendableActivity):
         return await self._client.activities_client.create(self._conversation_id, activity)
 
-    async def update(self, activity_id: str, activity: ActivityParams):
+    async def update(self, activity_id: str, activity: SendableActivity):
         return await self._client.activities_client.update(self._conversation_id, activity_id, activity)
 
-    async def reply(self, activity_id: str, activity: ActivityParams):
+    async def reply(self, activity_id: str, activity: SendableActivity):
         return await self._client.activities_client.reply(self._conversation_id, activity_id, activity)
 
     async def delete(self, activity_id: str):
@@ -41,11 +41,11 @@ class ActivityOperations(ConversationOperations):
     async def get_members(self, activity_id: str):
         return await self._client.activities_client.get_members(self._conversation_id, activity_id)
 
-    async def create_targeted(self, activity: ActivityParams):
+    async def create_targeted(self, activity: SendableActivity):
         """Create a new targeted activity visible only to the specified recipient."""
         return await self._client.activities_client.create_targeted(self._conversation_id, activity)
 
-    async def update_targeted(self, activity_id: str, activity: ActivityParams):
+    async def update_targeted(self, activity_id: str, activity: SendableActivity):
         """Update an existing targeted activity."""
         return await self._client.activities_client.update_targeted(self._conversation_id, activity_id, activity)
 

--- a/packages/api/src/microsoft_teams/api/clients/conversation/params.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/params.py
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 from typing import Any, Dict, List, Optional
 
 from ...models import Account, CustomBaseModel
-from .activity import ActivityParams
+from .activity import SendableActivity
 
 
 class CreateConversationParams(CustomBaseModel):
@@ -20,7 +20,7 @@ class CreateConversationParams(CustomBaseModel):
     """
     The tenant ID for the conversation.
     """
-    activity: Optional[ActivityParams] = None
+    activity: Optional[SendableActivity] = None
     """
     The initial activity to post in the conversation.
     """

--- a/packages/api/tests/unit/test_sent_activity.py
+++ b/packages/api/tests/unit/test_sent_activity.py
@@ -5,19 +5,19 @@ Licensed under the MIT License.
 # pyright: basic
 
 import pytest
-from microsoft_teams.api.activities import ActivityParams, MessageActivityInput, SentActivity
+from microsoft_teams.api.activities import SendableActivity, MessageActivityInput, SentActivity
 
 
 @pytest.fixture
-def mock_new_activity_params() -> ActivityParams:
-    """Create a mock ActivityParams for testing."""
+def mock_new_activity_params() -> SendableActivity:
+    """Create a mock SendableActivity for testing."""
     return MessageActivityInput(
         id="updated-id", type="message", text="updated message", locale="en-US", reply_to_id="activity-3"
     )
 
 
 @pytest.fixture
-def mock_sent_activity(mock_new_activity_params: ActivityParams) -> SentActivity:
+def mock_sent_activity(mock_new_activity_params: SendableActivity) -> SentActivity:
     """Create a mock SentActivity for testing."""
     return SentActivity(
         id="sent-1",

--- a/packages/apps/src/microsoft_teams/apps/activity_sender.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_sender.py
@@ -7,7 +7,7 @@ import logging
 from typing import cast
 
 from microsoft_teams.api import (
-    ActivityParams,
+    SendableActivity,
     ApiClient,
     ConversationReference,
     MessageActivityInput,
@@ -36,7 +36,7 @@ class ActivitySender:
         """
         self._client = client
 
-    async def send(self, activity: ActivityParams, ref: ConversationReference) -> SentActivity:
+    async def send(self, activity: SendableActivity, ref: ConversationReference) -> SentActivity:
         """
         Send an activity to the Bot Framework.
 

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -14,7 +14,7 @@ from dotenv import find_dotenv, load_dotenv
 from microsoft_teams.api import (
     Account,
     ActivityBase,
-    ActivityParams,
+    SendableActivity,
     ApiClient,
     ClientCredentials,
     ConversationAccount,
@@ -275,7 +275,7 @@ class App(ActivityHandlerMixin):
             self._events.emit("error", ErrorEvent(error, context={"method": "stop"}))
             raise
 
-    async def send(self, conversation_id: str, activity: str | ActivityParams | AdaptiveCard):
+    async def send(self, conversation_id: str, activity: str | SendableActivity | AdaptiveCard):
         """Send an activity proactively."""
 
         if not self._initialized:

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 
 from microsoft_teams.api import (
     ActivityBase,
-    ActivityParams,
+    SendableActivity,
     ActivityTypeAdapter,
     ApiClient,
     ApiClientSettings,
@@ -131,7 +131,7 @@ class ActivityProcessor:
         send = activityCtx.send
 
         async def updated_send(
-            message: str | ActivityParams | AdaptiveCard,
+            message: str | SendableActivity | AdaptiveCard,
             conversation_ref: Optional[ConversationReference] = None,
         ) -> SentActivity:
             res = await send(message, conversation_ref)

--- a/packages/apps/src/microsoft_teams/apps/contexts/function_context.py
+++ b/packages/apps/src/microsoft_teams/apps/contexts/function_context.py
@@ -11,7 +11,7 @@ from typing import Generic, Optional, TypeVar
 
 from microsoft_teams.api import (
     Account,
-    ActivityParams,
+    SendableActivity,
     ApiClient,
     ConversationAccount,
     ConversationReference,
@@ -50,7 +50,7 @@ class FunctionContext(ClientContext, Generic[T]):
     data: T
     """The function payload."""
 
-    async def send(self, activity: str | ActivityParams | AdaptiveCard) -> Optional[SentActivity]:
+    async def send(self, activity: str | SendableActivity | AdaptiveCard) -> Optional[SentActivity]:
         """
         Send an activity to the current conversation.
 
@@ -81,7 +81,7 @@ class FunctionContext(ClientContext, Generic[T]):
 
         return await self.activity_sender.send(activity, conversation_ref)
 
-    async def _resolve_conversation_id(self, activity: str | ActivityParams | AdaptiveCard) -> Optional[str]:
+    async def _resolve_conversation_id(self, activity: str | SendableActivity | AdaptiveCard) -> Optional[str]:
         """Resolve or create a conversation ID for the current user/context.
 
         Args:

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, Optional, T
 
 from microsoft_teams.api import (
     ActivityBase,
-    ActivityParams,
+    SendableActivity,
     ApiClient,
     CardAction,
     CardActionType,
@@ -71,7 +71,7 @@ class SignInOptions:
                 Optional[TokenPostResource],
                 Optional[str],
             ],
-            ActivityParams,
+            SendableActivity,
         ]
     ] = None
 
@@ -165,14 +165,14 @@ class ActivityContext(Generic[T]):
 
     async def send(
         self,
-        message: str | ActivityParams | AdaptiveCard,
+        message: str | SendableActivity | AdaptiveCard,
         conversation_ref: Optional[ConversationReference] = None,
     ) -> SentActivity:
         """
         Send a message to the conversation.
 
         Args:
-            message: The message to send, can be a string, ActivityParams, or AdaptiveCard
+            message: The message to send, can be a string, SendableActivity, or AdaptiveCard
             conversation_ref: Optional conversation reference to override the current conversation reference
         """
         if isinstance(message, str):
@@ -186,7 +186,7 @@ class ActivityContext(Generic[T]):
         res = await self._activity_sender.send(activity, ref)
         return res
 
-    async def reply(self, input: str | ActivityParams) -> SentActivity:
+    async def reply(self, input: str | SendableActivity) -> SentActivity:
         """Send a reply to the activity."""
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         if isinstance(activity, MessageActivityInput):

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -217,8 +217,8 @@ class TestActivityContextReply:
         assert "My reply" in (sent_activity.text or "")
 
     @pytest.mark.asyncio
-    async def test_reply_with_activity_params(self) -> None:
-        """reply() with an ActivityParams instance sets reply_to_id and delegates to send."""
+    async def test_reply_with_sendable_activity(self) -> None:
+        """reply() with a SendableActivity instance sets reply_to_id and delegates to send."""
         mock_activity = MagicMock()
         mock_activity.type = "event"
         mock_activity.id = "evt-id-999"


### PR DESCRIPTION
## Summary
Stacked on #340 → #341. Renames the outbound activity union type from `ActivityParams` to `SendableActivity`.

- Renames type: `ActivityParams` → `SendableActivity`
- Renames module: `activity_params.py` → `sendable_activity.py`
- Updates all 13 files that reference the type
- Pure rename — no logic changes

### Why
`ActivityParams` was vague — it didn't communicate that this union represents the set of activity types that can be sent outbound. `SendableActivity` makes the API self-documenting:

```python
async def send(self, activity: SendableActivity) -> SentActivity:
```

## Test plan

### Automated
- [x] CI passes: build, lint (ruff + pyright), and unit tests on Python 3.12/3.13/3.14
- [x] Local: 552 tests pass on Python 3.13

### Verification
- [x] `from microsoft_teams.api.activities import SendableActivity` works
- [x] `from microsoft_teams.api.activities import ActivityParams` raises `ImportError`
- [x] All `send()` / `reply()` / `create()` methods accept `SendableActivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
