### PR TITLE
Add sovereign cloud support (GCCH, DoD, China)

### DIFF
--- a/packages/api/src/microsoft_teams/api/auth/__init__.py
+++ b/packages/api/src/microsoft_teams/api/auth/__init__.py
@@ -4,6 +4,15 @@ Licensed under the MIT License.
 """
 
 from .caller import CallerIds, CallerType
+from .cloud_environment import (
+    CHINA,
+    PUBLIC,
+    US_GOV,
+    US_GOV_DOD,
+    CloudEnvironment,
+    from_name,
+    with_overrides,
+)
 from .credentials import (
     ClientCredentials,
     Credentials,
@@ -17,12 +26,19 @@ from .token import TokenProtocol
 __all__ = [
     "CallerIds",
     "CallerType",
+    "CHINA",
+    "CloudEnvironment",
     "ClientCredentials",
     "Credentials",
     "FederatedIdentityCredentials",
+    "from_name",
     "ManagedIdentityCredentials",
+    "PUBLIC",
     "TokenCredentials",
     "TokenProtocol",
     "JsonWebToken",
     "JsonWebTokenPayload",
+    "US_GOV",
+    "US_GOV_DOD",
+    "with_overrides",
 ]

--- a/packages/api/src/microsoft_teams/api/auth/__init__.py
+++ b/packages/api/src/microsoft_teams/api/auth/__init__.py
@@ -5,14 +5,11 @@ Licensed under the MIT License.
 
 from .caller import CallerIds, CallerType
 from .cloud_environment import (
-    CHINA,
-    PUBLIC,
-    US_GOV,
-    US_GOV_DOD,
     CloudEnvironment,
     from_name,
     with_overrides,
 )
+from .cloud_environment import from_name as config_from_cloud_name
 from .credentials import (
     ClientCredentials,
     Credentials,
@@ -26,19 +23,16 @@ from .token import TokenProtocol
 __all__ = [
     "CallerIds",
     "CallerType",
-    "CHINA",
     "CloudEnvironment",
     "ClientCredentials",
+    "config_from_cloud_name",
     "Credentials",
     "FederatedIdentityCredentials",
     "from_name",
     "ManagedIdentityCredentials",
-    "PUBLIC",
     "TokenCredentials",
     "TokenProtocol",
     "JsonWebToken",
     "JsonWebTokenPayload",
-    "US_GOV",
-    "US_GOV_DOD",
     "with_overrides",
 ]

--- a/packages/api/src/microsoft_teams/api/auth/__init__.py
+++ b/packages/api/src/microsoft_teams/api/auth/__init__.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 from .caller import CallerIds, CallerType
 from .cloud_environment import (
     CloudEnvironment,
-    from_name,
     with_overrides,
 )
 from .cloud_environment import from_name as config_from_cloud_name
@@ -28,7 +27,6 @@ __all__ = [
     "config_from_cloud_name",
     "Credentials",
     "FederatedIdentityCredentials",
-    "from_name",
     "ManagedIdentityCredentials",
     "TokenCredentials",
     "TokenProtocol",

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -1,0 +1,113 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class CloudEnvironment:
+    """
+    Bundles all cloud-specific service endpoints for a given Azure environment.
+    Use predefined instances (PUBLIC, US_GOV, US_GOV_DOD, CHINA)
+    or construct a custom one via with_overrides().
+    """
+
+    login_endpoint: str
+    """The Azure AD login endpoint (e.g. "https://login.microsoftonline.com")."""
+    login_tenant: str
+    """The default multi-tenant login tenant (e.g. "botframework.com")."""
+    bot_scope: str
+    """The Bot Framework OAuth scope (e.g. "https://api.botframework.com/.default")."""
+    token_service_url: str
+    """The Bot Framework token service base URL (e.g. "https://token.botframework.com")."""
+    openid_metadata_url: str
+    """The OpenID metadata URL for token validation."""
+    token_issuer: str
+    """The token issuer for Bot Framework tokens (e.g. "https://api.botframework.com")."""
+    channel_service: str
+    """The channel service URL. Empty for public cloud; set for sovereign clouds."""
+    oauth_redirect_url: str
+    """The OAuth redirect URL (e.g. "https://token.botframework.com/.auth/web/redirect")."""
+
+
+PUBLIC = CloudEnvironment(
+    login_endpoint="https://login.microsoftonline.com",
+    login_tenant="botframework.com",
+    bot_scope="https://api.botframework.com/.default",
+    token_service_url="https://token.botframework.com",
+    openid_metadata_url="https://login.botframework.com/v1/.well-known/openidconfiguration",
+    token_issuer="https://api.botframework.com",
+    channel_service="",
+    oauth_redirect_url="https://token.botframework.com/.auth/web/redirect",
+)
+"""Microsoft public (commercial) cloud."""
+
+US_GOV = CloudEnvironment(
+    login_endpoint="https://login.microsoftonline.us",
+    login_tenant="MicrosoftServices.onmicrosoft.us",
+    bot_scope="https://api.botframework.us/.default",
+    token_service_url="https://tokengcch.botframework.azure.us",
+    openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
+    token_issuer="https://api.botframework.us",
+    channel_service="https://botframework.azure.us",
+    oauth_redirect_url="https://tokengcch.botframework.azure.us/.auth/web/redirect",
+)
+"""US Government Community Cloud High (GCCH)."""
+
+US_GOV_DOD = CloudEnvironment(
+    login_endpoint="https://login.microsoftonline.us",
+    login_tenant="MicrosoftServices.onmicrosoft.us",
+    bot_scope="https://api.botframework.us/.default",
+    token_service_url="https://apiDoD.botframework.azure.us",
+    openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
+    token_issuer="https://api.botframework.us",
+    channel_service="https://botframework.azure.us",
+    oauth_redirect_url="https://apiDoD.botframework.azure.us/.auth/web/redirect",
+)
+"""US Government Department of Defense (DoD)."""
+
+CHINA = CloudEnvironment(
+    login_endpoint="https://login.partner.microsoftonline.cn",
+    login_tenant="microsoftservices.partner.onmschina.cn",
+    bot_scope="https://api.botframework.azure.cn/.default",
+    token_service_url="https://token.botframework.azure.cn",
+    openid_metadata_url="https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
+    token_issuer="https://api.botframework.azure.cn",
+    channel_service="https://botframework.azure.cn",
+    oauth_redirect_url="https://token.botframework.azure.cn/.auth/web/redirect",
+)
+"""China cloud (21Vianet)."""
+
+_CLOUD_ENVIRONMENTS: dict[str, CloudEnvironment] = {
+    "public": PUBLIC,
+    "usgov": US_GOV,
+    "usgovdod": US_GOV_DOD,
+    "china": CHINA,
+}
+
+
+def from_name(name: str) -> CloudEnvironment:
+    """
+    Resolve a cloud environment name (case-insensitive) to its corresponding instance.
+    Valid names: "Public", "USGov", "USGovDoD", "China".
+    """
+    env = _CLOUD_ENVIRONMENTS.get(name.lower())
+    if env is None:
+        raise ValueError(
+            f"Unknown cloud environment: '{name}'. Valid values are: Public, USGov, USGovDoD, China."
+        )
+    return env
+
+
+def with_overrides(base: CloudEnvironment, **overrides: Optional[str]) -> CloudEnvironment:
+    """
+    Create a new CloudEnvironment by applying non-None overrides on top of a base.
+    Returns the same instance if all overrides are None (no allocation).
+    """
+    filtered = {k: v for k, v in overrides.items() if v is not None}
+    if not filtered:
+        return base
+    return replace(base, **filtered)

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -31,6 +31,8 @@ class CloudEnvironment:
     """The channel service URL. Empty for public cloud; set for sovereign clouds."""
     oauth_redirect_url: str
     """The OAuth redirect URL (e.g. "https://token.botframework.com/.auth/web/redirect")."""
+    graph_scope: str
+    """The Microsoft Graph token scope (e.g. "https://graph.microsoft.com/.default")."""
 
 
 PUBLIC = CloudEnvironment(
@@ -42,6 +44,7 @@ PUBLIC = CloudEnvironment(
     token_issuer="https://api.botframework.com",
     channel_service="",
     oauth_redirect_url="https://token.botframework.com/.auth/web/redirect",
+    graph_scope="https://graph.microsoft.com/.default",
 )
 """Microsoft public (commercial) cloud."""
 
@@ -54,6 +57,7 @@ US_GOV = CloudEnvironment(
     token_issuer="https://api.botframework.us",
     channel_service="https://botframework.azure.us",
     oauth_redirect_url="https://tokengcch.botframework.azure.us/.auth/web/redirect",
+    graph_scope="https://graph.microsoft.us/.default",
 )
 """US Government Community Cloud High (GCCH)."""
 
@@ -66,6 +70,7 @@ US_GOV_DOD = CloudEnvironment(
     token_issuer="https://api.botframework.us",
     channel_service="https://botframework.azure.us",
     oauth_redirect_url="https://apiDoD.botframework.azure.us/.auth/web/redirect",
+    graph_scope="https://dod-graph.microsoft.us/.default",
 )
 """US Government Department of Defense (DoD)."""
 
@@ -78,6 +83,7 @@ CHINA = CloudEnvironment(
     token_issuer="https://api.botframework.azure.cn",
     channel_service="https://botframework.azure.cn",
     oauth_redirect_url="https://token.botframework.azure.cn/.auth/web/redirect",
+    graph_scope="https://microsoftgraph.chinacloudapi.cn/.default",
 )
 """China cloud (21Vianet)."""
 

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -27,10 +27,6 @@ class CloudEnvironment:
     """The OpenID metadata URL for token validation."""
     token_issuer: str
     """The token issuer for Bot Framework tokens (e.g. "https://api.botframework.com")."""
-    channel_service: str
-    """The channel service URL. Empty for public cloud; set for sovereign clouds."""
-    oauth_redirect_url: str
-    """The OAuth redirect URL (e.g. "https://token.botframework.com/.auth/web/redirect")."""
     graph_scope: str
     """The Microsoft Graph token scope (e.g. "https://graph.microsoft.com/.default")."""
 
@@ -42,8 +38,6 @@ PUBLIC = CloudEnvironment(
     token_service_url="https://token.botframework.com",
     openid_metadata_url="https://login.botframework.com/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.com",
-    channel_service="",
-    oauth_redirect_url="https://token.botframework.com/.auth/web/redirect",
     graph_scope="https://graph.microsoft.com/.default",
 )
 """Microsoft public (commercial) cloud."""
@@ -55,8 +49,6 @@ US_GOV = CloudEnvironment(
     token_service_url="https://tokengcch.botframework.azure.us",
     openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.us",
-    channel_service="https://botframework.azure.us",
-    oauth_redirect_url="https://tokengcch.botframework.azure.us/.auth/web/redirect",
     graph_scope="https://graph.microsoft.us/.default",
 )
 """US Government Community Cloud High (GCCH)."""
@@ -68,8 +60,6 @@ US_GOV_DOD = CloudEnvironment(
     token_service_url="https://apiDoD.botframework.azure.us",
     openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.us",
-    channel_service="https://botframework.azure.us",
-    oauth_redirect_url="https://apiDoD.botframework.azure.us/.auth/web/redirect",
     graph_scope="https://dod-graph.microsoft.us/.default",
 )
 """US Government Department of Defense (DoD)."""
@@ -81,8 +71,6 @@ CHINA = CloudEnvironment(
     token_service_url="https://token.botframework.azure.cn",
     openid_metadata_url="https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.azure.cn",
-    channel_service="https://botframework.azure.cn",
-    oauth_redirect_url="https://token.botframework.azure.cn/.auth/web/redirect",
     graph_scope="https://microsoftgraph.chinacloudapi.cn/.default",
 )
 """China cloud (21Vianet)."""

--- a/packages/api/src/microsoft_teams/api/clients/__init__.py
+++ b/packages/api/src/microsoft_teams/api/clients/__init__.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from . import bot, conversation, meeting, reaction, team, user
 from .api_client import ApiClient
-from .api_client_settings import DEFAULT_API_CLIENT_SETTINGS, ApiClientSettings, merge_api_client_settings
+from .api_client_settings import ApiClientSettings, merge_api_client_settings
 from .bot import *  # noqa: F403
 from .conversation import *  # noqa: F403
 from .meeting import *  # noqa: F403
@@ -17,7 +17,6 @@ from .user import *  # noqa: F403
 __all__: list[str] = [
     "ApiClient",
     "ApiClientSettings",
-    "DEFAULT_API_CLIENT_SETTINGS",
     "merge_api_client_settings",
 ]
 __all__.extend(bot.__all__)

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -3,7 +3,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
 
 from microsoft_teams.common import Client as HttpClient
 from microsoft_teams.common import ClientOptions
@@ -17,6 +19,9 @@ from .reaction import ReactionClient
 from .team import TeamClient
 from .user import UserClient
 
+if TYPE_CHECKING:
+    from ..auth.cloud_environment import CloudEnvironment
+
 
 class ApiClient(BaseClient):
     """Unified client for Microsoft Teams API operations."""
@@ -26,6 +31,7 @@ class ApiClient(BaseClient):
         service_url: str,
         options: Optional[Union[HttpClient, ClientOptions]] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        cloud: Optional[CloudEnvironment] = None,
     ) -> None:
         """Initialize the unified Teams API client.
 
@@ -33,12 +39,13 @@ class ApiClient(BaseClient):
             service_url: The Teams service URL for API calls.
             options: Either an HTTP client instance or client options. If None, a default client is created.
             api_client_settings: Optional API client settings.
+            cloud: Optional cloud environment for sovereign cloud support.
         """
         super().__init__(options, api_client_settings)
         self.service_url = service_url.rstrip("/")
 
         # Initialize all client types
-        self.bots = BotClient(self._http, self._api_client_settings)
+        self.bots = BotClient(self._http, self._api_client_settings, cloud=cloud)
         self.users = UserClient(self._http, self._api_client_settings)
         self.conversations = ConversationClient(self.service_url, self._http, self._api_client_settings)
         self.teams = TeamClient(self.service_url, self._http, self._api_client_settings)

--- a/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
@@ -3,14 +3,13 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from __future__ import annotations
-
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
-if TYPE_CHECKING:
-    from ..auth.cloud_environment import CloudEnvironment
+from ..auth.cloud_environment import PUBLIC, CloudEnvironment
+
+DEFAULT_OAUTH_URL = "https://token.botframework.com"
 
 
 @dataclass
@@ -25,35 +24,28 @@ class ApiClientSettings:
                    Default is https://token.botframework.com
     """
 
-    oauth_url: str = "https://token.botframework.com"
-
-
-DEFAULT_API_CLIENT_SETTINGS = ApiClientSettings()
+    oauth_url: str = DEFAULT_OAUTH_URL
 
 
 def merge_api_client_settings(
     api_client_settings: Optional[ApiClientSettings] = None,
-    cloud: Optional["CloudEnvironment"] = None,
+    cloud: CloudEnvironment = PUBLIC,
 ) -> ApiClientSettings:
     """
     Merge API client settings with environment variables and defaults.
 
     Args:
         api_client_settings: Optional API client settings to merge.
-        cloud: Optional cloud environment for default oauth_url.
+        cloud: Cloud environment for default oauth_url. Defaults to PUBLIC.
 
     Returns:
         Merged API client settings.
     """
-    if api_client_settings is None:
-        api_client_settings = ApiClientSettings()
-
-    # Check for environment variable override
     env_oauth_url = os.environ.get("OAUTH_URL")
-    default_oauth_url = cloud.token_service_url if cloud else DEFAULT_API_CLIENT_SETTINGS.oauth_url
+
+    if api_client_settings and api_client_settings.oauth_url != DEFAULT_OAUTH_URL:
+        return api_client_settings
 
     return ApiClientSettings(
-        oauth_url=api_client_settings.oauth_url
-        if api_client_settings.oauth_url != DEFAULT_API_CLIENT_SETTINGS.oauth_url
-        else (env_oauth_url or default_oauth_url)
+        oauth_url=env_oauth_url or cloud.token_service_url
     )

--- a/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
@@ -9,8 +9,6 @@ from typing import Optional
 
 from ..auth.cloud_environment import PUBLIC, CloudEnvironment
 
-DEFAULT_OAUTH_URL = "https://token.botframework.com"
-
 
 @dataclass
 class ApiClientSettings:
@@ -21,10 +19,10 @@ class ApiClientSettings:
         oauth_url: The URL to use for managing user OAuth tokens.
                    Specify this value if you are using a regional bot.
                    For example: https://europe.token.botframework.com
-                   Default is https://token.botframework.com
+                   Defaults to the cloud environment's token service URL.
     """
 
-    oauth_url: str = DEFAULT_OAUTH_URL
+    oauth_url: Optional[str] = None
 
 
 def merge_api_client_settings(
@@ -43,7 +41,7 @@ def merge_api_client_settings(
     """
     env_oauth_url = os.environ.get("OAUTH_URL")
 
-    if api_client_settings and api_client_settings.oauth_url != DEFAULT_OAUTH_URL:
+    if api_client_settings and api_client_settings.oauth_url:
         return api_client_settings
 
     return ApiClientSettings(

--- a/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
@@ -3,9 +3,14 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from __future__ import annotations
+
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ..auth.cloud_environment import CloudEnvironment
 
 
 @dataclass
@@ -26,12 +31,16 @@ class ApiClientSettings:
 DEFAULT_API_CLIENT_SETTINGS = ApiClientSettings()
 
 
-def merge_api_client_settings(api_client_settings: Optional[ApiClientSettings]) -> ApiClientSettings:
+def merge_api_client_settings(
+    api_client_settings: Optional[ApiClientSettings] = None,
+    cloud: Optional["CloudEnvironment"] = None,
+) -> ApiClientSettings:
     """
     Merge API client settings with environment variables and defaults.
 
     Args:
         api_client_settings: Optional API client settings to merge.
+        cloud: Optional cloud environment for default oauth_url.
 
     Returns:
         Merged API client settings.
@@ -41,5 +50,10 @@ def merge_api_client_settings(api_client_settings: Optional[ApiClientSettings]) 
 
     # Check for environment variable override
     env_oauth_url = os.environ.get("OAUTH_URL")
+    default_oauth_url = cloud.token_service_url if cloud else DEFAULT_API_CLIENT_SETTINGS.oauth_url
 
-    return ApiClientSettings(oauth_url=env_oauth_url if env_oauth_url else api_client_settings.oauth_url)
+    return ApiClientSettings(
+        oauth_url=api_client_settings.oauth_url
+        if api_client_settings.oauth_url != DEFAULT_API_CLIENT_SETTINGS.oauth_url
+        else (env_oauth_url or default_oauth_url)
+    )

--- a/packages/api/src/microsoft_teams/api/clients/bot/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/client.py
@@ -3,7 +3,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
 
 from microsoft_teams.common.http import Client, ClientOptions
 
@@ -11,6 +13,9 @@ from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 from .sign_in_client import BotSignInClient
 from .token_client import BotTokenClient
+
+if TYPE_CHECKING:
+    from ...auth.cloud_environment import CloudEnvironment
 
 
 class BotClient(BaseClient):
@@ -20,15 +25,17 @@ class BotClient(BaseClient):
         self,
         options: Optional[Union[Client, ClientOptions]] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        cloud: Optional[CloudEnvironment] = None,
     ) -> None:
         """Initialize the BotClient.
 
         Args:
             options: Optional Client or ClientOptions instance. If not provided, a default Client will be created.
             api_client_settings: Optional API client settings.
+            cloud: Optional cloud environment for sovereign cloud support.
         """
         super().__init__(options, api_client_settings)
-        self.token = BotTokenClient(self.http, self._api_client_settings)
+        self.token = BotTokenClient(self.http, self._api_client_settings, cloud=cloud)
         self.sign_in = BotSignInClient(self.http, self._api_client_settings)
 
     @property

--- a/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
@@ -3,16 +3,22 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from __future__ import annotations
+
 import inspect
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 from microsoft_teams.api.auth.credentials import ClientCredentials
 from microsoft_teams.common.http import Client, ClientOptions
 from pydantic import BaseModel
 
 from ...auth import Credentials, TokenCredentials
+from ...auth.cloud_environment import PUBLIC
 from ..api_client_settings import ApiClientSettings, merge_api_client_settings
 from ..base_client import BaseClient
+
+if TYPE_CHECKING:
+    from ...auth.cloud_environment import CloudEnvironment
 
 
 class GetBotTokenResponse(BaseModel):
@@ -44,15 +50,18 @@ class BotTokenClient(BaseClient):
         self,
         options: Union[Client, ClientOptions, None] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        cloud: Optional[CloudEnvironment] = None,
     ) -> None:
         """Initialize the bot token client.
 
         Args:
             options: Optional Client or ClientOptions instance.
             api_client_settings: Optional API client settings.
+            cloud: Optional cloud environment for sovereign cloud support.
         """
         super().__init__(options)
-        self._api_client_settings = merge_api_client_settings(api_client_settings)
+        self._cloud = cloud or PUBLIC
+        self._api_client_settings = merge_api_client_settings(api_client_settings, cloud)
 
     async def get(self, credentials: Credentials) -> GetBotTokenResponse:
         """Get a bot token.
@@ -65,7 +74,7 @@ class BotTokenClient(BaseClient):
         """
         if isinstance(credentials, TokenCredentials):
             token = credentials.token(
-                "https://api.botframework.com/.default",
+                self._cloud.bot_scope,
                 credentials.tenant_id,
             )
             if inspect.isawaitable(token):
@@ -81,14 +90,14 @@ class BotTokenClient(BaseClient):
             "Bot token client currently only supports Credentials with secrets."
         )
 
-        tenant_id = credentials.tenant_id or "botframework.com"
+        tenant_id = credentials.tenant_id or self._cloud.login_tenant
         res = await self.http.post(
-            f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+            f"{self._cloud.login_endpoint}/{tenant_id}/oauth2/v2.0/token",
             data={
                 "grant_type": "client_credentials",
                 "client_id": credentials.client_id,
                 "client_secret": credentials.client_secret,
-                "scope": "https://api.botframework.com/.default",
+                "scope": self._cloud.bot_scope,
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )
@@ -122,9 +131,9 @@ class BotTokenClient(BaseClient):
             "Bot token client currently only supports Credentials with secrets."
         )
 
-        tenant_id = credentials.tenant_id or "botframework.com"
+        tenant_id = credentials.tenant_id or self._cloud.login_tenant
         res = await self.http.post(
-            f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+            f"{self._cloud.login_endpoint}/{tenant_id}/oauth2/v2.0/token",
             data={
                 "grant_type": "client_credentials",
                 "client_id": credentials.client_id,

--- a/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
@@ -61,7 +61,7 @@ class BotTokenClient(BaseClient):
         """
         super().__init__(options)
         self._cloud = cloud or PUBLIC
-        self._api_client_settings = merge_api_client_settings(api_client_settings, cloud)
+        self._api_client_settings = merge_api_client_settings(api_client_settings, self._cloud)
 
     async def get(self, credentials: Credentials) -> GetBotTokenResponse:
         """Get a bot token.

--- a/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
@@ -115,7 +115,7 @@ class BotTokenClient(BaseClient):
         """
         if isinstance(credentials, TokenCredentials):
             token = credentials.token(
-                "https://graph.microsoft.com/.default",
+                self._cloud.graph_scope,
                 credentials.tenant_id,
             )
             if inspect.isawaitable(token):
@@ -138,7 +138,7 @@ class BotTokenClient(BaseClient):
                 "grant_type": "client_credentials",
                 "client_id": credentials.client_id,
                 "client_secret": credentials.client_secret,
-                "scope": "https://graph.microsoft.com/.default",
+                "scope": self._cloud.graph_scope,
             },
             headers={"Content-Type": "application/x-www-form-urlencoded"},
         )

--- a/packages/api/tests/unit/test_bot_client.py
+++ b/packages/api/tests/unit/test_bot_client.py
@@ -94,3 +94,27 @@ class TestBotClientRegionalEndpoints:
         response = await client.sign_in.get_resource(params)
         assert response.sign_in_link is not None
         assert response.sign_in_link.startswith("http")
+
+
+@pytest.mark.unit
+class TestBotClientSovereignCloud:
+    def test_bot_token_client_receives_cloud(self):
+        from microsoft_teams.api.auth.cloud_environment import US_GOV
+
+        client = BotClient(cloud=US_GOV)
+        assert client.token._cloud is US_GOV
+        assert client.token._cloud.bot_scope == "https://api.botframework.us/.default"
+        assert client.token._cloud.login_endpoint == "https://login.microsoftonline.us"
+
+    def test_bot_token_client_defaults_to_public(self):
+        from microsoft_teams.api.auth.cloud_environment import PUBLIC
+
+        client = BotClient()
+        assert client.token._cloud is PUBLIC
+
+    def test_api_client_passes_cloud_to_bot_client(self):
+        from microsoft_teams.api import ApiClient
+        from microsoft_teams.api.auth.cloud_environment import US_GOV
+
+        api = ApiClient("https://example.com", cloud=US_GOV)
+        assert api.bots.token._cloud is US_GOV

--- a/packages/api/tests/unit/test_cloud_environment.py
+++ b/packages/api/tests/unit/test_cloud_environment.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 import dataclasses
 
 import pytest
-
 from microsoft_teams.api.auth.cloud_environment import (
     CHINA,
     PUBLIC,

--- a/packages/api/tests/unit/test_cloud_environment.py
+++ b/packages/api/tests/unit/test_cloud_environment.py
@@ -1,0 +1,140 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import dataclasses
+
+import pytest
+
+from microsoft_teams.api.auth.cloud_environment import (
+    CHINA,
+    PUBLIC,
+    US_GOV,
+    US_GOV_DOD,
+    CloudEnvironment,
+    from_name,
+    with_overrides,
+)
+
+
+@pytest.mark.unit
+class TestCloudEnvironmentPresets:
+    def test_public_has_correct_endpoints(self):
+        assert PUBLIC.login_endpoint == "https://login.microsoftonline.com"
+        assert PUBLIC.login_tenant == "botframework.com"
+        assert PUBLIC.bot_scope == "https://api.botframework.com/.default"
+        assert PUBLIC.token_service_url == "https://token.botframework.com"
+        assert PUBLIC.openid_metadata_url == "https://login.botframework.com/v1/.well-known/openidconfiguration"
+        assert PUBLIC.token_issuer == "https://api.botframework.com"
+        assert PUBLIC.channel_service == ""
+        assert PUBLIC.oauth_redirect_url == "https://token.botframework.com/.auth/web/redirect"
+
+    def test_us_gov_has_correct_endpoints(self):
+        assert US_GOV.login_endpoint == "https://login.microsoftonline.us"
+        assert US_GOV.login_tenant == "MicrosoftServices.onmicrosoft.us"
+        assert US_GOV.bot_scope == "https://api.botframework.us/.default"
+        assert US_GOV.token_service_url == "https://tokengcch.botframework.azure.us"
+        assert US_GOV.openid_metadata_url == "https://login.botframework.azure.us/v1/.well-known/openidconfiguration"
+        assert US_GOV.token_issuer == "https://api.botframework.us"
+        assert US_GOV.channel_service == "https://botframework.azure.us"
+        assert US_GOV.oauth_redirect_url == "https://tokengcch.botframework.azure.us/.auth/web/redirect"
+
+    def test_us_gov_dod_has_correct_endpoints(self):
+        assert US_GOV_DOD.login_endpoint == "https://login.microsoftonline.us"
+        assert US_GOV_DOD.token_service_url == "https://apiDoD.botframework.azure.us"
+        assert US_GOV_DOD.token_issuer == "https://api.botframework.us"
+        assert US_GOV_DOD.channel_service == "https://botframework.azure.us"
+
+    def test_china_has_correct_endpoints(self):
+        assert CHINA.login_endpoint == "https://login.partner.microsoftonline.cn"
+        assert CHINA.login_tenant == "microsoftservices.partner.onmschina.cn"
+        assert CHINA.bot_scope == "https://api.botframework.azure.cn/.default"
+        assert CHINA.token_service_url == "https://token.botframework.azure.cn"
+        assert CHINA.token_issuer == "https://api.botframework.azure.cn"
+        assert CHINA.channel_service == "https://botframework.azure.cn"
+
+    def test_presets_are_frozen(self):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            PUBLIC.login_endpoint = "https://modified.example.com"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestFromName:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Public", PUBLIC),
+            ("public", PUBLIC),
+            ("PUBLIC", PUBLIC),
+            ("USGov", US_GOV),
+            ("usgov", US_GOV),
+            ("USGovDoD", US_GOV_DOD),
+            ("usgovdod", US_GOV_DOD),
+            ("China", CHINA),
+            ("china", CHINA),
+        ],
+    )
+    def test_resolves_correctly(self, name: str, expected: CloudEnvironment):
+        assert from_name(name) is expected
+
+    @pytest.mark.parametrize("name", ["invalid", "", "Azure"])
+    def test_raises_for_unknown_name(self, name: str):
+        with pytest.raises(ValueError, match="Unknown cloud environment"):
+            from_name(name)
+
+
+@pytest.mark.unit
+class TestWithOverrides:
+    def test_returns_same_instance_when_no_overrides(self):
+        result = with_overrides(PUBLIC)
+        assert result is PUBLIC
+
+    def test_returns_same_instance_when_all_none(self):
+        result = with_overrides(PUBLIC, login_endpoint=None, login_tenant=None)
+        assert result is PUBLIC
+
+    def test_replaces_single_property(self):
+        result = with_overrides(PUBLIC, login_tenant="my-tenant-id")
+        assert result is not PUBLIC
+        assert result.login_tenant == "my-tenant-id"
+        assert result.login_endpoint == PUBLIC.login_endpoint
+        assert result.bot_scope == PUBLIC.bot_scope
+
+    def test_replaces_multiple_properties(self):
+        result = with_overrides(
+            CHINA,
+            login_endpoint="https://custom.login.cn",
+            login_tenant="custom-tenant",
+            token_service_url="https://custom.token.cn",
+        )
+        assert result.login_endpoint == "https://custom.login.cn"
+        assert result.login_tenant == "custom-tenant"
+        assert result.token_service_url == "https://custom.token.cn"
+        assert result.bot_scope == CHINA.bot_scope
+
+    def test_replaces_all_properties(self):
+        result = with_overrides(
+            PUBLIC,
+            login_endpoint="a",
+            login_tenant="b",
+            bot_scope="c",
+            token_service_url="d",
+            openid_metadata_url="e",
+            token_issuer="f",
+            channel_service="g",
+            oauth_redirect_url="h",
+        )
+        assert result.login_endpoint == "a"
+        assert result.login_tenant == "b"
+        assert result.bot_scope == "c"
+        assert result.token_service_url == "d"
+        assert result.openid_metadata_url == "e"
+        assert result.token_issuer == "f"
+        assert result.channel_service == "g"
+        assert result.oauth_redirect_url == "h"
+
+    def test_result_is_frozen(self):
+        result = with_overrides(PUBLIC, login_tenant="test")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.login_tenant = "modified"  # type: ignore[misc]

--- a/packages/api/tests/unit/test_cloud_environment.py
+++ b/packages/api/tests/unit/test_cloud_environment.py
@@ -26,8 +26,6 @@ class TestCloudEnvironmentPresets:
         assert PUBLIC.token_service_url == "https://token.botframework.com"
         assert PUBLIC.openid_metadata_url == "https://login.botframework.com/v1/.well-known/openidconfiguration"
         assert PUBLIC.token_issuer == "https://api.botframework.com"
-        assert PUBLIC.channel_service == ""
-        assert PUBLIC.oauth_redirect_url == "https://token.botframework.com/.auth/web/redirect"
 
     def test_us_gov_has_correct_endpoints(self):
         assert US_GOV.login_endpoint == "https://login.microsoftonline.us"
@@ -36,14 +34,11 @@ class TestCloudEnvironmentPresets:
         assert US_GOV.token_service_url == "https://tokengcch.botframework.azure.us"
         assert US_GOV.openid_metadata_url == "https://login.botframework.azure.us/v1/.well-known/openidconfiguration"
         assert US_GOV.token_issuer == "https://api.botframework.us"
-        assert US_GOV.channel_service == "https://botframework.azure.us"
-        assert US_GOV.oauth_redirect_url == "https://tokengcch.botframework.azure.us/.auth/web/redirect"
 
     def test_us_gov_dod_has_correct_endpoints(self):
         assert US_GOV_DOD.login_endpoint == "https://login.microsoftonline.us"
         assert US_GOV_DOD.token_service_url == "https://apiDoD.botframework.azure.us"
         assert US_GOV_DOD.token_issuer == "https://api.botframework.us"
-        assert US_GOV_DOD.channel_service == "https://botframework.azure.us"
 
     def test_china_has_correct_endpoints(self):
         assert CHINA.login_endpoint == "https://login.partner.microsoftonline.cn"
@@ -51,7 +46,6 @@ class TestCloudEnvironmentPresets:
         assert CHINA.bot_scope == "https://api.botframework.azure.cn/.default"
         assert CHINA.token_service_url == "https://token.botframework.azure.cn"
         assert CHINA.token_issuer == "https://api.botframework.azure.cn"
-        assert CHINA.channel_service == "https://botframework.azure.cn"
 
     def test_presets_are_frozen(self):
         with pytest.raises(dataclasses.FrozenInstanceError):
@@ -121,8 +115,6 @@ class TestWithOverrides:
             token_service_url="d",
             openid_metadata_url="e",
             token_issuer="f",
-            channel_service="g",
-            oauth_redirect_url="h",
         )
         assert result.login_endpoint == "a"
         assert result.login_tenant == "b"
@@ -130,8 +122,6 @@ class TestWithOverrides:
         assert result.token_service_url == "d"
         assert result.openid_metadata_url == "e"
         assert result.token_issuer == "f"
-        assert result.channel_service == "g"
-        assert result.oauth_redirect_url == "h"
 
     def test_result_is_frozen(self):
         result = with_overrides(PUBLIC, login_tenant="test")

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -37,6 +37,8 @@ from .app_events import EventManager
 from .app_oauth import OauthHandlers
 from .app_plugins import PluginProcessor
 from .app_process import ActivityProcessor
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, from_name as cloud_from_name
+
 from .auth import TokenValidator
 from .auth.remote_function_jwt_middleware import validate_remote_function_request
 from .container import Container
@@ -79,6 +81,10 @@ class App(ActivityHandlerMixin):
     def __init__(self, **options: Unpack[AppOptions]):
         self.options = InternalAppOptions.from_typeddict(options)
 
+        # Resolve cloud environment from options or CLOUD env var
+        cloud_env_name = os.getenv("CLOUD")
+        self.cloud = self.options.cloud or (cloud_from_name(cloud_env_name) if cloud_env_name else PUBLIC)
+
         self.storage = self.options.storage or LocalStorage()
 
         self.http_client = Client(
@@ -94,6 +100,7 @@ class App(ActivityHandlerMixin):
 
         self._token_manager = TokenManager(
             credentials=self.credentials,
+            cloud=self.cloud,
         )
 
         self.container = Container()
@@ -159,6 +166,7 @@ class App(ActivityHandlerMixin):
                 self.credentials.client_id,
                 self.credentials.tenant_id,
                 application_id_uri=self.options.application_id_uri,
+                cloud=self.cloud,
             )
 
     @property
@@ -203,7 +211,7 @@ class App(ActivityHandlerMixin):
 
             # Initialize HttpServer (JWT validation + messaging endpoint route)
             self.server.on_request = self._process_activity_event
-            self.server.initialize(credentials=self.credentials, skip_auth=self.options.skip_auth)
+            self.server.initialize(credentials=self.credentials, skip_auth=self.options.skip_auth, cloud=self.cloud)
 
             self._initialized = True
             logger.info("Teams app initialized successfully")

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -26,6 +26,8 @@ from microsoft_teams.api import (
     TokenCredentials,
     TokenProtocol,
 )
+from microsoft_teams.api.auth.cloud_environment import PUBLIC
+from microsoft_teams.api.auth.cloud_environment import from_name as cloud_from_name
 from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Client, ClientOptions, EventEmitter, LocalStorage
 
@@ -37,8 +39,6 @@ from .app_events import EventManager
 from .app_oauth import OauthHandlers
 from .app_plugins import PluginProcessor
 from .app_process import ActivityProcessor
-from microsoft_teams.api.auth.cloud_environment import PUBLIC, from_name as cloud_from_name
-
 from .auth import TokenValidator
 from .auth.remote_function_jwt_middleware import validate_remote_function_request
 from .container import Container

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -118,6 +118,7 @@ class App(ActivityHandlerMixin):
             service_url,
             self.http_client.clone(ClientOptions(token=self._get_bot_token)),
             self.options.api_client_settings,
+            cloud=self.cloud,
         )
 
         plugins: List[PluginBase] = list(self.options.plugins)

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -3,11 +3,15 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from __future__ import annotations
+
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import jwt
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 
 JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
 
@@ -53,19 +57,28 @@ class TokenValidator:
 
     # ----- Factory constructors -----
     @classmethod
-    def for_service(cls, app_id: str, service_url: Optional[str] = None) -> "TokenValidator":
+    def for_service(
+        cls,
+        app_id: str,
+        service_url: Optional[str] = None,
+        cloud: Optional[CloudEnvironment] = None,
+    ) -> TokenValidator:
         """Create a validator for Bot Framework service tokens.
 
         Reference: https://learn.microsoft.com/en-us/azure/bot-service/rest-api/bot-framework-rest-connector-authentication
 
         Args:
             app_id: The bot's Microsoft App ID (used for audience validation)
-            service_url: Optional service URL to validate against token claims"""
+            service_url: Optional service URL to validate against token claims
+            cloud: Optional cloud environment for sovereign cloud support
+        """
+        env = cloud or PUBLIC
+        jwks_keys_uri = re.sub(r"/openidconfiguration$", "/keys", env.openid_metadata_url)
 
         options = JwtValidationOptions(
-            valid_issuers=["https://api.botframework.com"],
+            valid_issuers=[env.token_issuer],
             valid_audiences=cls._default_audiences(app_id),
-            jwks_uri="https://login.botframework.com/v1/.well-known/keys",
+            jwks_uri=jwks_keys_uri,
             service_url=service_url,
         )
         return cls(options)
@@ -77,7 +90,8 @@ class TokenValidator:
         tenant_id: Optional[str],
         scope: Optional[str] = None,
         application_id_uri: Optional[str] = None,
-    ) -> "TokenValidator":
+        cloud: Optional[CloudEnvironment] = None,
+    ) -> TokenValidator:
         """Create a validator for Entra ID tokens.
 
         Args:
@@ -86,12 +100,12 @@ class TokenValidator:
             scope: Optional scope that must be present in the token
             application_id_uri: Optional Application ID URI from Azure portal.
                 Matches webApplicationInfo.resource in the app manifest.
-
+            cloud: Optional cloud environment for sovereign cloud support
         """
-
+        env = cloud or PUBLIC
         valid_issuers: List[str] = []
         if tenant_id:
-            valid_issuers.append(f"https://login.microsoftonline.com/{tenant_id}/v2.0")
+            valid_issuers.append(f"{env.login_endpoint}/{tenant_id}/v2.0")
         tenant_id = tenant_id or "common"
         valid_audiences = cls._default_audiences(app_id)
         if application_id_uri:
@@ -99,7 +113,7 @@ class TokenValidator:
         options = JwtValidationOptions(
             valid_issuers=valid_issuers,
             valid_audiences=valid_audiences,
-            jwks_uri=f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys",
+            jwks_uri=f"{env.login_endpoint}/{tenant_id}/discovery/v2.0/keys",
             scope=scope,
         )
         return cls(options)

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -8,10 +8,9 @@ from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, Optional, cast
 
 from microsoft_teams.api import Credentials, InvokeResponse, TokenProtocol
+from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 from microsoft_teams.api.auth.json_web_token import JsonWebToken
 from pydantic import BaseModel
-
-from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 
 from ..auth import TokenValidator
 from ..events import ActivityEvent, CoreActivity

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -11,6 +11,8 @@ from microsoft_teams.api import Credentials, InvokeResponse, TokenProtocol
 from microsoft_teams.api.auth.json_web_token import JsonWebToken
 from pydantic import BaseModel
 
+from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
+
 from ..auth import TokenValidator
 from ..events import ActivityEvent, CoreActivity
 from .adapter import HttpRequest, HttpResponse, HttpServerAdapter
@@ -60,6 +62,7 @@ class HttpServer:
         self,
         credentials: Optional[Credentials] = None,
         skip_auth: bool = False,
+        cloud: Optional[CloudEnvironment] = None,
     ) -> None:
         """
         Set up JWT validation and register the messaging endpoint route.
@@ -67,6 +70,7 @@ class HttpServer:
         Args:
             credentials: App credentials for JWT validation.
             skip_auth: Whether to skip JWT validation.
+            cloud: Optional cloud environment for sovereign cloud support.
         """
         if self._initialized:
             return
@@ -75,7 +79,7 @@ class HttpServer:
 
         app_id = getattr(credentials, "client_id", None) if credentials else None
         if app_id and not skip_auth:
-            self._token_validator = TokenValidator.for_service(app_id)
+            self._token_validator = TokenValidator.for_service(app_id, cloud=cloud)
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
 
         self._adapter.register_route("POST", self._messaging_endpoint, self.handle_request)

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, List, Optional, TypedDict, Union, cast
 
 from microsoft_teams.api import ApiClientSettings
+from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 from microsoft_teams.common import Storage
 from typing_extensions import Unpack
 
@@ -69,6 +70,15 @@ class AppOptions(TypedDict, total=False):
     and defaults to https://smba.trafficmanager.net/teams
     """
 
+    # Cloud environment
+    cloud: Optional[CloudEnvironment]
+    """
+    Cloud environment for sovereign cloud support.
+    Accepts a CloudEnvironment instance or uses CLOUD environment variable.
+    Valid env var values: "Public", "USGov", "USGovDoD", "China".
+    Defaults to PUBLIC (commercial cloud).
+    """
+
 
 @dataclass
 class InternalAppOptions:
@@ -112,6 +122,8 @@ class InternalAppOptions:
     """Custom HTTP server adapter. Defaults to FastAPIAdapter if not provided."""
     messaging_endpoint: str = "/api/messages"
     """URL path for the Teams messaging endpoint. Defaults to '/api/messages'."""
+    cloud: Optional[CloudEnvironment] = None
+    """Cloud environment for sovereign cloud support."""
 
     @classmethod
     def from_typeddict(cls, options: AppOptions) -> "InternalAppOptions":

--- a/packages/apps/src/microsoft_teams/apps/token_manager.py
+++ b/packages/apps/src/microsoft_teams/apps/token_manager.py
@@ -15,6 +15,7 @@ from microsoft_teams.api import (
     JsonWebToken,
     TokenProtocol,
 )
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 from microsoft_teams.api.auth.credentials import (
     FederatedIdentityCredentials,
     ManagedIdentityCredentials,
@@ -27,11 +28,8 @@ from msal import (
     UserAssignedManagedIdentity,
 )
 
-BOT_TOKEN_SCOPE = "https://api.botframework.com/.default"
 GRAPH_TOKEN_SCOPE = "https://graph.microsoft.com/.default"
-DEFAULT_TENANT_FOR_BOT_TOKEN = "botframework.com"
 DEFAULT_TENANT_FOR_GRAPH_TOKEN = "common"
-DEFAULT_TOKEN_AUTHORITY = "https://login.microsoftonline.com/{tenant_id}"
 
 logger = logging.getLogger(__name__)
 
@@ -42,15 +40,17 @@ class TokenManager:
     def __init__(
         self,
         credentials: Optional[Credentials],
+        cloud: Optional[CloudEnvironment] = None,
     ):
         self._credentials = credentials
+        self._cloud = cloud or PUBLIC
         self._confidential_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
         self._managed_identity_client: Optional[ManagedIdentityClient] = None
 
     async def get_bot_token(self) -> Optional[TokenProtocol]:
         """Refresh the bot authentication token."""
         return await self._get_token(
-            BOT_TOKEN_SCOPE, tenant_id=self._resolve_tenant_id(None, DEFAULT_TENANT_FOR_BOT_TOKEN)
+            self._cloud.bot_scope, tenant_id=self._resolve_tenant_id(None, self._cloud.login_tenant)
         )
 
     async def get_graph_token(self, tenant_id: Optional[str] = None) -> Optional[TokenProtocol]:
@@ -134,7 +134,7 @@ class TokenManager:
         confidential_client = ConfidentialClientApplication(
             credentials.client_id,
             client_credential={"client_assertion": mi_token},
-            authority=DEFAULT_TOKEN_AUTHORITY.format(tenant_id=tenant_id),
+            authority=f"{self._cloud.login_endpoint}/{tenant_id}",
         )
 
         token_res: dict[str, Any] = await asyncio.to_thread(
@@ -205,7 +205,7 @@ class TokenManager:
         client: ConfidentialClientApplication = ConfidentialClientApplication(
             credentials.client_id,
             client_credential=credentials.client_secret,
-            authority=f"https://login.microsoftonline.com/{tenant_id}",
+            authority=f"{self._cloud.login_endpoint}/{tenant_id}",
         )
         self._confidential_clients_by_tenant[tenant_id] = client
         return client

--- a/packages/apps/src/microsoft_teams/apps/token_manager.py
+++ b/packages/apps/src/microsoft_teams/apps/token_manager.py
@@ -28,7 +28,6 @@ from msal import (
     UserAssignedManagedIdentity,
 )
 
-GRAPH_TOKEN_SCOPE = "https://graph.microsoft.com/.default"
 DEFAULT_TENANT_FOR_GRAPH_TOKEN = "common"
 
 logger = logging.getLogger(__name__)
@@ -65,7 +64,7 @@ class TokenManager:
             The graph token or None if not available
         """
         return await self._get_token(
-            GRAPH_TOKEN_SCOPE, tenant_id=self._resolve_tenant_id(tenant_id, DEFAULT_TENANT_FOR_GRAPH_TOKEN)
+            self._cloud.graph_scope, tenant_id=self._resolve_tenant_id(tenant_id, DEFAULT_TENANT_FOR_GRAPH_TOKEN)
         )
 
     async def _get_token(


### PR DESCRIPTION
## Summary
- Introduces `CloudEnvironment` frozen dataclass with predefined presets (`PUBLIC`, `US_GOV`, `US_GOV_DOD`, `CHINA`) bundling all cloud-specific service endpoints
- Threads cloud environment through `App`, `TokenManager`, `BotTokenClient`, `TokenValidator`, `ApiClient`, and `ApiClientSettings`
- Supports `CLOUD` environment variable and programmatic `AppOptions.cloud` configuration
- Adds `graph_scope` to `CloudEnvironment` for cloud-aware Microsoft Graph token acquisition
- Simplifies `merge_api_client_settings` with `cloud` default to `PUBLIC`, removes `DEFAULT_API_CLIENT_SETTINGS`
- Fixes cloud propagation through `ApiClient` -> `BotClient` -> `BotTokenClient`

### Note
`graph_base_url` (Graph API endpoint per cloud) is intentionally deferred. This PR focuses on auth/token acquisition. Graph API routing is a separate concern.

### Sources
- Bot Framework GCCH/DoD endpoints: https://learn.microsoft.com/en-us/azure/bot-service/how-to-deploy-gov-cloud-high
- Bot Framework China endpoints: https://learn.microsoft.com/en-us/azure/bot-service/how-to-deploy-china-cloud
- Graph national cloud deployments: https://learn.microsoft.com/en-us/graph/deployments

## Test plan
- [x] `pytest packages/api/tests/` -- 168 tests pass
- [x] `pytest packages/apps/tests/` -- 389 tests pass (1 pre-existing failure unrelated)
- [x] E2E: Echo bot with `CLOUD=USGov` against real GCCH tenant -- message received, echo reply sent
- [x] Copilot review feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)