### PR TITLE
Remove supports_threading guard from app.reply()

### DIFF
--- a/examples/threading/README.md
+++ b/examples/threading/README.md
@@ -9,14 +9,15 @@ A bot that demonstrates reactive and proactive threading in Microsoft Teams chan
 | `test reply` | `ctx.reply()` — reactive threaded reply with visual quote |
 | `test send` | `ctx.send()` — reactive send to same thread, no quote |
 | `test proactive` | `app.reply()` — proactive threaded reply |
-| `test manual` | `to_threaded_conversation_id()` + `app.send()` — advanced manual control (channels and 1:1 chats only) |
+| `test manual` | `to_threaded_conversation_id()` + `app.send()` — advanced manual control |
 | `help` | Shows available commands |
 
 ## Notes
 
 - `test reply` and `test send` work in all scopes (1:1, group chat, channels)
-- `test proactive` works in all scopes — in channels it threads, in non-threading scopes it sends normally
-- `test manual` only works in channels and 1:1 chats since `to_threaded_conversation_id()` constructs a threaded conversation ID (group chats and meetings do not support threading)
+- `test proactive` constructs a threaded conversation ID and sends to that thread
+- `test manual` does the same using `to_threaded_conversation_id()` + `app.send()` directly
+- `test proactive` and `test manual` will return a service error in meetings, which do not currently support threading
 
 ## Run
 

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -48,15 +48,9 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
         return
 
     # ============================================
-    # to_threaded_conversation_id() + app.send() — advanced manual control (channels only)
+    # to_threaded_conversation_id() + app.send() — advanced manual control
     # ============================================
     if "test manual" in text:
-        # to_threaded_conversation_id() is only valid for conversations that support threading
-        base = conversation_id.split(";")[0]
-        threading_suffixes = ("@thread.tacv2", "@thread.skype", "@unq.gbl.spaces")
-        if not any(base.endswith(s) for s in threading_suffixes):
-            await ctx.reply("This command doesn't support threading in this conversation type.")
-            return
         thread_id = to_threaded_conversation_id(conversation_id, thread_root_id)
         await app.send(thread_id, "This was sent using to_threaded_conversation_id() + app.send() for manual control.")
         return

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -60,7 +60,7 @@ from .routing import ActivityHandlerMixin, ActivityRouter
 from .routing.activity_context import ActivityContext
 from .token_manager import TokenManager
 from .utils import create_graph_client
-from .utils.thread import supports_threading, to_threaded_conversation_id
+from .utils.thread import to_threaded_conversation_id
 
 version = importlib.metadata.version("microsoft-teams-apps")
 
@@ -344,31 +344,25 @@ class App(ActivityHandlerMixin):
         message_id: str | ActivityParams | AdaptiveCard = "",
         activity: str | ActivityParams | AdaptiveCard | None = None,
     ) -> SentActivity:
-        """Send an activity proactively to a conversation or channel thread.
+        """Send an activity proactively as a threaded reply.
 
         **3-arg form** ``reply(conversation_id, message_id, activity)``:
-        In channels, constructs a threaded conversation ID and sends to that thread.
-        In scopes that do not support threading (group chat, meetings), sends as a
-        normal message - the message ID is ignored.
+        Constructs a threaded conversation ID via :func:`to_threaded_conversation_id`
+        and sends to that thread.
 
         **2-arg form** ``reply(conversation_id, activity)``:
         Sends to the exact conversation ID provided - threaded if it contains
         ``;messageid=``, flat otherwise.
 
         Args:
-            conversation_id: The channel or conversation ID
+            conversation_id: The conversation ID
             message_id: The thread root message ID (3-arg form) or the activity (2-arg form)
             activity: The activity to send (only in 3-arg form)
         """
         if activity is not None:
             if not isinstance(message_id, str):
                 raise TypeError("message_id must be a string when activity is provided")
-            target_id = (
-                to_threaded_conversation_id(conversation_id, message_id)
-                if supports_threading(conversation_id)
-                else conversation_id
-            )
-            return await self.send(target_id, activity)
+            return await self.send(to_threaded_conversation_id(conversation_id, message_id), activity)
 
         return await self.send(conversation_id, message_id)
 

--- a/packages/apps/src/microsoft_teams/apps/utils/thread.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/thread.py
@@ -3,11 +3,6 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-# Conversation ID suffixes that support threading.
-# Channels use @thread.tacv2 or @thread.skype, 1:1 chats use @unq.gbl.spaces.
-# Group chats and meetings use @thread.v2 which does not support threading.
-THREADING_SUFFIXES = ("@thread.tacv2", "@thread.skype", "@unq.gbl.spaces")
-
 
 def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
     """Construct a threaded conversation ID by appending `;messageid={message_id}`
@@ -30,9 +25,3 @@ def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
     # Strip any existing ;messageid= suffix (mirrors APX's NormalizeConversationId)
     base_id = conversation_id.split(";")[0]
     return f"{base_id};messageid={message_id}"
-
-
-# Check if a conversation ID represents a conversation that supports threading.
-def supports_threading(conversation_id: str) -> bool:
-    base = conversation_id.split(";")[0]
-    return any(base.endswith(s) for s in THREADING_SUFFIXES)

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 import pytest
-from microsoft_teams.apps.utils.thread import supports_threading, to_threaded_conversation_id
+from microsoft_teams.apps.utils.thread import to_threaded_conversation_id
 
 
 class TestToThreadedConversationId:
@@ -43,29 +43,3 @@ class TestToThreadedConversationId:
     def test_strips_existing_messageid_and_replaces_with_thread_root(self):
         result = to_threaded_conversation_id("19:abc@thread.skype;messageid=111", "222")
         assert result == "19:abc@thread.skype;messageid=222"
-
-
-class TestSupportsThreading:
-    def test_tacv2_returns_true(self):
-        assert supports_threading("19:abc@thread.tacv2") is True
-
-    def test_skype_returns_true(self):
-        assert supports_threading("19:abc@thread.skype") is True
-
-    def test_unq_gbl_spaces_returns_true(self):
-        assert supports_threading("19:abc@unq.gbl.spaces") is True
-
-    def test_thread_v2_returns_false(self):
-        assert supports_threading("19:meeting_abc@thread.v2") is False
-
-    def test_tacv2_with_messageid_suffix_returns_true(self):
-        assert supports_threading("19:abc@thread.tacv2;messageid=123") is True
-
-    def test_skype_with_messageid_suffix_returns_true(self):
-        assert supports_threading("19:abc@thread.skype;messageid=456") is True
-
-    def test_unq_gbl_spaces_with_messageid_suffix_returns_true(self):
-        assert supports_threading("19:abc@unq.gbl.spaces;messageid=789") is True
-
-    def test_thread_v2_with_messageid_suffix_returns_false(self):
-        assert supports_threading("19:meeting_abc@thread.v2;messageid=111") is False


### PR DESCRIPTION
## Summary
- Remove `supports_threading()` guard from `app.reply()` 3-arg form -- always calls `to_threaded_conversation_id()` when message_id is provided
- Remove `supports_threading()` function and `THREADING_SUFFIXES` constant (dead code)
- Remove `supports_threading` tests
- Update `test manual` example to remove conversation type guard
- Threading support is now determined by the service, not the SDK

**Why:** Threading support is expanding (channels, 1:1, group chats). Maintaining an allowlist of conversation ID suffixes creates a maintenance burden and can block developers from using newly supported scopes until the SDK is updated.

## Test plan
- [x] ruff check: all passed
- [x] pyright: 0 errors
- [x] pytest: 630 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)