### PR TITLE
Reject unauthenticated when no credentials

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -138,12 +138,9 @@ class HttpServer:
                     ),
                 )
             elif not self._token_validator:
-                # No credentials configured — reject the request
-                logger.error(
-                    "No credentials configured. Configure client authentication "
-                    "to securely receive messages, or set skip_auth=True to allow "
-                    "unauthenticated requests."
-                )
+                # No credentials configured: reject the request. A startup
+                # warning was already emitted; logging per request would
+                # just add noise without new information.
                 return HttpResponse(status=401, body={"error": "Authentication not configured"})
             else:
                 if not authorization.startswith("Bearer "):
@@ -169,7 +166,7 @@ class HttpServer:
             core_activity = CoreActivity.model_validate(body)
             activity_type = core_activity.type or "unknown"
             activity_id = core_activity.id or "unknown"
-            logger.debug(f"Received activity: {activity_type} (ID: {activity_id})")
+            logger.debug("Received activity: %s (ID: %s)", activity_type, activity_id)
 
             # Process the activity via the App callback
             result = await self._process_activity(core_activity, token)

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -79,7 +79,7 @@ class HttpServer:
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
         elif not skip_auth:
             logger.warning(
-                "No credentials configured and skipAuth is not enabled. "
+                "No credentials configured and skip_auth is not enabled. "
                 "All incoming requests will be rejected. Configure client authentication "
                 "to securely receive messages, or set skip_auth=True for local development."
             )

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -94,10 +94,16 @@ class HttpServer:
                 cloud=self._cloud,
             )
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
-        elif not app_id:
+        elif not app_id and not skip_auth:
             logger.warning(
-                "No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). "
-                "Bot will accept unauthenticated requests on %s.",
+                "No credentials configured and skip_auth is not enabled. "
+                "All incoming requests will be rejected. Configure client authentication "
+                "to securely receive messages, or set skip_auth=True for local development."
+            )
+        elif not app_id and skip_auth:
+            logger.warning(
+                "No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID), "
+                "but skip_auth is enabled. Bot will accept unauthenticated requests on %s.",
                 self._messaging_endpoint,
             )
 
@@ -116,7 +122,30 @@ class HttpServer:
             # Validate JWT token
             authorization = headers.get("authorization") or headers.get("Authorization") or ""
 
-            if self._token_validator and not self._skip_auth:
+            if self._skip_auth:
+                # Auth explicitly skipped — use a default token
+                service_url = cast(Optional[str], body.get("serviceUrl"))
+                token: TokenProtocol = cast(
+                    TokenProtocol,
+                    SimpleNamespace(
+                        app_id="",
+                        app_display_name="",
+                        tenant_id="",
+                        service_url=service_url or "",
+                        from_="azure",
+                        from_id="",
+                        is_expired=lambda: False,
+                    ),
+                )
+            elif not self._token_validator:
+                # No credentials configured — reject the request
+                logger.error(
+                    "No credentials configured. Configure client authentication "
+                    "to securely receive messages, or set skip_auth=True to allow "
+                    "unauthenticated requests."
+                )
+                return HttpResponse(status=401, body={"error": "Authentication not configured"})
+            else:
                 if not authorization.startswith("Bearer "):
                     logger.warning(
                         "inbound activity rejected (type=%s, id=%s): missing or malformed "
@@ -135,22 +164,7 @@ class HttpServer:
                     logger.warning(f"JWT token validation failed: {e}")
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 
-                token: TokenProtocol = cast(TokenProtocol, JsonWebToken(value=raw_token))
-            else:
-                # No auth — use a default token
-                service_url = cast(Optional[str], body.get("serviceUrl"))
-                token = cast(
-                    TokenProtocol,
-                    SimpleNamespace(
-                        app_id="",
-                        app_display_name="",
-                        tenant_id="",
-                        service_url=service_url or "",
-                        from_="azure",
-                        from_id="",
-                        is_expired=lambda: False,
-                    ),
-                )
+                token = cast(TokenProtocol, JsonWebToken(value=raw_token))
 
             core_activity = CoreActivity.model_validate(body)
             activity_type = core_activity.type or "unknown"

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -161,7 +161,7 @@ class HttpServer:
                 try:
                     await self._token_validator.validate_token(raw_token, service_url)
                 except Exception as e:
-                    logger.warning(f"JWT token validation failed: {e}")
+                    logger.warning("JWT token validation failed: %s", e)
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 
                 token = cast(TokenProtocol, JsonWebToken(value=raw_token))

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -129,7 +129,7 @@ class HttpServer:
                 try:
                     await self._token_validator.validate_token(raw_token, service_url)
                 except Exception as e:
-                    logger.warning(f"JWT token validation failed: {e}")
+                    logger.warning("JWT token validation failed: %s", e)
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 
                 token = cast(TokenProtocol, JsonWebToken(value=raw_token))

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -77,6 +77,12 @@ class HttpServer:
         if app_id and not skip_auth:
             self._token_validator = TokenValidator.for_service(app_id)
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
+        elif not skip_auth:
+            logger.warning(
+                "No credentials configured and skipAuth is not enabled. "
+                "All incoming requests will be rejected. Configure client authentication "
+                "to securely receive messages, or set skip_auth=True for local development."
+            )
 
         self._adapter.register_route("POST", self._messaging_endpoint, self.handle_request)
         self._initialized = True
@@ -90,7 +96,30 @@ class HttpServer:
             # Validate JWT token
             authorization = headers.get("authorization") or headers.get("Authorization") or ""
 
-            if self._token_validator and not self._skip_auth:
+            if self._skip_auth:
+                # Auth explicitly skipped — use a default token
+                service_url = cast(Optional[str], body.get("serviceUrl"))
+                token: TokenProtocol = cast(
+                    TokenProtocol,
+                    SimpleNamespace(
+                        app_id="",
+                        app_display_name="",
+                        tenant_id="",
+                        service_url=service_url or "",
+                        from_="azure",
+                        from_id="",
+                        is_expired=lambda: False,
+                    ),
+                )
+            elif not self._token_validator:
+                # No credentials configured — reject the request
+                logger.error(
+                    "No credentials configured. Configure client authentication "
+                    "to securely receive messages, or set skip_auth=True to allow "
+                    "unauthenticated requests."
+                )
+                return HttpResponse(status=401, body={"error": "Authentication not configured"})
+            else:
                 if not authorization.startswith("Bearer "):
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 
@@ -103,22 +132,7 @@ class HttpServer:
                     logger.warning(f"JWT token validation failed: {e}")
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 
-                token: TokenProtocol = cast(TokenProtocol, JsonWebToken(value=raw_token))
-            else:
-                # No auth — use a default token
-                service_url = cast(Optional[str], body.get("serviceUrl"))
-                token = cast(
-                    TokenProtocol,
-                    SimpleNamespace(
-                        app_id="",
-                        app_display_name="",
-                        tenant_id="",
-                        service_url=service_url or "",
-                        from_="azure",
-                        from_id="",
-                        is_expired=lambda: False,
-                    ),
-                )
+                token = cast(TokenProtocol, JsonWebToken(value=raw_token))
 
             core_activity = CoreActivity.model_validate(body)
             activity_type = core_activity.type or "unknown"

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -131,6 +131,64 @@ class TestHttpServer:
         assert result["status"] == 500
 
 
+class TestHttpServerNoCredentials:
+    """Test cases for HttpServer when no credentials are configured and skipAuth is not set."""
+
+    @pytest.fixture
+    def mock_adapter(self):
+        adapter = MagicMock()
+        adapter.register_route = MagicMock()
+        adapter.start = AsyncMock()
+        adapter.stop = AsyncMock()
+        return adapter
+
+    @pytest.fixture
+    def server(self, mock_adapter):
+        server = HttpServer(mock_adapter)
+        server.initialize(credentials=None, skip_auth=False)
+        return server
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_when_no_credentials(self, server):
+        """Test that requests are rejected with 401 when no credentials are configured."""
+        server.on_request = AsyncMock(return_value=InvokeResponse(status=200))
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "serviceUrl": "https://attacker.com",
+            },
+            headers={},
+        )
+
+        result = await server.handle_request(request)
+
+        assert result["status"] == 401
+        assert result["body"] == {"error": "Authentication not configured"}
+        server.on_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_with_auth_header_when_no_credentials(self, server):
+        """Test that even requests with auth headers are rejected when no credentials are configured."""
+        server.on_request = AsyncMock(return_value=InvokeResponse(status=200))
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "serviceUrl": "https://example.com",
+            },
+            headers={"authorization": "Bearer some-token"},
+        )
+
+        result = await server.handle_request(request)
+
+        assert result["status"] == 401
+        assert result["body"] == {"error": "Authentication not configured"}
+        server.on_request.assert_not_called()
+
+
 class TestFastAPIAdapter:
     """Test cases for FastAPIAdapter."""
 
@@ -145,7 +203,7 @@ class TestFastAPIAdapter:
         """Test route registration on FastAPI app."""
         adapter = FastAPIAdapter()
 
-        async def handler(req: HttpRequest) -> HttpResponse:
+        async def handler(request: HttpRequest) -> HttpResponse:
             return HttpResponse(status=200, body=None)
 
         adapter.register_route("POST", "/test", handler)

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -200,7 +200,7 @@ class TestHttpServer:
 
 
 class TestHttpServerNoCredentials:
-    """Test cases for HttpServer when no credentials are configured and skipAuth is not set."""
+    """Test cases for HttpServer when no credentials are configured and skip_auth is not set."""
 
     @pytest.fixture
     def mock_adapter(self):

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -199,6 +199,64 @@ class TestHttpServer:
         assert result["status"] == 401
 
 
+class TestHttpServerNoCredentials:
+    """Test cases for HttpServer when no credentials are configured and skipAuth is not set."""
+
+    @pytest.fixture
+    def mock_adapter(self):
+        adapter = MagicMock()
+        adapter.register_route = MagicMock()
+        adapter.start = AsyncMock()
+        adapter.stop = AsyncMock()
+        return adapter
+
+    @pytest.fixture
+    def server(self, mock_adapter):
+        server = HttpServer(mock_adapter)
+        server.initialize(credentials=None, skip_auth=False)
+        return server
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_when_no_credentials(self, server):
+        """Test that requests are rejected with 401 when no credentials are configured."""
+        server.on_request = AsyncMock(return_value=InvokeResponse(status=200))
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "serviceUrl": "https://attacker.com",
+            },
+            headers={},
+        )
+
+        result = await server.handle_request(request)
+
+        assert result["status"] == 401
+        assert result["body"] == {"error": "Authentication not configured"}
+        server.on_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_request_with_auth_header_when_no_credentials(self, server):
+        """Test that even requests with auth headers are rejected when no credentials are configured."""
+        server.on_request = AsyncMock(return_value=InvokeResponse(status=200))
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "serviceUrl": "https://example.com",
+            },
+            headers={"authorization": "Bearer some-token"},
+        )
+
+        result = await server.handle_request(request)
+
+        assert result["status"] == 401
+        assert result["body"] == {"error": "Authentication not configured"}
+        server.on_request.assert_not_called()
+
+
 class TestFastAPIAdapter:
     """Test cases for FastAPIAdapter."""
 
@@ -213,7 +271,7 @@ class TestFastAPIAdapter:
         """Test route registration on FastAPI app."""
         adapter = FastAPIAdapter()
 
-        async def handler(req: HttpRequest) -> HttpResponse:
+        async def handler(request: HttpRequest) -> HttpResponse:
             return HttpResponse(status=200, body=None)
 
         adapter.register_route("POST", "/test", handler)

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -132,7 +132,7 @@ class TestHttpServer:
 
 
 class TestHttpServerNoCredentials:
-    """Test cases for HttpServer when no credentials are configured and skipAuth is not set."""
+    """Test cases for HttpServer when no credentials are configured and skip_auth is not set."""
 
     @pytest.fixture
     def mock_adapter(self):


### PR DESCRIPTION
If a server is set up without any credentials, it currently will not be able to _send_ messages, but it _will_ currently accept all incoming requests.
This scenario is rare, but possible, and in this PR we reject any incoming requests if creds are not setup (and if `skip_auth` isn't explicitly set to `True`).