### PR TITLE
Security hardening: token validation and service URL improvements

### DIFF
--- a/examples/cards/src/main.py
+++ b/examples/cards/src/main.py
@@ -151,9 +151,7 @@ def create_profile_card_input_validation() -> AdaptiveCard:
             TextInput(id="location").with_label("Location"),
             ActionSet(
                 actions=[
-                    ExecuteAction(title="Save")
-                    .with_data(SubmitData("save_profile"))
-                    .with_associated_inputs("auto")
+                    ExecuteAction(title="Save").with_data(SubmitData("save_profile")).with_associated_inputs("auto")
                 ]
             ),
         ],

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -41,7 +41,11 @@ PUBLIC = CloudEnvironment(
     openid_metadata_url="https://login.botframework.com/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.com",
     graph_scope="https://graph.microsoft.com/.default",
-    allowed_service_urls=("smba.trafficmanager.net", "smba.onyx.prod.teams.trafficmanager.net", "smba.infra.gcc.teams.microsoft.com"),
+    allowed_service_urls=(
+        "smba.trafficmanager.net",
+        "smba.onyx.prod.teams.trafficmanager.net",
+        "smba.infra.gcc.teams.microsoft.com",
+    ),
 )
 """Microsoft public (commercial) cloud."""
 
@@ -96,9 +100,7 @@ def from_name(name: str) -> CloudEnvironment:
     """
     env = _CLOUD_ENVIRONMENTS.get(name.lower())
     if env is None:
-        raise ValueError(
-            f"Unknown cloud environment: '{name}'. Valid values are: Public, USGov, USGovDoD, China."
-        )
+        raise ValueError(f"Unknown cloud environment: '{name}'. Valid values are: Public, USGov, USGovDoD, China.")
     return env
 
 

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -29,6 +29,8 @@ class CloudEnvironment:
     """The token issuer for Bot Framework tokens (e.g. "https://api.botframework.com")."""
     graph_scope: str
     """The Microsoft Graph token scope (e.g. "https://graph.microsoft.com/.default")."""
+    allowed_service_urls: tuple[str, ...] = ()
+    """Allowed service URL hostnames for this cloud environment."""
 
 
 PUBLIC = CloudEnvironment(
@@ -39,6 +41,7 @@ PUBLIC = CloudEnvironment(
     openid_metadata_url="https://login.botframework.com/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.com",
     graph_scope="https://graph.microsoft.com/.default",
+    allowed_service_urls=("smba.trafficmanager.net", "smba.onyx.prod.teams.trafficmanager.net"),
 )
 """Microsoft public (commercial) cloud."""
 
@@ -50,6 +53,7 @@ US_GOV = CloudEnvironment(
     openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.us",
     graph_scope="https://graph.microsoft.us/.default",
+    allowed_service_urls=("smba.infra.gov.teams.microsoft.us",),
 )
 """US Government Community Cloud High (GCCH)."""
 
@@ -61,6 +65,7 @@ US_GOV_DOD = CloudEnvironment(
     openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.us",
     graph_scope="https://dod-graph.microsoft.us/.default",
+    allowed_service_urls=("smba.infra.dod.teams.microsoft.us",),
 )
 """US Government Department of Defense (DoD)."""
 
@@ -72,6 +77,7 @@ CHINA = CloudEnvironment(
     openid_metadata_url="https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.azure.cn",
     graph_scope="https://microsoftgraph.chinacloudapi.cn/.default",
+    allowed_service_urls=("frontend.botapi.msg.infra.teams.microsoftonline.cn",),
 )
 """China cloud (21Vianet)."""
 

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -41,7 +41,7 @@ PUBLIC = CloudEnvironment(
     openid_metadata_url="https://login.botframework.com/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.com",
     graph_scope="https://graph.microsoft.com/.default",
-    allowed_service_urls=("smba.trafficmanager.net", "smba.onyx.prod.teams.trafficmanager.net"),
+    allowed_service_urls=("smba.trafficmanager.net", "smba.onyx.prod.teams.trafficmanager.net", "smba.infra.gcc.teams.microsoft.com"),
 )
 """Microsoft public (commercial) cloud."""
 

--- a/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client_settings.py
@@ -44,6 +44,4 @@ def merge_api_client_settings(
     if api_client_settings and api_client_settings.oauth_url:
         return api_client_settings
 
-    return ApiClientSettings(
-        oauth_url=env_oauth_url or cloud.token_service_url
-    )
+    return ApiClientSettings(oauth_url=env_oauth_url or cloud.token_service_url)

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -214,7 +214,12 @@ class App(ActivityHandlerMixin):
 
             # Initialize HttpServer (JWT validation + messaging endpoint route)
             self.server.on_request = self._process_activity_event
-            self.server.initialize(credentials=self.credentials, skip_auth=self.options.skip_auth, cloud=self.cloud)
+            self.server.initialize(
+                credentials=self.credentials,
+                skip_auth=self.options.skip_auth,
+                additional_allowed_domains=self.options.additional_allowed_domains,
+                cloud=self.cloud,
+            )
 
             self._initialized = True
             logger.info("Teams app initialized successfully")

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -202,8 +202,8 @@ class TokenValidator:
             # Validate service URL against allowed domains
             effective_service_url = service_url or self.options.service_url
             if effective_service_url and not is_allowed_service_url(effective_service_url, self.cloud):
-                logger.error(f"Service URL '{effective_service_url}' is not from an allowed domain")
-                raise jwt.InvalidTokenError(f"Service URL '{effective_service_url}' is not from an allowed domain")
+                logger.error(f"Rejected service URL: {effective_service_url}")
+                raise jwt.InvalidTokenError("Service URL is not from an allowed domain")
 
             # Optional service URL claim validation
             if effective_service_url:

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -37,17 +37,16 @@ def is_allowed_service_url(
         if hostname in ("localhost", "127.0.0.1"):
             return True
 
-        additional = additional_domains or []
-        if "*" in additional:
+        if parsed.scheme != "https":
+            return False
+
+        allowed = [d.lower() for d in [*cloud.allowed_service_urls, *(additional_domains or [])]]
+        if "*" in allowed:
             return True
 
-        # Check against cloud environment's allowed FQDNs
-        if any(hostname == allowed.lower() for allowed in cloud.allowed_service_urls):
-            return True
-
-        # Check against additional domains (suffix match)
-        return any(hostname.endswith(domain.lower()) for domain in additional)
+        return hostname in allowed
     except Exception:  # pragma: no cover
+        logger.error("Failed to parse service URL for validation: %s", service_url)
         return False
 
 

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 import jwt
 from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
@@ -16,6 +17,43 @@ from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
 
 logger = logging.getLogger(__name__)
+
+# Default allowed service URL domain patterns.
+# Covers public, government, sovereign, and regional clouds.
+DEFAULT_ALLOWED_SERVICE_URL_DOMAINS = [
+    # Public cloud
+    ".botframework.com",
+    # US Government
+    ".botframework.azure.us",
+    ".teams.microsoft.com",
+    ".teams.microsoft.us",
+    # China (21Vianet)
+    ".botframework.azure.cn",
+    ".teams.microsoftonline.cn",
+]
+
+
+def is_allowed_service_url(service_url: str, additional_domains: Optional[List[str]] = None) -> bool:
+    """Validate that a service URL belongs to a known domain.
+
+    Returns True if the URL's hostname ends with one of the allowed domain suffixes,
+    or if the hostname is localhost (for local development).
+    """
+    try:
+        parsed = urlparse(service_url)
+        hostname = (parsed.hostname or "").lower()
+
+        if hostname in ("localhost", "127.0.0.1"):
+            return True
+
+        # trafficmanager.net is a shared Azure service; only allow smba-prefixed hostnames
+        if hostname.endswith(".trafficmanager.net") or hostname == "trafficmanager.net":
+            return hostname.startswith("smba")
+
+        allowed = DEFAULT_ALLOWED_SERVICE_URL_DOMAINS + (additional_domains or [])
+        return any(domain == "*" or hostname.endswith(domain.lower()) for domain in allowed)
+    except Exception:  # pragma: no cover
+        return False
 
 
 @dataclass
@@ -34,6 +72,8 @@ class JwtValidationOptions:
     """ Optional scope that must be present in the token """
     clock_tolerance: int = JWT_LEEWAY_SECONDS
     """ Allowable clock skew when validating JWTs """
+    additional_allowed_domains: List[str] = field(default_factory=lambda: [])
+    """ Additional allowed service URL domains beyond the defaults """
 
 
 class TokenValidator:
@@ -106,6 +146,11 @@ class TokenValidator:
         valid_issuers: List[str] = []
         if tenant_id:
             valid_issuers.append(f"{env.login_endpoint}/{tenant_id}/v2.0")
+        else:
+            logger.warning(
+                "No tenant_id provided for Entra token validation. "
+                "Issuer validation will be skipped, accepting tokens from any tenant."
+            )
         tenant_id = tenant_id or "common"
         valid_audiences = cls._default_audiences(app_id)
         if application_id_uri:
@@ -159,10 +204,17 @@ class TokenValidator:
                 leeway=JWT_LEEWAY_SECONDS,
             )
 
-            # Optional service URL validation
-            expected_service_url = service_url or self.options.service_url
-            if expected_service_url:
-                self._validate_service_url(payload, expected_service_url)
+            # Validate service URL against allowed domains
+            effective_service_url = service_url or self.options.service_url
+            if effective_service_url and not is_allowed_service_url(
+                effective_service_url, self.options.additional_allowed_domains
+            ):
+                logger.error(f"Service URL '{effective_service_url}' is not from an allowed domain")
+                raise jwt.InvalidTokenError(f"Service URL '{effective_service_url}' is not from an allowed domain")
+
+            # Optional service URL claim validation
+            if effective_service_url:
+                self._validate_service_url(payload, effective_service_url)
 
             required_scope = scope or self.options.scope
             if required_scope:
@@ -205,7 +257,7 @@ class TokenValidator:
             payload: The decoded JWT payload
             required_scope: The scope required to be present in the token
         """
-        scopes = payload.get("scp", "") or ""
-        if required_scope not in scopes:
+        scope_set = set((payload.get("scp", "") or "").split())
+        if required_scope not in scope_set:
             logger.error(f"Token missing required scope: {required_scope}")
             raise jwt.InvalidTokenError(f"Token missing required scope: {required_scope}")

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -18,6 +18,7 @@ JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
 
 logger = logging.getLogger(__name__)
 
+
 def is_allowed_service_url(
     service_url: str,
     cloud: CloudEnvironment,

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -18,26 +18,16 @@ JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
 
 logger = logging.getLogger(__name__)
 
-# Default allowed service URL domain patterns.
-# Covers public, government, sovereign, and regional clouds.
-DEFAULT_ALLOWED_SERVICE_URL_DOMAINS = [
-    # Public cloud
-    ".botframework.com",
-    # US Government
-    ".botframework.azure.us",
-    ".teams.microsoft.com",
-    ".teams.microsoft.us",
-    # China (21Vianet)
-    ".botframework.azure.cn",
-    ".teams.microsoftonline.cn",
-]
+def is_allowed_service_url(
+    service_url: str,
+    cloud: CloudEnvironment,
+    additional_domains: Optional[List[str]] = None,
+) -> bool:
+    """Validate that a service URL hostname is allowed.
 
-
-def is_allowed_service_url(service_url: str, additional_domains: Optional[List[str]] = None) -> bool:
-    """Validate that a service URL belongs to a known domain.
-
-    Returns True if the URL's hostname ends with one of the allowed domain suffixes,
-    or if the hostname is localhost (for local development).
+    Checks against the cloud environment's allowed service URLs,
+    plus any additional domains provided by the caller.
+    Localhost is always allowed for local development.
     """
     try:
         parsed = urlparse(service_url)
@@ -46,12 +36,16 @@ def is_allowed_service_url(service_url: str, additional_domains: Optional[List[s
         if hostname in ("localhost", "127.0.0.1"):
             return True
 
-        # trafficmanager.net is a shared Azure service; only allow smba-prefixed hostnames
-        if hostname.endswith(".trafficmanager.net") or hostname == "trafficmanager.net":
-            return hostname.startswith("smba")
+        additional = additional_domains or []
+        if "*" in additional:
+            return True
 
-        allowed = DEFAULT_ALLOWED_SERVICE_URL_DOMAINS + (additional_domains or [])
-        return any(domain == "*" or hostname.endswith(domain.lower()) for domain in allowed)
+        # Check against cloud environment's allowed FQDNs
+        if any(hostname == allowed.lower() for allowed in cloud.allowed_service_urls):
+            return True
+
+        # Check against additional domains (suffix match)
+        return any(hostname.endswith(domain.lower()) for domain in additional)
     except Exception:  # pragma: no cover
         return False
 
@@ -72,8 +66,6 @@ class JwtValidationOptions:
     """ Optional scope that must be present in the token """
     clock_tolerance: int = JWT_LEEWAY_SECONDS
     """ Allowable clock skew when validating JWTs """
-    additional_allowed_domains: List[str] = field(default_factory=lambda: [])
-    """ Additional allowed service URL domains beyond the defaults """
 
 
 class TokenValidator:
@@ -81,14 +73,16 @@ class TokenValidator:
     JWT token validator using PyJWKClient for simplified validation.
     """
 
-    def __init__(self, jwt_validation_options: JwtValidationOptions):
+    def __init__(self, jwt_validation_options: JwtValidationOptions, cloud: Optional[CloudEnvironment] = None):
         """
         Initialize the token validator.
 
         Args:
             jwt_validation_options: Configuration for JWT validation
+            cloud: Optional cloud environment for service URL validation
         """
         self.options = jwt_validation_options
+        self.cloud = cloud or PUBLIC
         self._jwks_client = jwt.PyJWKClient(jwt_validation_options.jwks_uri)
 
     @staticmethod
@@ -121,7 +115,7 @@ class TokenValidator:
             jwks_uri=jwks_keys_uri,
             service_url=service_url,
         )
-        return cls(options)
+        return cls(options, cloud=env)
 
     @classmethod
     def for_entra(
@@ -206,9 +200,7 @@ class TokenValidator:
 
             # Validate service URL against allowed domains
             effective_service_url = service_url or self.options.service_url
-            if effective_service_url and not is_allowed_service_url(
-                effective_service_url, self.options.additional_allowed_domains
-            ):
+            if effective_service_url and not is_allowed_service_url(effective_service_url, self.cloud):
                 logger.error(f"Service URL '{effective_service_url}' is not from an allowed domain")
                 raise jwt.InvalidTokenError(f"Service URL '{effective_service_url}' is not from an allowed domain")
 

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -8,11 +8,9 @@ from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, Optional, cast
 
 from microsoft_teams.api import Credentials, InvokeResponse, TokenProtocol
-from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 from microsoft_teams.api.auth.json_web_token import JsonWebToken
 from pydantic import BaseModel
-
-from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 
 from ..auth import TokenValidator
 from ..auth.token_validator import is_allowed_service_url

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -12,6 +12,8 @@ from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 from microsoft_teams.api.auth.json_web_token import JsonWebToken
 from pydantic import BaseModel
 
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
+
 from ..auth import TokenValidator
 from ..auth.token_validator import is_allowed_service_url
 from ..events import ActivityEvent, CoreActivity
@@ -38,6 +40,7 @@ class HttpServer:
         self._token_validator: Optional[TokenValidator] = None
         self._skip_auth: bool = False
         self._additional_allowed_domains: Optional[list[str]] = None
+        self._cloud: CloudEnvironment = PUBLIC
         self._initialized: bool = False
 
     @property
@@ -80,10 +83,11 @@ class HttpServer:
 
         self._skip_auth = skip_auth
         self._additional_allowed_domains = additional_allowed_domains
+        self._cloud = cloud or PUBLIC
 
         app_id = getattr(credentials, "client_id", None) if credentials else None
         if app_id and not skip_auth:
-            self._token_validator = TokenValidator.for_service(app_id, cloud=cloud)
+            self._token_validator = TokenValidator.for_service(app_id, cloud=self._cloud)
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
 
         self._adapter.register_route("POST", self._messaging_endpoint, self.handle_request)
@@ -129,7 +133,7 @@ class HttpServer:
                 )
 
             # Validate service URL against allowed domains
-            if service_url and not is_allowed_service_url(service_url, self._additional_allowed_domains):
+            if service_url and not is_allowed_service_url(service_url, self._cloud, self._additional_allowed_domains):
                 logger.warning(f"Service URL '{service_url}' is not from an allowed domain")
                 return HttpResponse(status=403, body={"error": "Service URL not allowed"})
 

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -13,6 +13,7 @@ from microsoft_teams.api.auth.json_web_token import JsonWebToken
 from pydantic import BaseModel
 
 from ..auth import TokenValidator
+from ..auth.token_validator import is_allowed_service_url
 from ..events import ActivityEvent, CoreActivity
 from .adapter import HttpRequest, HttpResponse, HttpServerAdapter
 
@@ -36,6 +37,7 @@ class HttpServer:
         self._on_request: Optional[Callable[[ActivityEvent], Awaitable[InvokeResponse[Any]]]] = None
         self._token_validator: Optional[TokenValidator] = None
         self._skip_auth: bool = False
+        self._additional_allowed_domains: Optional[list[str]] = None
         self._initialized: bool = False
 
     @property
@@ -61,6 +63,7 @@ class HttpServer:
         self,
         credentials: Optional[Credentials] = None,
         skip_auth: bool = False,
+        additional_allowed_domains: Optional[list[str]] = None,
         cloud: Optional[CloudEnvironment] = None,
     ) -> None:
         """
@@ -69,12 +72,14 @@ class HttpServer:
         Args:
             credentials: App credentials for JWT validation.
             skip_auth: Whether to skip JWT validation.
+            additional_allowed_domains: Additional allowed service URL domain suffixes.
             cloud: Optional cloud environment for sovereign cloud support.
         """
         if self._initialized:
             return
 
         self._skip_auth = skip_auth
+        self._additional_allowed_domains = additional_allowed_domains
 
         app_id = getattr(credentials, "client_id", None) if credentials else None
         if app_id and not skip_auth:
@@ -122,6 +127,11 @@ class HttpServer:
                         is_expired=lambda: False,
                     ),
                 )
+
+            # Validate service URL against allowed domains
+            if service_url and not is_allowed_service_url(service_url, self._additional_allowed_domains):
+                logger.warning(f"Service URL '{service_url}' is not from an allowed domain")
+                return HttpResponse(status=403, body={"error": "Service URL not allowed"})
 
             core_activity = CoreActivity.model_validate(body)
             activity_type = core_activity.type or "unknown"

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -132,7 +132,7 @@ class HttpServer:
 
             # Validate service URL against allowed domains
             if service_url and not is_allowed_service_url(service_url, self._cloud, self._additional_allowed_domains):
-                logger.warning(f"Service URL '{service_url}' is not from an allowed domain")
+                logger.warning(f"Rejected service URL: {service_url}")
                 return HttpResponse(status=403, body={"error": "Service URL not allowed"})
 
             core_activity = CoreActivity.model_validate(body)

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -83,6 +83,9 @@ class HttpServer:
         self._additional_allowed_domains = additional_allowed_domains
         self._cloud = cloud or PUBLIC
 
+        if "*" in (additional_allowed_domains or []):
+            logger.warning("Service URL validation is disabled via wildcard in additional_allowed_domains")
+
         app_id = getattr(credentials, "client_id", None) if credentials else None
         if app_id and not skip_auth:
             self._token_validator = TokenValidator.for_service(app_id, cloud=self._cloud)

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -46,6 +46,8 @@ class AppOptions(TypedDict, total=False):
     storage: Optional[Storage[str, Any]]
     plugins: Optional[List[PluginBase]]
     skip_auth: Optional[bool]
+    additional_allowed_domains: Optional[List[str]]
+    """Additional allowed service URL domain suffixes beyond the built-in defaults."""
 
     # HTTP adapter
     http_server_adapter: Optional[HttpServerAdapter]
@@ -86,6 +88,8 @@ class InternalAppOptions:
 
     # Fields with defaults
     skip_auth: bool = False
+    additional_allowed_domains: Optional[List[str]] = None
+    """Additional allowed service URL domain suffixes beyond the built-in defaults."""
     default_connection_name: str = "graph"
     """The OAuth connection name to use for authentication."""
     plugins: List[PluginBase] = field(default_factory=lambda: [])

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -47,7 +47,7 @@ class AppOptions(TypedDict, total=False):
     plugins: Optional[List[PluginBase]]
     skip_auth: Optional[bool]
     additional_allowed_domains: Optional[List[str]]
-    """Additional allowed service URL domain suffixes beyond the built-in defaults."""
+    """Additional allowed service URL hostnames beyond the built-in defaults."""
 
     # HTTP adapter
     http_server_adapter: Optional[HttpServerAdapter]
@@ -89,7 +89,7 @@ class InternalAppOptions:
     # Fields with defaults
     skip_auth: bool = False
     additional_allowed_domains: Optional[List[str]] = None
-    """Additional allowed service URL domain suffixes beyond the built-in defaults."""
+    """Additional allowed service URL hostnames beyond the built-in defaults."""
     default_connection_name: str = "graph"
     """The OAuth connection name to use for authentication."""
     plugins: List[PluginBase] = field(default_factory=lambda: [])

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -813,3 +813,13 @@ class TestAppReply:
 
         with pytest.raises(ValueError, match="app not initialized"):
             await app.reply("conv-id", "Hello")
+
+
+class TestMergeAppOptions:
+    def test_merge_with_defaults(self):
+        from microsoft_teams.apps.options import merge_app_options_with_defaults
+
+        result = merge_app_options_with_defaults(client_id="test-id")
+        assert result["client_id"] == "test-id"
+        assert result["skip_auth"] is False
+        assert result["default_connection_name"] == "graph"

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -39,6 +39,18 @@ class TestHttpServer:
         assert server.adapter is mock_adapter
         assert server.on_request is None
 
+    def test_initialize_idempotent(self, server, mock_adapter):
+        """Test that initialize can be called multiple times safely."""
+        server.initialize(skip_auth=True)
+        server.initialize(skip_auth=True)
+        # Should only register route once
+        assert mock_adapter.register_route.call_count == 1
+
+    def test_invalid_messaging_endpoint_raises(self, mock_adapter):
+        """Test that invalid messaging endpoint raises ValueError."""
+        with pytest.raises(ValueError, match="must be a non-empty path"):
+            HttpServer(mock_adapter, messaging_endpoint="no-slash")
+
     def test_messaging_endpoint_default(self, server):
         """Test default messaging endpoint."""
         assert server.messaging_endpoint == "/api/messages"
@@ -129,6 +141,105 @@ class TestHttpServer:
         result = await server.handle_request(request)
 
         assert result["status"] == 500
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_bearer_token(self, server, mock_adapter):
+        """Test that auth-enabled server rejects requests without Bearer token."""
+        from unittest.mock import MagicMock
+
+        creds = MagicMock()
+        creds.client_id = "test-app-id"
+        server.initialize(credentials=creds)
+
+        request = HttpRequest(
+            body={"type": "message", "id": "test-123"},
+            headers={"authorization": "Basic invalid"},
+        )
+
+        result = await server.handle_request(request)
+        assert result["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_jwt(self, server, mock_adapter):
+        """Test that auth-enabled server rejects invalid JWT tokens."""
+        from unittest.mock import MagicMock
+
+        creds = MagicMock()
+        creds.client_id = "test-app-id"
+        server.initialize(credentials=creds)
+
+        request = HttpRequest(
+            body={"type": "message", "id": "test-123"},
+            headers={"authorization": "Bearer invalid.jwt.token"},
+        )
+
+        result = await server.handle_request(request)
+        assert result["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_allowed_service_url(self, server):
+        """Test that requests with non-allowed serviceUrl are rejected."""
+        server.initialize(skip_auth=True)
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "text": "Test",
+                "serviceUrl": "https://evil.com/steal",
+            },
+            headers={},
+        )
+
+        result = await server.handle_request(request)
+        assert result["status"] == 403
+
+    @pytest.mark.asyncio
+    async def test_accepts_allowed_service_url(self, server):
+        """Test that requests with allowed serviceUrl pass validation."""
+
+        async def mock_handler(event):
+            return InvokeResponse(status=200, body=cast(ConfigResponse, {}))
+
+        server.on_request = mock_handler
+        server.initialize(skip_auth=True)
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "text": "Test",
+                "serviceUrl": "https://smba.trafficmanager.net/teams/",
+            },
+            headers={},
+        )
+
+        result = await server.handle_request(request)
+        assert result["status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_allows_any_service_url_with_wildcard_domain(self, mock_adapter):
+        """Test that additional_allowed_domains=["*"] allows any serviceUrl."""
+        server = HttpServer(mock_adapter)
+
+        async def mock_handler(event):
+            return InvokeResponse(status=200, body=cast(ConfigResponse, {}))
+
+        server.on_request = mock_handler
+        server.initialize(skip_auth=True, additional_allowed_domains=["*"])
+
+        request = HttpRequest(
+            body={
+                "type": "message",
+                "id": "test-123",
+                "text": "Test",
+                "serviceUrl": "https://evil.com/steal",
+            },
+            headers={},
+        )
+
+        result = await server.handle_request(request)
+        assert result["status"] == 200
 
 
 class TestFastAPIAdapter:

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -499,7 +499,7 @@ class TestTokenValidator:
         """Additional domains should be accepted."""
         from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
 
-        assert is_allowed_service_url("https://api.custom.com", PUBLIC, [".custom.com"]) is True
+        assert is_allowed_service_url("https://api.custom.com", PUBLIC, ["api.custom.com"]) is True
         assert is_allowed_service_url("https://api.custom.com", PUBLIC) is False
 
     def test_is_allowed_service_url_wildcard(self):

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import jwt
 import pytest
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, US_GOV
 from microsoft_teams.apps.auth.token_validator import TokenValidator
 
 # pyright: basic
@@ -387,6 +388,15 @@ class TestTokenValidator:
     # --- Finding 1: Service URL domain allowlist ---
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
+    async def test_service_url_rejects_botframework_by_default(self, validator, mock_jwks_client, valid_payload):
+        """botframework.com should be rejected by default (non-Teams channel)."""
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=valid_payload):
+            with pytest.raises(jwt.InvalidTokenError, match="is not from an allowed domain"):
+                await validator.validate_token("valid.jwt.token", "https://webchat.botframework.com")
+
+    @pytest.mark.asyncio
     async def test_service_url_rejects_non_allowed_domain(self, validator, mock_jwks_client, valid_payload):
         """Service URL from unknown domain should be rejected."""
         validator._jwks_client = mock_jwks_client
@@ -395,19 +405,19 @@ class TestTokenValidator:
                 await validator.validate_token("valid.jwt.token", "https://evil.com/api")
 
     @pytest.mark.asyncio
-    async def test_service_url_accepts_botframework_domain(self, validator, mock_jwks_client):
-        """Service URL from botframework.com should be accepted."""
+    async def test_service_url_accepts_cloud_preset_fqdn(self, validator, mock_jwks_client):
+        """Service URL from cloud preset should be accepted."""
         payload = {
             "iss": "https://api.botframework.com",
             "aud": "test-app-id",
-            "serviceurl": "https://webchat.botframework.com",
+            "serviceurl": "https://smba.trafficmanager.net/amer/",
             "exp": 9999999999,
             "iat": 1000000000,
         }
         validator._jwks_client = mock_jwks_client
         with patch("jwt.decode", return_value=payload):
-            result = await validator.validate_token("valid.jwt.token", "https://webchat.botframework.com")
-            assert result["serviceurl"] == "https://webchat.botframework.com"
+            result = await validator.validate_token("valid.jwt.token", "https://smba.trafficmanager.net/amer/")
+            assert result["serviceurl"] == "https://smba.trafficmanager.net/amer/"
 
     @pytest.mark.asyncio
     async def test_service_url_accepts_localhost(self, validator, mock_jwks_client):
@@ -425,18 +435,19 @@ class TestTokenValidator:
             assert result["serviceurl"] == "http://localhost:3978"
 
     @pytest.mark.asyncio
-    async def test_service_url_accepts_gov_cloud(self, validator, mock_jwks_client):
-        """US Government cloud service URL should be accepted."""
+    async def test_service_url_accepts_gov_cloud_with_us_gov_preset(self, mock_jwks_client):
+        """US Government cloud service URL should be accepted with US_GOV cloud."""
+        validator = TokenValidator.for_service("test-app-id", cloud=US_GOV)
         payload = {
-            "iss": "https://api.botframework.com",
+            "iss": "https://api.botframework.us",
             "aud": "test-app-id",
-            "serviceurl": "https://smba.infra.gcc.teams.microsoft.com/",
+            "serviceurl": "https://smba.infra.gov.teams.microsoft.us/",
             "exp": 9999999999,
             "iat": 1000000000,
         }
         validator._jwks_client = mock_jwks_client
         with patch("jwt.decode", return_value=payload):
-            result = await validator.validate_token("valid.jwt.token", "https://smba.infra.gcc.teams.microsoft.com/")
+            result = await validator.validate_token("valid.jwt.token", "https://smba.infra.gov.teams.microsoft.us/")
             assert isinstance(result, dict)
 
     @pytest.mark.asyncio
@@ -476,23 +487,23 @@ class TestTokenValidator:
         """Invalid URL should return False."""
         from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
 
-        assert is_allowed_service_url("not-a-url") is False
+        assert is_allowed_service_url("not-a-url", PUBLIC) is False
 
     def test_is_allowed_service_url_empty(self):
         """Empty string should return False (no hostname to match)."""
         from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
 
-        assert is_allowed_service_url("") is False
+        assert is_allowed_service_url("", PUBLIC) is False
 
     def test_is_allowed_service_url_with_additional_domains(self):
         """Additional domains should be accepted."""
         from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
 
-        assert is_allowed_service_url("https://api.custom.com", [".custom.com"]) is True
-        assert is_allowed_service_url("https://api.custom.com") is False
+        assert is_allowed_service_url("https://api.custom.com", PUBLIC, [".custom.com"]) is True
+        assert is_allowed_service_url("https://api.custom.com", PUBLIC) is False
 
     def test_is_allowed_service_url_wildcard(self):
         """Wildcard '*' should accept any domain."""
         from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
 
-        assert is_allowed_service_url("https://anything.example.com", ["*"]) is True
+        assert is_allowed_service_url("https://anything.example.com", PUBLIC, ["*"]) is True

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -336,3 +336,163 @@ class TestTokenValidator:
         ):
             with pytest.raises(jwt.InvalidTokenError):
                 await validator_entra.validate_token(token)
+
+    # --- Finding 4: Scope validation uses exact match, not substring ---
+
+    @pytest.mark.asyncio
+    async def test_scope_validation_rejects_substring_match(self, mock_jwks_client):
+        """Scope 'User.Read' should NOT match 'User.ReadBasic.All' (substring)."""
+        validator = TokenValidator.for_entra(app_id="test-app-id", tenant_id="test-tenant-id", scope="User.Read")
+        validator._jwks_client = mock_jwks_client
+        payload = {
+            "iss": "https://login.microsoftonline.com/test-tenant-id/v2.0",
+            "aud": "test-app-id",
+            "scp": "User.ReadBasic.All",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+
+        with patch("jwt.decode", return_value=payload):
+            with pytest.raises(jwt.InvalidTokenError, match="Token missing required scope: User.Read"):
+                await validator.validate_token("valid.jwt.token")
+
+    @pytest.mark.asyncio
+    async def test_scope_validation_accepts_exact_match_among_multiple(self, mock_jwks_client):
+        """Scope 'User.Read' should match when present among multiple scopes."""
+        validator = TokenValidator.for_entra(app_id="test-app-id", tenant_id="test-tenant-id", scope="User.Read")
+        validator._jwks_client = mock_jwks_client
+        payload = {
+            "iss": "https://login.microsoftonline.com/test-tenant-id/v2.0",
+            "aud": "test-app-id",
+            "scp": "Mail.Read User.Read Files.ReadWrite",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token("valid.jwt.token")
+            assert result["scp"] == "Mail.Read User.Read Files.ReadWrite"
+
+    # --- Finding 10: Issuer validation bypass ---
+
+    def test_for_entra_without_tenant_id_logs_warning(self, caplog):
+        """Creating Entra validator without tenant_id should log a warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            validator = TokenValidator.for_entra(app_id="test-app-id", tenant_id=None)
+            assert validator.options.valid_issuers == []
+            assert "Issuer validation will be skipped" in caplog.text
+
+    # --- Finding 1: Service URL domain allowlist ---
+
+    @pytest.mark.asyncio
+    async def test_service_url_rejects_non_allowed_domain(self, validator, mock_jwks_client, valid_payload):
+        """Service URL from unknown domain should be rejected."""
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=valid_payload):
+            with pytest.raises(jwt.InvalidTokenError, match="is not from an allowed domain"):
+                await validator.validate_token("valid.jwt.token", "https://evil.com/api")
+
+    @pytest.mark.asyncio
+    async def test_service_url_accepts_botframework_domain(self, validator, mock_jwks_client):
+        """Service URL from botframework.com should be accepted."""
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "https://webchat.botframework.com",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token("valid.jwt.token", "https://webchat.botframework.com")
+            assert result["serviceurl"] == "https://webchat.botframework.com"
+
+    @pytest.mark.asyncio
+    async def test_service_url_accepts_localhost(self, validator, mock_jwks_client):
+        """Localhost service URL should be accepted for development."""
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "http://localhost:3978",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token("valid.jwt.token", "http://localhost:3978")
+            assert result["serviceurl"] == "http://localhost:3978"
+
+    @pytest.mark.asyncio
+    async def test_service_url_accepts_gov_cloud(self, validator, mock_jwks_client):
+        """US Government cloud service URL should be accepted."""
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "https://smba.infra.gcc.teams.microsoft.com/",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token("valid.jwt.token", "https://smba.infra.gcc.teams.microsoft.com/")
+            assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_service_url_rejects_spoofed_suffix(self, validator, mock_jwks_client, valid_payload):
+        """Domain containing allowed suffix as substring should be rejected."""
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=valid_payload):
+            with pytest.raises(jwt.InvalidTokenError, match="is not from an allowed domain"):
+                await validator.validate_token("valid.jwt.token", "https://botframework.com.evil.com")
+
+    @pytest.mark.asyncio
+    async def test_service_url_rejects_attacker_trafficmanager(self, validator, mock_jwks_client, valid_payload):
+        """Attacker-controlled trafficmanager subdomain should be rejected."""
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=valid_payload):
+            with pytest.raises(jwt.InvalidTokenError, match="is not from an allowed domain"):
+                await validator.validate_token("valid.jwt.token", "https://attacker.trafficmanager.net")
+
+    @pytest.mark.asyncio
+    async def test_service_url_accepts_smba_onyx_trafficmanager(self, validator, mock_jwks_client):
+        """smba.onyx.prod.teams.trafficmanager.net should be accepted."""
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "https://smba.onyx.prod.teams.trafficmanager.net",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        validator._jwks_client = mock_jwks_client
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token(
+                "valid.jwt.token", "https://smba.onyx.prod.teams.trafficmanager.net"
+            )
+            assert isinstance(result, dict)
+
+    def test_is_allowed_service_url_invalid_url(self):
+        """Invalid URL should return False."""
+        from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
+
+        assert is_allowed_service_url("not-a-url") is False
+
+    def test_is_allowed_service_url_empty(self):
+        """Empty string should return False (no hostname to match)."""
+        from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
+
+        assert is_allowed_service_url("") is False
+
+    def test_is_allowed_service_url_with_additional_domains(self):
+        """Additional domains should be accepted."""
+        from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
+
+        assert is_allowed_service_url("https://api.custom.com", [".custom.com"]) is True
+        assert is_allowed_service_url("https://api.custom.com") is False
+
+    def test_is_allowed_service_url_wildcard(self):
+        """Wildcard '*' should accept any domain."""
+        from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
+
+        assert is_allowed_service_url("https://anything.example.com", ["*"]) is True

--- a/packages/devtools/src/microsoft_teams/devtools/devtools_plugin.py
+++ b/packages/devtools/src/microsoft_teams/devtools/devtools_plugin.py
@@ -114,8 +114,9 @@ class DevToolsPlugin(PluginBase):
         self._on_stopped_callback = callback
 
     async def on_init(self) -> None:
-        env = os.environ.get("PYTHON_ENV", "") or os.environ.get("NODE_ENV", "")
-        if env.lower() == "production":
+        python_env = os.environ.get("PYTHON_ENV", "").lower()
+        node_env = os.environ.get("NODE_ENV", "").lower()
+        if python_env == "production" or node_env == "production":
             raise RuntimeError(
                 "Devtools plugin cannot be used in production environments "
                 "(PYTHON_ENV=production or NODE_ENV=production). "

--- a/packages/devtools/src/microsoft_teams/devtools/devtools_plugin.py
+++ b/packages/devtools/src/microsoft_teams/devtools/devtools_plugin.py
@@ -114,6 +114,14 @@ class DevToolsPlugin(PluginBase):
         self._on_stopped_callback = callback
 
     async def on_init(self) -> None:
+        env = os.environ.get("PYTHON_ENV", "") or os.environ.get("NODE_ENV", "")
+        if env.lower() == "production":
+            raise RuntimeError(
+                "Devtools plugin cannot be used in production environments "
+                "(PYTHON_ENV=production or NODE_ENV=production). "
+                "Remove the devtools plugin from your app configuration."
+            )
+
         logger.warning("⚠️ Devtools is not secure and should not be used in production environments ⚠️")
 
     async def on_start(self, event: PluginStartEvent) -> None:

--- a/packages/devtools/tests/test_devtools_plugin.py
+++ b/packages/devtools/tests/test_devtools_plugin.py
@@ -1,0 +1,85 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import pytest
+from microsoft_teams.devtools.devtools_plugin import DevToolsPlugin
+
+# pyright: basic
+
+
+class TestDevToolsPluginEnvironmentGuard:
+    """Test that DevTools refuses to start in production environments."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        """Clear environment variables before each test."""
+        monkeypatch.delenv("PYTHON_ENV", raising=False)
+        monkeypatch.delenv("NODE_ENV", raising=False)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_python_env_is_production(self, monkeypatch):
+        monkeypatch.setenv("PYTHON_ENV", "production")
+        plugin = DevToolsPlugin()
+
+        with pytest.raises(RuntimeError, match="cannot be used in production"):
+            await plugin.on_init()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_node_env_is_production(self, monkeypatch):
+        monkeypatch.setenv("NODE_ENV", "production")
+        plugin = DevToolsPlugin()
+
+        with pytest.raises(RuntimeError, match="cannot be used in production"):
+            await plugin.on_init()
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_in_development(self, monkeypatch):
+        monkeypatch.setenv("NODE_ENV", "development")
+        plugin = DevToolsPlugin()
+
+        # Should not raise — just logs a warning
+        await plugin.on_init()
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_env_not_set(self):
+        plugin = DevToolsPlugin()
+
+        # Should not raise when no env var is set
+        await plugin.on_init()
+
+
+class TestDevToolsPluginInit:
+    """Test DevToolsPlugin initialization and properties."""
+
+    def test_init_defaults(self):
+        plugin = DevToolsPlugin()
+        assert plugin.pages == []
+        assert plugin.sockets == {}
+        assert plugin.pending == {}
+        assert plugin.on_ready_callback is None
+        assert plugin.on_stopped_callback is None
+
+    def test_callback_setters(self):
+        plugin = DevToolsPlugin()
+
+        async def ready():
+            pass
+
+        async def stopped():
+            pass
+
+        plugin.on_ready_callback = ready
+        plugin.on_stopped_callback = stopped
+        assert plugin.on_ready_callback is ready
+        assert plugin.on_stopped_callback is stopped
+
+    def test_add_page(self):
+        from microsoft_teams.devtools.page import Page
+
+        plugin = DevToolsPlugin()
+        page = Page(name="test", display_name="Test Page", url="/test")
+        plugin.add_page(page)
+        assert len(plugin.pages) == 1
+        assert plugin.pages[0].name == "test"


### PR DESCRIPTION
## Summary

Security hardening for token validation, service URL handling, and development tooling.

- **Service URL validation**: Validate inbound `serviceUrl` against allowed hostnames from the configured cloud environment preset. Configurable via `additional_allowed_domains` for non-standard channels or sovereign clouds without presets.
- **Scope validation**: Use exact set membership instead of substring matching for JWT scope checks.
- **Issuer validation**: Log a warning when Entra token validation is configured without a tenant ID, making the silent issuer validation skip visible.
- **DevTools**: Prevent the DevTools plugin from starting in production environments.

## Test plan

- Unit tests for domain allowlist (cloud preset FQDNs, rejected domains, attacker trafficmanager, localhost, custom domains, wildcard, botframework.com rejected by default)
- Unit tests for exact scope matching
- Unit test for issuer validation warning
- Unit tests for DevTools production guard
- E2E validated in Teams -- no regressions
- E2E validated DevTools blocked on `PYTHON_ENV=production`