### PR TITLE
Remove with_reply_to_id method

### DIFF
--- a/packages/api/src/microsoft_teams/api/models/activity.py
+++ b/packages/api/src/microsoft_teams/api/models/activity.py
@@ -113,11 +113,6 @@ class ActivityInput(_ActivityBase):
         self.id = value
         return self
 
-    def with_reply_to_id(self, value: str) -> Self:
-        """Set the reply_to_id."""
-        self.reply_to_id = value
-        return self
-
     def with_channel_id(self, value: ChannelID) -> Self:
         """Set the channel_id."""
         self.channel_id = value

--- a/packages/api/tests/unit/test_activity.py
+++ b/packages/api/tests/unit/test_activity.py
@@ -63,7 +63,6 @@ class TestActivity:
         activity = (
             test_activity.with_locale("en")
             .with_recipient(bot)
-            .with_reply_to_id("3")
             .with_service_url("http://localhost")
             .with_timestamp(datetime.now())
             .with_local_timestamp(datetime.now())
@@ -75,7 +74,6 @@ class TestActivity:
         assert activity.from_ == user
         assert activity.conversation == chat
         assert activity.recipient == bot
-        assert activity.reply_to_id == "3"
         assert activity.service_url == "http://localhost"
         assert activity.timestamp is not None
         assert activity.local_timestamp is not None


### PR DESCRIPTION
- Remove `with_reply_to_id()` method

`reply_to_id` is a field on the activity that is used by the service, but any changes to it on the bot side are completely ignored. After thorough testing to confirm, this PR removes the misleading method `with_reply_to_id`; setting replyToId on outgoing activities is a no-op.

Originally part of #321 but separated out due to timing concerns for GA