### PR TITLE
Support suggested actions on streamed messages

### DIFF
--- a/examples/ai-test/README.md
+++ b/examples/ai-test/README.md
@@ -55,6 +55,8 @@ From Teams, DevTools, or your test client, use any of the following commands to 
 | Memory management      | `memory clear`                          | Clears conversation memory                                |
 | Feedback collection    | `feedback demo`                         | Demonstrates message feedback with like/dislike buttons   |
 | Feedback statistics    | `feedback stats <message_id>`           | Shows feedback summary for a specific message             |
+| Suggested prompts      | `suggested-prompt message`              | AI response with suggested action buttons                 |
+| Suggested prompts      | `suggested-prompt stream`               | Streamed AI response with suggested action buttons        |
 | Stateful interactions  | `<any other message>`                   | Shows persistent conversation memory across interactions  |
 
 ## Features Demonstrated
@@ -74,6 +76,7 @@ From Teams, DevTools, or your test client, use any of the following commands to 
 ### Advanced Features
 
 - **Streaming responses** - Real-time response streaming with group/1:1 handling
+- **Suggested prompts** - Suggested action buttons on both regular and streamed messages
 - **Memory management** - Per-conversation memory with manual clearing
 - **Custom plugins** - AI plugin system with lifecycle hooks
 - **Citations** - Position-based citations with proper formatting
@@ -96,6 +99,7 @@ The sample follows a modular architecture:
   - `memory_management.py` - Stateful conversation handling
   - `citations.py` - Citation demo functionality
   - `plugins.py` - Custom AI plugin implementation
+  - `suggested_prompts.py` - Shared suggested action prompts
   - `feedback_management.py` - Message feedback collection and storage
 
 This structure mirrors the TypeScript AI test implementation for consistency across language implementations.

--- a/examples/ai-test/src/handlers/memory_management.py
+++ b/examples/ai-test/src/handlers/memory_management.py
@@ -5,17 +5,10 @@ Licensed under the MIT License.
 
 from microsoft_teams.ai import ChatPrompt, ListMemory
 from microsoft_teams.ai.ai_model import AIModel
-from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
+from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext
 
-SUGGESTED_PROMPTS = SuggestedActions(
-    to=[],
-    actions=[
-        CardAction(type=CardActionType.IM_BACK, title="Tell me a joke", value="Tell me a joke"),
-        CardAction(type=CardActionType.IM_BACK, title="What's the weather?", value="weather"),
-        CardAction(type=CardActionType.IM_BACK, title="Stream a story", value="stream Tell me a short story"),
-    ],
-)
+from .suggested_prompts import SUGGESTED_PROMPTS
 
 # Simple in-memory store for conversation histories
 # In your application, it may be a good idea to use a more

--- a/examples/ai-test/src/handlers/memory_management.py
+++ b/examples/ai-test/src/handlers/memory_management.py
@@ -8,8 +8,6 @@ from microsoft_teams.ai.ai_model import AIModel
 from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext
 
-from .suggested_prompts import SUGGESTED_PROMPTS
-
 # Simple in-memory store for conversation histories
 # In your application, it may be a good idea to use a more
 # persistent store backed by a database or other storage solution
@@ -42,11 +40,7 @@ async def handle_stateful_conversation(model: AIModel, ctx: ActivityContext[Mess
     )
 
     if chat_result.response.content:
-        message = (
-            MessageActivityInput(text=chat_result.response.content)
-            .add_ai_generated()
-            .with_suggested_actions(SUGGESTED_PROMPTS)
-        )
+        message = MessageActivityInput(text=chat_result.response.content).add_ai_generated()
         await ctx.send(message)
     else:
         await ctx.reply("I did not generate a response.")

--- a/examples/ai-test/src/handlers/memory_management.py
+++ b/examples/ai-test/src/handlers/memory_management.py
@@ -5,8 +5,17 @@ Licensed under the MIT License.
 
 from microsoft_teams.ai import ChatPrompt, ListMemory
 from microsoft_teams.ai.ai_model import AIModel
-from microsoft_teams.api import MessageActivity, MessageActivityInput
+from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
 from microsoft_teams.apps import ActivityContext
+
+SUGGESTED_PROMPTS = SuggestedActions(
+    to=[],
+    actions=[
+        CardAction(type=CardActionType.IM_BACK, title="Tell me a joke", value="Tell me a joke"),
+        CardAction(type=CardActionType.IM_BACK, title="What's the weather?", value="weather"),
+        CardAction(type=CardActionType.IM_BACK, title="Stream a story", value="stream Tell me a short story"),
+    ],
+)
 
 # Simple in-memory store for conversation histories
 # In your application, it may be a good idea to use a more
@@ -40,7 +49,11 @@ async def handle_stateful_conversation(model: AIModel, ctx: ActivityContext[Mess
     )
 
     if chat_result.response.content:
-        message = MessageActivityInput(text=chat_result.response.content).add_ai_generated()
+        message = (
+            MessageActivityInput(text=chat_result.response.content)
+            .add_ai_generated()
+            .with_suggested_actions(SUGGESTED_PROMPTS)
+        )
         await ctx.send(message)
     else:
         await ctx.reply("I did not generate a response.")

--- a/examples/ai-test/src/handlers/suggested_prompts.py
+++ b/examples/ai-test/src/handlers/suggested_prompts.py
@@ -1,0 +1,15 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from microsoft_teams.api import CardAction, CardActionType, SuggestedActions
+
+SUGGESTED_PROMPTS = SuggestedActions(
+    to=[],
+    actions=[
+        CardAction(type=CardActionType.IM_BACK, title="Tell me a joke", value="Tell me a joke"),
+        CardAction(type=CardActionType.IM_BACK, title="What's the weather?", value="weather"),
+        CardAction(type=CardActionType.IM_BACK, title="Stream a story", value="stream Tell me a short story"),
+    ],
+)

--- a/examples/ai-test/src/main.py
+++ b/examples/ai-test/src/main.py
@@ -23,7 +23,7 @@ from handlers.feedback_management import (
 )
 from handlers.memory_management import clear_conversation_memory
 from microsoft_teams.ai import ChatPrompt
-from microsoft_teams.api import MessageActivity, MessageActivityInput
+from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
 from microsoft_teams.api.activities.invoke.message.submit_action import MessageSubmitActionInvokeActivity
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.devtools import DevToolsPlugin
@@ -56,6 +56,15 @@ completions_model = OpenAICompletionsAIModel(
 responses_model = OpenAIResponsesAIModel(
     model=AZURE_OPENAI_MODEL,
     stateful=True,
+)
+
+SUGGESTED_PROMPTS = SuggestedActions(
+    to=[],
+    actions=[
+        CardAction(type=CardActionType.IM_BACK, title="Tell me a joke", value="Tell me a joke"),
+        CardAction(type=CardActionType.IM_BACK, title="What's the weather?", value="weather"),
+        CardAction(type=CardActionType.IM_BACK, title="Stream a story", value="stream Tell me a short story"),
+    ],
 )
 
 # Global state
@@ -102,21 +111,13 @@ async def handle_streaming(ctx: ActivityContext[MessageActivity]):
         query = match.group(1).strip()
 
         prompt = ChatPrompt(current_model)
-        chat_result = await prompt.send(
+        await prompt.send(
             input=query,
             instructions="You are a friendly assistant who responds in extremely verbose language",
             on_chunk=lambda chunk: ctx.stream.emit(chunk) if hasattr(ctx, "stream") else None,
         )
 
-        if hasattr(ctx.activity.conversation, "is_group") and ctx.activity.conversation.is_group:
-            # Group chat - send final response
-            if chat_result.response.content:
-                message = MessageActivityInput(text=chat_result.response.content).add_ai_generated()
-                await ctx.send(message)
-        else:
-            # 1:1 chat - streaming handled above
-            if hasattr(ctx, "stream"):
-                ctx.stream.emit(MessageActivityInput().add_ai_generated())
+        ctx.stream.emit(MessageActivityInput().add_ai_generated().with_suggested_actions(SUGGESTED_PROMPTS))
 
 
 # Utility commands

--- a/examples/ai-test/src/main.py
+++ b/examples/ai-test/src/main.py
@@ -22,8 +22,9 @@ from handlers.feedback_management import (
     initialize_feedback_storage,
 )
 from handlers.memory_management import clear_conversation_memory
+from handlers.suggested_prompts import SUGGESTED_PROMPTS
 from microsoft_teams.ai import ChatPrompt
-from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
+from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.api.activities.invoke.message.submit_action import MessageSubmitActionInvokeActivity
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.devtools import DevToolsPlugin
@@ -56,15 +57,6 @@ completions_model = OpenAICompletionsAIModel(
 responses_model = OpenAIResponsesAIModel(
     model=AZURE_OPENAI_MODEL,
     stateful=True,
-)
-
-SUGGESTED_PROMPTS = SuggestedActions(
-    to=[],
-    actions=[
-        CardAction(type=CardActionType.IM_BACK, title="Tell me a joke", value="Tell me a joke"),
-        CardAction(type=CardActionType.IM_BACK, title="What's the weather?", value="weather"),
-        CardAction(type=CardActionType.IM_BACK, title="Stream a story", value="stream Tell me a short story"),
-    ],
 )
 
 # Global state
@@ -111,13 +103,22 @@ async def handle_streaming(ctx: ActivityContext[MessageActivity]):
         query = match.group(1).strip()
 
         prompt = ChatPrompt(current_model)
-        await prompt.send(
+        chat_result = await prompt.send(
             input=query,
             instructions="You are a friendly assistant who responds in extremely verbose language",
             on_chunk=lambda chunk: ctx.stream.emit(chunk) if hasattr(ctx, "stream") else None,
         )
 
-        ctx.stream.emit(MessageActivityInput().add_ai_generated().with_suggested_actions(SUGGESTED_PROMPTS))
+        if hasattr(ctx.activity.conversation, "is_group") and ctx.activity.conversation.is_group:
+            if chat_result.response.content:
+                message = (
+                    MessageActivityInput(text=chat_result.response.content)
+                    .add_ai_generated()
+                    .with_suggested_actions(SUGGESTED_PROMPTS)
+                )
+                await ctx.send(message)
+        else:
+            ctx.stream.emit(MessageActivityInput().add_ai_generated().with_suggested_actions(SUGGESTED_PROMPTS))
 
 
 # Utility commands

--- a/examples/ai-test/src/main.py
+++ b/examples/ai-test/src/main.py
@@ -111,14 +111,41 @@ async def handle_streaming(ctx: ActivityContext[MessageActivity]):
 
         if hasattr(ctx.activity.conversation, "is_group") and ctx.activity.conversation.is_group:
             if chat_result.response.content:
-                message = (
-                    MessageActivityInput(text=chat_result.response.content)
-                    .add_ai_generated()
-                    .with_suggested_actions(SUGGESTED_PROMPTS)
-                )
+                message = MessageActivityInput(text=chat_result.response.content).add_ai_generated()
                 await ctx.send(message)
         else:
-            ctx.stream.emit(MessageActivityInput().add_ai_generated().with_suggested_actions(SUGGESTED_PROMPTS))
+            ctx.stream.emit(MessageActivityInput().add_ai_generated())
+
+
+# Suggested prompts demos
+@app.on_message_pattern(re.compile(r"^suggested-prompt message$", re.IGNORECASE))
+async def handle_suggested_prompt_message(ctx: ActivityContext[MessageActivity]):
+    """Demo suggested prompts on a regular message."""
+    prompt = ChatPrompt(current_model)
+    chat_result = await prompt.send(
+        input="Tell me something interesting", instructions="You are a friendly assistant. Keep it brief."
+    )
+
+    if chat_result.response.content:
+        message = (
+            MessageActivityInput(text=chat_result.response.content)
+            .add_ai_generated()
+            .with_suggested_actions(SUGGESTED_PROMPTS)
+        )
+        await ctx.send(message)
+
+
+@app.on_message_pattern(re.compile(r"^suggested-prompt stream$", re.IGNORECASE))
+async def handle_suggested_prompt_stream(ctx: ActivityContext[MessageActivity]):
+    """Demo suggested prompts on a streamed message."""
+    prompt = ChatPrompt(current_model)
+    await prompt.send(
+        input="Tell me something interesting",
+        instructions="You are a friendly assistant who responds in extremely verbose language",
+        on_chunk=lambda chunk: ctx.stream.emit(chunk),
+    )
+
+    ctx.stream.emit(MessageActivityInput().add_ai_generated().with_suggested_actions(SUGGESTED_PROMPTS))
 
 
 # Utility commands

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -6,7 +6,7 @@ Licensed under the MIT License.
 import asyncio
 from random import random
 
-from microsoft_teams.api import MessageActivity
+from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
 from microsoft_teams.apps import ActivityContext, App
 
 app = App()
@@ -35,10 +35,22 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
     # Stream messages with delays using ctx.stream.emit
     for message in STREAM_MESSAGES:
-        # Add some randomness to timing
         await asyncio.sleep(random())
-
         ctx.stream.emit(message)
+
+    # Add suggested actions to the final message
+    ctx.stream.emit(
+        MessageActivityInput().with_suggested_actions(
+            SuggestedActions(
+                to=[ctx.activity.from_.id],
+                actions=[
+                    CardAction(type=CardActionType.IM_BACK, title="Run again", value="Run again"),
+                    CardAction(type=CardActionType.IM_BACK, title="Show status", value="Show status"),
+                    CardAction(type=CardActionType.IM_BACK, title="Help", value="Help"),
+                ],
+            )
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -164,8 +164,13 @@ class HttpStream(StreamerProtocol):
             logger.warning("Timeout while waiting for _id to be set and queue to be empty, cannot close stream")
             return None
 
-        if self._text == "" and (not self._final_activity or not self._final_activity.attachments):
-            logger.warning("no text or attachments to send, cannot close stream")
+        has_content = (
+            self._text != ""
+            or (self._final_activity and self._final_activity.attachments)
+            or (self._final_activity and self._final_activity.suggested_actions)
+        )
+        if not has_content:
+            logger.warning("no text, attachments, or suggested actions to send, cannot close stream")
             return None
 
         # Build final message from the last emitted MessageActivityInput (last wins)

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -6,15 +6,13 @@ Licensed under the MIT License.
 import asyncio
 import logging
 from collections import deque
-from typing import Awaitable, Callable, List, Optional, Union
+from typing import Awaitable, Callable, Optional, Union
 
 from httpx import HTTPStatusError
 from microsoft_teams.api import (
     ApiClient,
-    Attachment,
     ChannelData,
     ConversationReference,
-    Entity,
     MessageActivityInput,
     SentActivity,
     TypingActivityInput,
@@ -71,9 +69,8 @@ class HttpStream(StreamerProtocol):
         self._index = 1
         self._id: Optional[str] = None
         self._text: str = ""
-        self._attachments: List[Attachment] = []
         self._channel_data: ChannelData = ChannelData()
-        self._entities: List[Entity] = []
+        self._final_activity: Optional[MessageActivityInput] = None
         self._queue: deque[Union[MessageActivityInput, TypingActivityInput, str]] = deque()
 
     @property
@@ -167,14 +164,14 @@ class HttpStream(StreamerProtocol):
             logger.warning("Timeout while waiting for _id to be set and queue to be empty, cannot close stream")
             return None
 
-        if self._text == "" and self._attachments == []:
+        if self._text == "" and (not self._final_activity or not self._final_activity.attachments):
             logger.warning("no text or attachments to send, cannot close stream")
             return None
 
-        # Build final message
+        # Build final message from the last emitted MessageActivityInput (last wins)
         assert self._id is not None, "ID should be set by this point"
-        activity = MessageActivityInput(text=self._text).with_id(self._id).with_channel_data(self._channel_data)
-        activity.add_attachments(*self._attachments).add_entities(*self._entities).add_stream_final()
+        activity = self._final_activity or MessageActivityInput()
+        activity.with_text(self._text).with_id(self._id).with_channel_data(self._channel_data).add_stream_final()
 
         res = await retry(lambda: self._send(activity), options=RetryOptions())
 
@@ -205,7 +202,7 @@ class HttpStream(StreamerProtocol):
                 self._timeout.cancel()
                 self._timeout = None
 
-            informative_updates: List[TypingActivityInput] = []
+            informative_updates: list[TypingActivityInput] = []
             start_length = len(self._queue)
 
             while self._queue:
@@ -213,8 +210,7 @@ class HttpStream(StreamerProtocol):
 
                 if isinstance(activity, MessageActivityInput):
                     self._text += activity.text or ""
-                    self._attachments.extend(activity.attachments or [])
-                    self._entities.extend(activity.entities or [])
+                    self._final_activity = activity
                 if isinstance(activity, (MessageActivityInput, TypingActivityInput)) and activity.channel_data:
                     merged = {**self._channel_data.model_dump(), **activity.channel_data.model_dump()}
                     self._channel_data = ChannelData(**merged)

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -12,9 +12,13 @@ from httpx import HTTPStatusError, Request, Response
 from microsoft_teams.api import (
     Account,
     ApiClient,
+    CardAction,
+    CardActionType,
     ConversationAccount,
     ConversationReference,
+    MessageActivityInput,
     SentActivity,
+    SuggestedActions,
     TypingActivityInput,
 )
 from microsoft_teams.apps import HttpStream
@@ -327,3 +331,98 @@ class TestHttpStream:
 
         result = await stream.close()
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_final_activity_last_wins(self, mock_api_client, conversation_reference, patch_loop_call_later):
+        """When multiple MessageActivityInputs are emitted, the last one's non-text fields are used."""
+        loop = asyncio.get_running_loop()
+        patcher, scheduled = patch_loop_call_later(loop)
+
+        update_call_count = 0
+        original_create = mock_api_client.conversations.activities().create
+
+        async def mock_send(activity):
+            nonlocal update_call_count
+            if (
+                hasattr(activity, "id")
+                and activity.id
+                and not any(e.type == "streaminfo" for e in (activity.entities or []))
+            ):
+                update_call_count += 1
+                return SentActivity(id=activity.id, activity_params=activity)
+            return await original_create(activity)
+
+        mock_api_client.conversations.activities().create = mock_send
+        mock_api_client.conversations.activities().update = mock_send
+
+        with patcher:
+            stream = HttpStream(mock_api_client, conversation_reference)
+
+            early_actions = SuggestedActions(
+                to=[],
+                actions=[CardAction(type=CardActionType.IM_BACK, title="Early", value="early")],
+            )
+            late_actions = SuggestedActions(
+                to=[],
+                actions=[CardAction(type=CardActionType.IM_BACK, title="Late", value="late")],
+            )
+
+            stream.emit("Hello ")
+            stream.emit(MessageActivityInput(text="world").with_suggested_actions(early_actions))
+            stream.emit(MessageActivityInput().add_ai_generated().with_suggested_actions(late_actions))
+            await asyncio.sleep(0)
+            await self._run_scheduled_flushes(scheduled)
+
+            result = await stream.close()
+            assert result is not None
+            # The final activity should use the last emitted MessageActivityInput's suggested actions
+            assert result.activity_params.suggested_actions == late_actions
+            # Text should be accumulated from all emits
+            assert result.activity_params.text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_suggested_actions_on_final_message(
+        self, mock_api_client, conversation_reference, patch_loop_call_later
+    ):
+        """Suggested actions emitted mid-stream appear on the final close() message."""
+        loop = asyncio.get_running_loop()
+        patcher, scheduled = patch_loop_call_later(loop)
+
+        update_call_count = 0
+        original_create = mock_api_client.conversations.activities().create
+
+        async def mock_send(activity):
+            nonlocal update_call_count
+            if (
+                hasattr(activity, "id")
+                and activity.id
+                and not any(e.type == "streaminfo" for e in (activity.entities or []))
+            ):
+                update_call_count += 1
+                return SentActivity(id=activity.id, activity_params=activity)
+            return await original_create(activity)
+
+        mock_api_client.conversations.activities().create = mock_send
+        mock_api_client.conversations.activities().update = mock_send
+
+        with patcher:
+            stream = HttpStream(mock_api_client, conversation_reference)
+
+            actions = SuggestedActions(
+                to=[],
+                actions=[
+                    CardAction(type=CardActionType.IM_BACK, title="Option A", value="a"),
+                    CardAction(type=CardActionType.IM_BACK, title="Option B", value="b"),
+                ],
+            )
+
+            stream.emit("Streaming content...")
+            stream.emit(MessageActivityInput().with_suggested_actions(actions))
+            await asyncio.sleep(0)
+            await self._run_scheduled_flushes(scheduled)
+
+            result = await stream.close()
+            assert result is not None
+            assert result.activity_params.suggested_actions is not None
+            assert len(result.activity_params.suggested_actions.actions) == 2
+            assert result.activity_params.suggested_actions.actions[0].title == "Option A"


### PR DESCRIPTION
## Summary
- Simplify `HttpStream` to save the last emitted `MessageActivityInput` as the final message template (last wins), instead of separately accumulating attachments, entities, and suggested actions
- Text is still accumulated across all emits; everything else comes from the last `MessageActivityInput`
- Add suggested action buttons to stream and ai-test examples

## Test plan
- [ ] Run `poe test` — all 11 `test_http_stream.py` tests pass
- [ ] Deploy stream example, verify suggested actions appear after stream completes
- [ ] Deploy ai-test example, verify suggested actions on both streaming and non-streaming responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)