### PR TITLE
Add proactive threading support

### DIFF
--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -1,0 +1,34 @@
+# Example: Threading
+
+A bot that demonstrates reactive and proactive threading in Microsoft Teams channels.
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `test reply` | `ctx.reply()` — reactive threaded reply with visual quote |
+| `test send` | `ctx.send()` — reactive send to same thread, no quote |
+| `test proactive` | `app.reply()` — proactive threaded reply |
+| `test manual` | `to_thread_id()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
+| `help` | Shows available commands |
+
+## Notes
+
+- `test reply` and `test send` work in all scopes (1:1, group chat, channels)
+- `test proactive` works in all scopes — in channels it threads, in flat scopes it sends normally
+- `test manual` only works in channels and 1:1 chats since `to_thread_id()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+
+## Run
+
+```bash
+uv run python src/main.py
+```
+
+## Environment Variables
+
+Create a `.env` file:
+
+```
+CLIENT_ID=<your-azure-bot-app-id>
+CLIENT_SECRET=<your-azure-bot-app-secret>
+```

--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -9,14 +9,14 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 | `test reply` | `ctx.reply()` — reactive threaded reply with visual quote |
 | `test send` | `ctx.send()` — reactive send to same thread, no quote |
 | `test proactive` | `app.reply()` — proactive threaded reply |
-| `test manual` | `to_thread_id()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
+| `test manual` | `to_threaded_conversation_id()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
 | `help` | Shows available commands |
 
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
 - `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
-- `test manual` only works in channels and 1:1 chats since `to_thread_id()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+- `test manual` only works in channels and 1:1 chats since `to_threaded_conversation_id()` constructs a threaded conversation ID (group chats and meetings do not support threading)
 
 ## Run
 

--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -15,7 +15,7 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
-- `test proactive` works in all scopes — in channels it threads, in flat scopes it sends normally
+- `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
 - `test manual` only works in channels and 1:1 chats since `to_thread_id()` constructs a threaded conversation ID (group chats and meetings do not support threading)
 
 ## Run

--- a/examples/threading/pyproject.toml
+++ b/examples/threading/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "threading"
+version = "0.1.0"
+description = "Threading test bot"
+requires-python = ">=3.12,<3.15"
+dependencies = [
+    "dotenv>=0.9.9",
+    "microsoft-teams-apps",
+    "microsoft-teams-api",
+    "microsoft-teams-devtools"
+]
+
+[tool.uv.sources]
+microsoft-teams-apps = { workspace = true }

--- a/examples/threading/pyproject.toml
+++ b/examples/threading/pyproject.toml
@@ -6,8 +6,7 @@ requires-python = ">=3.12,<3.15"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",
-    "microsoft-teams-api",
-    "microsoft-teams-devtools"
+    "microsoft-teams-api"
 ]
 
 [tool.uv.sources]

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -15,7 +15,7 @@ app = App()
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Handle message activities."""
-    await ctx.send(TypingActivityInput())
+    await ctx.reply(TypingActivityInput())
 
     text = (ctx.activity.text or "").lower()
     conversation_id = ctx.conversation_ref.conversation.id

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -53,7 +53,8 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     if "test manual" in text:
         # to_thread_id() is only valid for conversations that support threading
         base = conversation_id.split(";")[0]
-        if not base.endswith("@thread.tacv2") and not base.endswith("@thread.skype") and not base.endswith("@unq.gbl.spaces"):
+        threading_suffixes = ("@thread.tacv2", "@thread.skype", "@unq.gbl.spaces")
+        if not any(base.endswith(s) for s in threading_suffixes):
             await ctx.reply("This command doesn't support threading in this conversation type.")
             return
         thread_id = to_thread_id(conversation_id, thread_root_id)

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -1,0 +1,81 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+
+from microsoft_teams.api import MessageActivity
+from microsoft_teams.api.activities.typing import TypingActivityInput
+from microsoft_teams.apps import ActivityContext, App, to_thread_id
+
+app = App()
+
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]):
+    """Handle message activities."""
+    await ctx.reply(TypingActivityInput())
+
+    text = (ctx.activity.text or "").lower()
+    conversation_id = ctx.conversation_ref.conversation.id
+    message_id = ctx.activity.id
+
+    # When inside a thread, conversation_id contains ;messageid=<rootId>.
+    # Extract the root ID for threading; for top-level messages, use activity.id.
+    parts = conversation_id.split(";messageid=")
+    thread_root_id = parts[1] if len(parts) > 1 else message_id
+
+    # ============================================
+    # context.reply() — reactive threaded reply
+    # ============================================
+    if "test reply" in text:
+        await ctx.reply("This is a threaded reply to your message.")
+        return
+
+    # ============================================
+    # context.send() — reactive send to same thread
+    # ============================================
+    if "test send" in text:
+        await ctx.send("This is sent to the same thread, without quoting.")
+        return
+
+    # ============================================
+    # app.reply() — proactive threaded reply
+    # ============================================
+    if "test proactive" in text:
+        await app.reply(conversation_id, thread_root_id, "This is a proactive threaded reply using app.reply().")
+        return
+
+    # ============================================
+    # to_thread_id() + app.send() — advanced manual control (channels only)
+    # ============================================
+    if "test manual" in text:
+        # to_thread_id() is only valid for conversations that support threading
+        base = conversation_id.split(";")[0]
+        if not base.endswith("@thread.tacv2") and not base.endswith("@thread.skype") and not base.endswith("@unq.gbl.spaces"):
+            await ctx.reply("This command doesn't support threading in this conversation type.")
+            return
+        thread_id = to_thread_id(conversation_id, thread_root_id)
+        await app.send(thread_id, "This was sent using to_thread_id() + app.send() for manual control.")
+        return
+
+    # ============================================
+    # Help / Default
+    # ============================================
+    if "help" in text:
+        await ctx.reply(
+            "**Threading Test Bot**\n\n"
+            "**Commands:**\n"
+            "- `test reply` - ctx.reply() reactive threaded reply\n"
+            "- `test send` - ctx.send() to same thread without quoting\n"
+            "- `test proactive` - app.reply() proactive threaded reply\n"
+            "- `test manual` - to_thread_id() + app.send() for advanced control"
+        )
+        return
+
+    await ctx.send('Say "help" for available commands.')
+
+
+if __name__ == "__main__":
+    asyncio.run(app.start())

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -7,7 +7,7 @@ import asyncio
 
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
-from microsoft_teams.apps import ActivityContext, App, to_thread_id
+from microsoft_teams.apps import ActivityContext, App, to_threaded_conversation_id
 
 app = App()
 
@@ -48,17 +48,17 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
         return
 
     # ============================================
-    # to_thread_id() + app.send() — advanced manual control (channels only)
+    # to_threaded_conversation_id() + app.send() — advanced manual control (channels only)
     # ============================================
     if "test manual" in text:
-        # to_thread_id() is only valid for conversations that support threading
+        # to_threaded_conversation_id() is only valid for conversations that support threading
         base = conversation_id.split(";")[0]
         threading_suffixes = ("@thread.tacv2", "@thread.skype", "@unq.gbl.spaces")
         if not any(base.endswith(s) for s in threading_suffixes):
             await ctx.reply("This command doesn't support threading in this conversation type.")
             return
-        thread_id = to_thread_id(conversation_id, thread_root_id)
-        await app.send(thread_id, "This was sent using to_thread_id() + app.send() for manual control.")
+        thread_id = to_threaded_conversation_id(conversation_id, thread_root_id)
+        await app.send(thread_id, "This was sent using to_threaded_conversation_id() + app.send() for manual control.")
         return
 
     # ============================================
@@ -71,7 +71,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             "- `test reply` - ctx.reply() reactive threaded reply\n"
             "- `test send` - ctx.send() to same thread without quoting\n"
             "- `test proactive` - app.reply() proactive threaded reply\n"
-            "- `test manual` - to_thread_id() + app.send() for advanced control"
+            "- `test manual` - to_threaded_conversation_id() + app.send() for advanced control"
         )
         return
 

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -15,7 +15,7 @@ app = App()
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Handle message activities."""
-    await ctx.reply(TypingActivityInput())
+    await ctx.send(TypingActivityInput())
 
     text = (ctx.activity.text or "").lower()
     conversation_id = ctx.conversation_ref.conversation.id

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -15,6 +15,7 @@ from .http_stream import HttpStream
 from .options import AppOptions
 from .plugins import *  # noqa: F401, F403
 from .routing import ActivityContext
+from .utils.thread import to_thread_id
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -27,6 +28,7 @@ __all__: list[str] = [
     "FastAPIAdapter",
     "HttpStream",
     "ActivityContext",
+    "to_thread_id",
 ]
 __all__.extend(auth.__all__)
 __all__.extend(events.__all__)

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -15,7 +15,7 @@ from .http_stream import HttpStream
 from .options import AppOptions
 from .plugins import *  # noqa: F401, F403
 from .routing import ActivityContext
-from .utils.thread import to_thread_id
+from .utils.thread import to_threaded_conversation_id
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -28,7 +28,7 @@ __all__: list[str] = [
     "FastAPIAdapter",
     "HttpStream",
     "ActivityContext",
-    "to_thread_id",
+    "to_threaded_conversation_id",
 ]
 __all__.extend(auth.__all__)
 __all__.extend(events.__all__)

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -363,7 +363,7 @@ class App(ActivityHandlerMixin):
             if not isinstance(message_id, str):
                 raise TypeError("message_id must be a string when activity is provided")
             target_id = (
-                to_threaded_conversation_id(conversation_id, cast(str, message_id))
+                to_threaded_conversation_id(conversation_id, message_id)
                 if supports_threading(conversation_id)
                 else conversation_id
             )

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -23,6 +23,7 @@ from microsoft_teams.api import (
     FederatedIdentityCredentials,
     ManagedIdentityCredentials,
     MessageActivityInput,
+    SentActivity,
     TokenCredentials,
     TokenProtocol,
 )
@@ -328,21 +329,21 @@ class App(ActivityHandlerMixin):
         conversation_id: str,
         message_id: str,
         activity: str | ActivityParams | AdaptiveCard,
-    ) -> Any: ...
+    ) -> SentActivity: ...
 
     @overload
     async def reply(
         self,
         conversation_id: str,
         message_id: str | ActivityParams | AdaptiveCard,
-    ) -> Any: ...
+    ) -> SentActivity: ...
 
     async def reply(  # type: ignore[reportInconsistentOverload]
         self,
         conversation_id: str,
         message_id: str | ActivityParams | AdaptiveCard = "",
         activity: str | ActivityParams | AdaptiveCard | None = None,
-    ) -> Any:
+    ) -> SentActivity:
         """Send an activity proactively to a conversation or channel thread.
 
         **3-arg form** ``reply(conversation_id, message_id, activity)``:

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -59,7 +59,7 @@ from .routing import ActivityHandlerMixin, ActivityRouter
 from .routing.activity_context import ActivityContext
 from .token_manager import TokenManager
 from .utils import create_graph_client
-from .utils.thread import supports_threading, to_thread_id
+from .utils.thread import supports_threading, to_threaded_conversation_id
 
 version = importlib.metadata.version("microsoft-teams-apps")
 
@@ -296,7 +296,7 @@ class App(ActivityHandlerMixin):
         """Send an activity proactively to a conversation.
 
         Sends to the exact conversation ID provided. For channel threads,
-        the conversation ID must include ``;messageid=`` - use :func:`to_thread_id`
+        the conversation ID must include ``;messageid=`` - use :func:`to_threaded_conversation_id`
         to construct it, or use :meth:`reply` which handles this automatically.
         """
 
@@ -363,7 +363,7 @@ class App(ActivityHandlerMixin):
             if not isinstance(message_id, str):
                 raise TypeError("message_id must be a string when activity is provided")
             target_id = (
-                to_thread_id(conversation_id, cast(str, message_id))
+                to_threaded_conversation_id(conversation_id, cast(str, message_id))
                 if supports_threading(conversation_id)
                 else conversation_id
             )

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -347,8 +347,8 @@ class App(ActivityHandlerMixin):
 
         **3-arg form** ``reply(conversation_id, message_id, activity)``:
         In channels, constructs a threaded conversation ID and sends to that thread.
-        In flat scopes (1:1, group chat, meetings), sends as a normal message -
-        the message ID is ignored.
+        In scopes that do not support threading (group chat, meetings), sends as a
+        normal message - the message ID is ignored.
 
         **2-arg form** ``reply(conversation_id, activity)``:
         Sends to the exact conversation ID provided - threaded if it contains
@@ -360,6 +360,8 @@ class App(ActivityHandlerMixin):
             activity: The activity to send (only in 3-arg form)
         """
         if activity is not None:
+            if not isinstance(message_id, str):
+                raise TypeError("message_id must be a string when activity is provided")
             target_id = (
                 to_thread_id(conversation_id, cast(str, message_id))
                 if supports_threading(conversation_id)

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -59,6 +59,7 @@ from .routing import ActivityHandlerMixin, ActivityRouter
 from .routing.activity_context import ActivityContext
 from .token_manager import TokenManager
 from .utils import create_graph_client
+from .utils.thread import supports_threading, to_thread_id
 
 version = importlib.metadata.version("microsoft-teams-apps")
 
@@ -292,7 +293,12 @@ class App(ActivityHandlerMixin):
             raise
 
     async def send(self, conversation_id: str, activity: str | ActivityParams | AdaptiveCard):
-        """Send an activity proactively."""
+        """Send an activity proactively to a conversation.
+
+        Sends to the exact conversation ID provided. For channel threads,
+        the conversation ID must include ``;messageid=`` - use :func:`to_thread_id`
+        to construct it, or use :meth:`reply` which handles this automatically.
+        """
 
         if not self._initialized:
             raise ValueError("app not initialized - call app.initialize() or app.start() first")
@@ -304,7 +310,7 @@ class App(ActivityHandlerMixin):
             channel_id="msteams",
             service_url=self.api.service_url,
             bot=Account(id=self.id),
-            conversation=ConversationAccount(id=conversation_id, conversation_type="personal"),
+            conversation=ConversationAccount(id=conversation_id),
         )
 
         if isinstance(activity, str):
@@ -315,6 +321,53 @@ class App(ActivityHandlerMixin):
             activity = activity
 
         return await self.activity_sender.send(activity, conversation_ref)
+
+    @overload
+    async def reply(
+        self,
+        conversation_id: str,
+        message_id: str,
+        activity: str | ActivityParams | AdaptiveCard,
+    ) -> Any: ...
+
+    @overload
+    async def reply(
+        self,
+        conversation_id: str,
+        message_id: str | ActivityParams | AdaptiveCard,
+    ) -> Any: ...
+
+    async def reply(  # type: ignore[reportInconsistentOverload]
+        self,
+        conversation_id: str,
+        message_id: str | ActivityParams | AdaptiveCard = "",
+        activity: str | ActivityParams | AdaptiveCard | None = None,
+    ) -> Any:
+        """Send an activity proactively to a conversation or channel thread.
+
+        **3-arg form** ``reply(conversation_id, message_id, activity)``:
+        In channels, constructs a threaded conversation ID and sends to that thread.
+        In flat scopes (1:1, group chat, meetings), sends as a normal message -
+        the message ID is ignored.
+
+        **2-arg form** ``reply(conversation_id, activity)``:
+        Sends to the exact conversation ID provided - threaded if it contains
+        ``;messageid=``, flat otherwise.
+
+        Args:
+            conversation_id: The channel or conversation ID
+            message_id: The thread root message ID (3-arg form) or the activity (2-arg form)
+            activity: The activity to send (only in 3-arg form)
+        """
+        if activity is not None:
+            target_id = (
+                to_thread_id(conversation_id, cast(str, message_id))
+                if supports_threading(conversation_id)
+                else conversation_id
+            )
+            return await self.send(target_id, activity)
+
+        return await self.send(conversation_id, message_id)
 
     def use(self, middleware: Callable[[ActivityContext[ActivityBase]], Awaitable[None]]) -> None:
         """Add middleware to run on all activities."""

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -161,12 +161,15 @@ class ActivityContext(Generic[T]):
         message: str | ActivityParams | AdaptiveCard,
         conversation_ref: Optional[ConversationReference] = None,
     ) -> SentActivity:
-        """
-        Send a message to the conversation.
+        """Send a message in the current conversation without quoting.
+
+        In channels, sends to the current thread. In flat scopes (1:1,
+        group chat, meetings), sends as a normal message.
+        To send with a visual quote of the inbound message, use :meth:`reply`.
 
         Args:
             message: The message to send, can be a string, ActivityParams, or AdaptiveCard
-            conversation_ref: Optional conversation reference to override the current conversation reference
+            conversation_ref: Optional conversation reference to send to a different conversation or thread
         """
         if isinstance(message, str):
             activity = MessageActivityInput(text=message)
@@ -180,7 +183,12 @@ class ActivityContext(Generic[T]):
         return res
 
     async def reply(self, input: str | ActivityParams) -> SentActivity:
-        """Send a reply to the activity."""
+        """Send a message in the current conversation with a visual quote of the inbound message.
+
+        In channels, sends to the current thread with a quoted reply.
+        In flat scopes, sends with a quoted reply.
+        To send without quoting, use :meth:`send`.
+        """
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         if isinstance(activity, MessageActivityInput):
             block_quote = self._build_block_quote_for_activity()

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -163,8 +163,8 @@ class ActivityContext(Generic[T]):
     ) -> SentActivity:
         """Send a message in the current conversation without quoting.
 
-        In channels, sends to the current thread. In flat scopes (1:1,
-        group chat, meetings), sends as a normal message.
+        In channels, sends to the current thread. In scopes that do not
+        support threading (group chat, meetings), sends as a normal message.
         To send with a visual quote of the inbound message, use :meth:`reply`.
 
         Args:
@@ -186,7 +186,7 @@ class ActivityContext(Generic[T]):
         """Send a message in the current conversation with a visual quote of the inbound message.
 
         In channels, sends to the current thread with a quoted reply.
-        In flat scopes, sends with a quoted reply.
+        In other scopes, sends with a quoted reply.
         To send without quoting, use :meth:`send`.
         """
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input

--- a/packages/apps/src/microsoft_teams/apps/utils/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/__init__.py
@@ -6,5 +6,6 @@ Licensed under the MIT License.
 from .activity_utils import extract_tenant_id
 from .graph import create_graph_client
 from .retry import RetryOptions, retry
+from .thread import to_thread_id
 
-__all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions"]
+__all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions", "to_thread_id"]

--- a/packages/apps/src/microsoft_teams/apps/utils/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/__init__.py
@@ -6,6 +6,6 @@ Licensed under the MIT License.
 from .activity_utils import extract_tenant_id
 from .graph import create_graph_client
 from .retry import RetryOptions, retry
-from .thread import to_thread_id
+from .thread import to_threaded_conversation_id
 
-__all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions", "to_thread_id"]
+__all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions", "to_threaded_conversation_id"]

--- a/packages/apps/src/microsoft_teams/apps/utils/thread.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/thread.py
@@ -3,8 +3,13 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+# Conversation ID suffixes that support threading.
+# Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
+# Group chats and meetings use @thread.v2 which does not support threading.
+THREADING_SUFFIXES = ("@thread.tacv2", "@thread.skype", "@unq.gbl.spaces")
 
-def to_thread_id(conversation_id: str, message_id: str) -> str:
+
+def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
     """Construct a threaded conversation ID by appending `;messageid={message_id}`
     to the conversation ID. This is the format APX uses to route messages
     to a specific thread.
@@ -28,8 +33,6 @@ def to_thread_id(conversation_id: str, message_id: str) -> str:
 
 
 # Check if a conversation ID represents a conversation that supports threading.
-# Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
-# Group chats and meetings use @thread.v2 which does not support threading.
 def supports_threading(conversation_id: str) -> bool:
     base = conversation_id.split(";")[0]
-    return base.endswith("@thread.tacv2") or base.endswith("@thread.skype") or base.endswith("@unq.gbl.spaces")
+    return any(base.endswith(s) for s in THREADING_SUFFIXES)

--- a/packages/apps/src/microsoft_teams/apps/utils/thread.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/thread.py
@@ -1,0 +1,35 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+
+def to_thread_id(conversation_id: str, message_id: str) -> str:
+    """Construct a threaded conversation ID by appending `;messageid={message_id}`
+    to the conversation ID. This is the format APX uses to route messages
+    to a specific thread.
+
+    Args:
+        conversation_id: The conversation to thread into (e.g. `19:abc@thread.skype`)
+        message_id: The thread root message ID (must be a non-zero numeric string)
+
+    Returns:
+        The threaded conversation ID (e.g. `19:abc@thread.skype;messageid=123`)
+    """
+    if not conversation_id:
+        raise ValueError("conversation_id must be a non-empty string")
+
+    if not message_id or not message_id.isdigit() or message_id == "0":
+        raise ValueError(f'Invalid message_id "{message_id}": must be a non-zero numeric value')
+
+    # Strip any existing ;messageid= suffix (mirrors APX's NormalizeConversationId)
+    base_id = conversation_id.split(";")[0]
+    return f"{base_id};messageid={message_id}"
+
+
+# Check if a conversation ID represents a conversation that supports threading.
+# Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
+# Group chats and meetings use @thread.v2 which does not support threading.
+def supports_threading(conversation_id: str) -> bool:
+    base = conversation_id.split(";")[0]
+    return base.endswith("@thread.tacv2") or base.endswith("@thread.skype") or base.endswith("@unq.gbl.spaces")

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -762,3 +762,54 @@ class TestApp:
 
         app.activity_sender.send.assert_called_once()
         assert result.id == "sent-activity-id"
+
+
+class TestAppReply:
+    """Test cases for App.reply() method."""
+
+    @pytest.fixture(scope="function")
+    def started_app(self):
+        options = AppOptions(client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+        app._initialized = True
+        app.activity_sender.send = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
+        return app
+
+    @pytest.mark.asyncio
+    async def test_reply_with_three_args_constructs_threaded_id(self, started_app):
+        await started_app.reply("19:abc@thread.skype", "1680000000000", "Hello thread")
+
+        started_app.activity_sender.send.assert_called_once()
+        _, ref = started_app.activity_sender.send.call_args[0]
+        assert ref.conversation.id == "19:abc@thread.skype;messageid=1680000000000"
+
+    @pytest.mark.asyncio
+    async def test_reply_with_two_args_passes_conversation_id_as_is(self, started_app):
+        await started_app.reply("19:abc@thread.skype", "Hello flat")
+
+        started_app.activity_sender.send.assert_called_once()
+        _, ref = started_app.activity_sender.send.call_args[0]
+        assert ref.conversation.id == "19:abc@thread.skype"
+
+    @pytest.mark.asyncio
+    async def test_reply_with_pre_constructed_threaded_id(self, started_app):
+        await started_app.reply("19:abc@thread.skype;messageid=123", "Hello")
+
+        started_app.activity_sender.send.assert_called_once()
+        _, ref = started_app.activity_sender.send.call_args[0]
+        assert ref.conversation.id == "19:abc@thread.skype;messageid=123"
+
+    @pytest.mark.asyncio
+    async def test_reply_with_invalid_message_id_raises(self, started_app):
+        with pytest.raises(ValueError, match="Invalid message_id"):
+            await started_app.reply("19:abc@thread.skype", "not-a-number", "Hello")
+
+    @pytest.mark.asyncio
+    async def test_reply_raises_when_not_initialized(self):
+        options = AppOptions(client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        with pytest.raises(ValueError, match="app not initialized"):
+            await app.reply("conv-id", "Hello")

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -4,42 +4,42 @@ Licensed under the MIT License.
 """
 
 import pytest
-from microsoft_teams.apps.utils.thread import supports_threading, to_thread_id
+from microsoft_teams.apps.utils.thread import supports_threading, to_threaded_conversation_id
 
 
-class TestToThreadId:
+class TestToThreadedConversationId:
     def test_constructs_threaded_conversation_id(self):
-        assert to_thread_id("19:abc@thread.skype", "1680000000000") == "19:abc@thread.skype;messageid=1680000000000"
+        assert to_threaded_conversation_id("19:abc@thread.skype", "1680000000000") == "19:abc@thread.skype;messageid=1680000000000"
 
     def test_works_with_different_conversation_id_formats(self):
-        assert to_thread_id("19:meeting_abc@thread.v2", "999") == "19:meeting_abc@thread.v2;messageid=999"
+        assert to_threaded_conversation_id("19:meeting_abc@thread.v2", "999") == "19:meeting_abc@thread.v2;messageid=999"
 
     def test_raises_on_empty_conversation_id(self):
         with pytest.raises(ValueError, match="conversation_id must be a non-empty string"):
-            to_thread_id("", "123")
+            to_threaded_conversation_id("", "123")
 
     def test_raises_on_empty_message_id(self):
         with pytest.raises(ValueError, match="Invalid message_id"):
-            to_thread_id("19:abc@thread.skype", "")
+            to_threaded_conversation_id("19:abc@thread.skype", "")
 
     def test_raises_on_zero_message_id(self):
         with pytest.raises(ValueError, match="Invalid message_id"):
-            to_thread_id("19:abc@thread.skype", "0")
+            to_threaded_conversation_id("19:abc@thread.skype", "0")
 
     def test_raises_on_non_numeric_message_id(self):
         with pytest.raises(ValueError, match="Invalid message_id"):
-            to_thread_id("19:abc@thread.skype", "abc")
+            to_threaded_conversation_id("19:abc@thread.skype", "abc")
 
     def test_raises_on_negative_message_id(self):
         with pytest.raises(ValueError, match="Invalid message_id"):
-            to_thread_id("19:abc@thread.skype", "-1")
+            to_threaded_conversation_id("19:abc@thread.skype", "-1")
 
     def test_raises_on_decimal_message_id(self):
         with pytest.raises(ValueError, match="Invalid message_id"):
-            to_thread_id("19:abc@thread.skype", "1.5")
+            to_threaded_conversation_id("19:abc@thread.skype", "1.5")
 
     def test_strips_existing_messageid_and_replaces_with_thread_root(self):
-        assert to_thread_id("19:abc@thread.skype;messageid=111", "222") == "19:abc@thread.skype;messageid=222"
+        assert to_threaded_conversation_id("19:abc@thread.skype;messageid=111", "222") == "19:abc@thread.skype;messageid=222"
 
 
 class TestSupportsThreading:

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import pytest
+from microsoft_teams.apps.utils.thread import to_thread_id
+
+
+class TestToThreadId:
+    def test_constructs_threaded_conversation_id(self):
+        assert to_thread_id("19:abc@thread.skype", "1680000000000") == "19:abc@thread.skype;messageid=1680000000000"
+
+    def test_works_with_different_conversation_id_formats(self):
+        assert to_thread_id("19:meeting_abc@thread.v2", "999") == "19:meeting_abc@thread.v2;messageid=999"
+
+    def test_raises_on_empty_conversation_id(self):
+        with pytest.raises(ValueError, match="conversation_id must be a non-empty string"):
+            to_thread_id("", "123")
+
+    def test_raises_on_empty_message_id(self):
+        with pytest.raises(ValueError, match="Invalid message_id"):
+            to_thread_id("19:abc@thread.skype", "")
+
+    def test_raises_on_zero_message_id(self):
+        with pytest.raises(ValueError, match="Invalid message_id"):
+            to_thread_id("19:abc@thread.skype", "0")
+
+    def test_raises_on_non_numeric_message_id(self):
+        with pytest.raises(ValueError, match="Invalid message_id"):
+            to_thread_id("19:abc@thread.skype", "abc")
+
+    def test_raises_on_negative_message_id(self):
+        with pytest.raises(ValueError, match="Invalid message_id"):
+            to_thread_id("19:abc@thread.skype", "-1")
+
+    def test_raises_on_decimal_message_id(self):
+        with pytest.raises(ValueError, match="Invalid message_id"):
+            to_thread_id("19:abc@thread.skype", "1.5")
+
+    def test_strips_existing_messageid_and_replaces_with_thread_root(self):
+        assert to_thread_id("19:abc@thread.skype;messageid=111", "222") == "19:abc@thread.skype;messageid=222"

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 import pytest
-from microsoft_teams.apps.utils.thread import to_thread_id
+from microsoft_teams.apps.utils.thread import supports_threading, to_thread_id
 
 
 class TestToThreadId:
@@ -40,3 +40,29 @@ class TestToThreadId:
 
     def test_strips_existing_messageid_and_replaces_with_thread_root(self):
         assert to_thread_id("19:abc@thread.skype;messageid=111", "222") == "19:abc@thread.skype;messageid=222"
+
+
+class TestSupportsThreading:
+    def test_tacv2_returns_true(self):
+        assert supports_threading("19:abc@thread.tacv2") is True
+
+    def test_skype_returns_true(self):
+        assert supports_threading("19:abc@thread.skype") is True
+
+    def test_unq_gbl_spaces_returns_true(self):
+        assert supports_threading("19:abc@unq.gbl.spaces") is True
+
+    def test_thread_v2_returns_false(self):
+        assert supports_threading("19:meeting_abc@thread.v2") is False
+
+    def test_tacv2_with_messageid_suffix_returns_true(self):
+        assert supports_threading("19:abc@thread.tacv2;messageid=123") is True
+
+    def test_skype_with_messageid_suffix_returns_true(self):
+        assert supports_threading("19:abc@thread.skype;messageid=456") is True
+
+    def test_unq_gbl_spaces_with_messageid_suffix_returns_true(self):
+        assert supports_threading("19:abc@unq.gbl.spaces;messageid=789") is True
+
+    def test_thread_v2_with_messageid_suffix_returns_false(self):
+        assert supports_threading("19:meeting_abc@thread.v2;messageid=111") is False

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -9,10 +9,12 @@ from microsoft_teams.apps.utils.thread import supports_threading, to_threaded_co
 
 class TestToThreadedConversationId:
     def test_constructs_threaded_conversation_id(self):
-        assert to_threaded_conversation_id("19:abc@thread.skype", "1680000000000") == "19:abc@thread.skype;messageid=1680000000000"
+        result = to_threaded_conversation_id("19:abc@thread.skype", "1680000000000")
+        assert result == "19:abc@thread.skype;messageid=1680000000000"
 
     def test_works_with_different_conversation_id_formats(self):
-        assert to_threaded_conversation_id("19:meeting_abc@thread.v2", "999") == "19:meeting_abc@thread.v2;messageid=999"
+        result = to_threaded_conversation_id("19:meeting_abc@thread.v2", "999")
+        assert result == "19:meeting_abc@thread.v2;messageid=999"
 
     def test_raises_on_empty_conversation_id(self):
         with pytest.raises(ValueError, match="conversation_id must be a non-empty string"):
@@ -39,7 +41,8 @@ class TestToThreadedConversationId:
             to_threaded_conversation_id("19:abc@thread.skype", "1.5")
 
     def test_strips_existing_messageid_and_replaces_with_thread_root(self):
-        assert to_threaded_conversation_id("19:abc@thread.skype;messageid=111", "222") == "19:abc@thread.skype;messageid=222"
+        result = to_threaded_conversation_id("19:abc@thread.skype;messageid=111", "222")
+        assert result == "19:abc@thread.skype;messageid=222"
 
 
 class TestSupportsThreading:

--- a/uv.lock
+++ b/uv.lock
@@ -3289,7 +3289,6 @@ dependencies = [
     { name = "dotenv" },
     { name = "microsoft-teams-api" },
     { name = "microsoft-teams-apps" },
-    { name = "microsoft-teams-devtools" },
 ]
 
 [package.metadata]
@@ -3297,7 +3296,6 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "microsoft-teams-api", editable = "packages/api" },
     { name = "microsoft-teams-apps", editable = "packages/apps" },
-    { name = "microsoft-teams-devtools", editable = "packages/devtools" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,7 @@ members = [
     "stream",
     "tab",
     "targeted-messages",
+    "threading",
 ]
 
 [manifest.dependency-groups]
@@ -3278,6 +3279,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
+name = "threading"
+version = "0.1.0"
+source = { virtual = "examples/threading" }
+dependencies = [
+    { name = "dotenv" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+    { name = "microsoft-teams-devtools" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
+    { name = "microsoft-teams-devtools", editable = "packages/devtools" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `app.reply(conversation_id, message_id, activity)` for proactive thread sends
- Add `to_threaded_conversation_id()` helper and `supports_threading()` internal guard
- Update `context.send()` and `context.reply()` doc comments
- Add threading example bot

## Test plan
- [x] Unit tests for `to_threaded_conversation_id()` (9 tests), `supports_threading()` (8 tests), and `app.reply()` (5 tests)
- [x] E2E: All commands tested in 1:1 and channel (top-level + existing thread)
- [x] All tests passed, `poe check` clean, pyright 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)