### PR TITLE
fix: drain entire queue per flush to avoid streaming tail lag

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -33,7 +33,7 @@ class HttpStream(StreamerProtocol):
 
     Flow:
     1. emit() adds activities to a queue
-    2. _flush() processes up to 10 queued items under a lock.
+    2. _flush() drains the entire queue under a lock.
     3. Informative typing updates are sent immediately if no message started.
     4. Message text are combined into a typing chunk.
     5. Another flush is scheduled if more items remain.
@@ -205,10 +205,10 @@ class HttpStream(StreamerProtocol):
                 self._timeout.cancel()
                 self._timeout = None
 
-            i = 0
             informative_updates: List[TypingActivityInput] = []
+            start_length = len(self._queue)
 
-            while i < 10 and self._queue:
+            while self._queue:
                 activity = self._queue.popleft()
 
                 if isinstance(activity, MessageActivityInput):
@@ -227,9 +227,7 @@ class HttpStream(StreamerProtocol):
                     # And so informative updates cannot be sent.
                     informative_updates.append(activity)
 
-                i += 1
-
-            if i == 0:
+            if start_length == 0:
                 logger.debug("No activities to flush")
                 return
 

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -91,10 +91,9 @@ class TestHttpStream:
                 http_stream.emit(f"Message {i + 1}")
 
             await asyncio.sleep(0)
+            # First flush drains the entire queue, no second flush needed
             assert http_stream._client.send_call_count == 1
-
-            await self._run_scheduled_flushes(scheduled)
-            assert http_stream._client.send_call_count == 2
+            assert len(scheduled) == 0
 
     @pytest.mark.asyncio
     async def test_stream_error_handled_gracefully(


### PR DESCRIPTION
## Summary
- Removes the 10-item batch cap in `HttpStream._flush()` so each flush cycle drains the entire queue
- Prevents a long streaming tail when the LLM finishes generating faster than chunks are sent to Teams
- Port of [microsoft/teams.ts#520](https://github.com/microsoft/teams.ts/pull/520)

## Test plan
- [x] Existing `test_http_stream.py` tests pass (11/11)
- [x] Updated `test_stream_multiple_emits_with_timer` to verify the first flush drains all 12 messages with no second flush scheduled
- [x] Pre-commit hooks (ruff, pyright) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)