### PR TITLE
Local tool simplification 

### DIFF
--- a/examples/ai-agentframework/README.md
+++ b/examples/ai-agentframework/README.md
@@ -3,7 +3,7 @@
 
 # Teams AI Agent (agent-framework)
 
-A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and Azure OpenAI. Supports streaming responses, inline citations from MCP search results, per-conversation memory, and a adaptive-card local tool alongside remote MCP servers.
+A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and Azure OpenAI. Supports streaming responses, inline citations from MCP search results, per-conversation memory, and an Adaptive Card local tool alongside remote MCP servers.
 
 ## Features
 

--- a/examples/ai-agentframework/README.md
+++ b/examples/ai-agentframework/README.md
@@ -74,7 +74,7 @@ uv run src/main.py
 
 Once the bot is running in a Teams chat, try:
 
-- `Hi! My name is Alex !` — agent calls `send_welcome_card` and greets you with an Adaptive Card
+- `Hi! My name is Alex!` — agent calls `send_welcome_card` and greets you with an Adaptive Card
 - `How do I stream in teams.py?` — searches Microsoft Learn docs (MCP) with inline citations
 - `How do I send a proactive message in teams.py?` — searches Microsoft Learn docs (MCP) with inline citations
 

--- a/examples/ai-agentframework/README.md
+++ b/examples/ai-agentframework/README.md
@@ -3,20 +3,20 @@
 
 # Teams AI Agent (agent-framework)
 
-A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and Azure OpenAI. Supports streaming responses, inline citations from MCP search results, per-conversation memory, and Microsoft Graph-backed local tools alongside remote MCP servers.
+A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and Azure OpenAI. Supports streaming responses, inline citations from MCP search results, per-conversation memory, and a adaptive-card local tool alongside remote MCP servers.
 
 ## Features
 
 - **Streaming responses** — text streams token-by-token into Teams as the model generates it
 - **Citations** — sources from MCP search tools are attached as clickable references in the reply
 - **Conversation memory** — each conversation maintains its own session so the agent remembers context across turns
-- **AI-generated label + feedback** — replies include the Teams "AI-generated" label and thumbs up/down feedback buttons; clicking a reaction opens a custom Adaptive Card form for additional feedback
-- **Local tools** — Microsoft Graph-backed tools for org directory lookups, org hierarchy, team membership, and presence
+- **AI-generated label + custom feedback** — replies include the Teams "AI-generated" label and thumbs up/down feedback buttons; clicking a reaction opens a custom Adaptive Card form for additional feedback
+- **Welcome card tool** — a local `@tool` the agent calls to greet users with an Adaptive Card
 - **MCP tools** — remote tool servers: Microsoft Learn docs search
 
 ## Prerequisites
 
-- Python >= 3.12, < 3.15 
+- Python >= 3.12, < 3.15
 - UV >= 0.8.11
 - An Azure OpenAI resource with a deployed model
 - A Teams bot registration (App ID + password)
@@ -31,28 +31,17 @@ AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
 AZURE_OPENAI_MODEL=<deployment-name>
 AZURE_OPENAI_API_KEY=<api-key>
 
-# Teams bot credentials — also used by Microsoft Graph local tools
+# Teams bot credentials
 CLIENT_ID=<app-id>
 TENANT_ID=<tenant-id>
 CLIENT_SECRET=<client-secret>
 ```
 
-`AZURE_OPENAI_MODEL` is the **deployment name** of your model, not the base model name. The bot's Service Principal (`CLIENT_ID`) is used for Teams and Microsoft Graph.
-
-### Microsoft Graph permissions
-
-The local tools call Graph as the bot's service principal (app-only). Grant these **Application** permissions to the app registration in the Azure portal (**Entra ID > App registrations > your app > API permissions**), then click **Grant admin consent**:
-
-| Permission             | Used by                                |
-| ---------------------- | -------------------------------------- |
-| `User.Read.All`        | `find_people`, `get_org_context`       |
-| `Group.Read.All`       | `list_team_members`                    |
-| `GroupMember.Read.All` | `list_team_members`                    |
-| `Presence.Read.All`    | `get_presence`                         |
+`AZURE_OPENAI_MODEL` is the **deployment name** of your model, not the base model name.
 
 ### Using a Service Principal for Azure OpenAI instead of an API key
 
-`agent.py` authenticates to Azure OpenAI with `AZURE_OPENAI_API_KEY`. If you'd rather use the bot's Service Principal (so the same identity powers Teams, Graph, and Azure OpenAI), swap `api_key` for a `ClientSecretCredential`:
+`agent.py` authenticates to Azure OpenAI with `AZURE_OPENAI_API_KEY`. If you'd rather use the bot's Service Principal, swap `api_key` for a `ClientSecretCredential`:
 
 ```python
 from azure.identity import ClientSecretCredential
@@ -85,22 +74,19 @@ uv run src/main.py
 
 Once the bot is running in a Teams chat, try:
 
-- `Who is <colleague's name>?` — directory lookup via `find_people`
-- `Who does <colleague> report to?` — manager + direct reports via `get_org_context`
-- `Who's on the <team-name> team?` — group membership via `list_team_members`
-- `Is <colleague> available right now?` — Teams presence via `get_presence`
-- `Find the manager of <colleague> and tell me if they're online` — chains `get_org_context` and `get_presence`
-- `How do I send a proactive message in teams.py?` — searches Microsoft Learn docs (MCP)
+- `Hi! My name is Alex !` — agent calls `send_welcome_card` and greets you with an Adaptive Card
+- `How do I stream in teams.py?` — searches Microsoft Learn docs (MCP) with inline citations
+- `How do I send a proactive message in teams.py?` — searches Microsoft Learn docs (MCP) with inline citations
 
 ## Architecture
 
 ```
-main.py          — Teams App, message handler, streaming, citations
+main.py          — Teams App, message handler, streaming, citations, card attachment
 agent.py         — Agent setup, OpenAIChatClient, AgentMiddleware
-local_tools.py   — @tool functions (Microsoft Graph-backed directory lookups)
+local_tools.py   — @tool functions (welcome card)
 mcp_tools.py     — MCP server declarations (remote tool servers)
 ```
 
-`main.py` streams every response with `agent.run(..., stream=True)`. Citations collected during tool calls are attached to the final activity.
+`main.py` streams every response with `agent.run(..., stream=True)`. Citations collected during tool calls, and any cards queued by local tools, are attached to the final activity.
 
 `AgentMiddleware` intercepts every tool call to log it and extract citation URLs from MCP search results. Citations are filtered to only those the model actually referenced with `[N]` markers before being attached to the Teams reply.

--- a/examples/ai-agentframework/pyproject.toml
+++ b/examples/ai-agentframework/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",
     "agent-framework",
-    "msgraph-sdk>=1.0.0",
 ]
 
 [tool.uv.sources]

--- a/examples/ai-agentframework/src/agent.py
+++ b/examples/ai-agentframework/src/agent.py
@@ -81,6 +81,8 @@ client = OpenAIChatClient(
 INSTRUCTIONS = """\
 You are a helpful Teams assistant with access to local tools and remote MCP servers.
 
+Always greet new users with a welcome card.
+
 When you use information from a search tool, cite your sources inline using the "citation" value \
 provided in each result (e.g. [1], [2]).
 Do not add a references or sources list at the end of your response — citations are displayed separately in the UI.

--- a/examples/ai-agentframework/src/local_tools.py
+++ b/examples/ai-agentframework/src/local_tools.py
@@ -3,141 +3,38 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-import asyncio
+from contextvars import ContextVar
 from typing import Annotated
 
 from agent_framework import tool
-from microsoft_teams.apps import App
-from msgraph.generated.groups.groups_request_builder import (  # pyright: ignore[reportMissingTypeStubs]
-    GroupsRequestBuilder,  # pyright: ignore[reportMissingTypeStubs]
-)
-from msgraph.generated.users.users_request_builder import UsersRequestBuilder  # pyright: ignore[reportMissingTypeStubs]
-from msgraph.graph_service_client import GraphServiceClient
+from microsoft_teams.cards import AdaptiveCard, Fact, FactSet, TextBlock
 from pydantic import Field
 
-_graph: GraphServiceClient | None = None
-
-
-def bind_app(app: App) -> None:
-    """Wire the App's Graph client into the tools. Call once after App() construction."""
-    global _graph
-    _graph = app.get_app_graph()
-
-
-def _require_graph() -> GraphServiceClient:
-    if _graph is None:
-        raise RuntimeError("local_tools.bind_app(app) must be called before invoking tools")
-    return _graph
-
-
-def _person(user: object) -> dict[str, str]:
-    return {
-        "id": getattr(user, "id", None) or "",
-        "name": getattr(user, "display_name", None) or "",
-        "upn": getattr(user, "user_principal_name", None) or "",
-        "email": getattr(user, "mail", None) or getattr(user, "user_principal_name", None) or "",
-        "title": getattr(user, "job_title", None) or "",
-        "department": getattr(user, "department", None) or "",
-        "office": getattr(user, "office_location", None) or "",
-    }
+# Per-turn card bucket. main.py sets a fresh list at the start of each handler so concurrent turns
+# don't clobber each other. The tool appends into whichever list is active in its context.
+pending_cards: ContextVar[list[AdaptiveCard]] = ContextVar("pending_cards")
 
 
 @tool
-async def find_people(
-    query: Annotated[str, Field(description="Name, email, job title, or department fragment")],
-    limit: Annotated[int, Field(description="Max results", ge=1, le=25)] = 5,
-) -> list[dict[str, str]] | str:
-    """Search the org directory. Returns up to `limit` people with name, email, title, department, office."""
-    safe = query.replace('"', "")
-    params = UsersRequestBuilder.UsersRequestBuilderGetQueryParameters(
-        search=f'"displayName:{safe}" OR "mail:{safe}" OR "jobTitle:{safe}" OR "department:{safe}"',
-        select=["id", "displayName", "mail", "userPrincipalName", "jobTitle", "department", "officeLocation"],
-        top=limit,
+async def send_welcome_card(
+    greeting: Annotated[str, Field(description="The greeting message for the user. eg Hello, John! or Welcome!")],
+) -> str:
+    """Attach a welcome card with a capabilities overview."""
+    card = AdaptiveCard(version="1.5").with_body(
+        [
+            TextBlock(text=f"{greeting}! Here are some things I can do:", size="Large", weight="Bolder", wrap=True),
+            FactSet(
+                facts=[
+                    Fact(title="Docs", value="Microsoft Learn search with citations"),
+                    Fact(title="Streaming", value="Token-by-token replies"),
+                    Fact(title="Memory", value="Per-conversation context"),
+                    Fact(title="Feedback", value="Thumbs up/down with a follow-up form"),
+                ]
+            ),
+        ]
     )
-    config = UsersRequestBuilder.UsersRequestBuilderGetRequestConfiguration(query_parameters=params)
-    config.headers.add("ConsistencyLevel", "eventual")
-    result = await _require_graph().users.get(request_configuration=config)
-    if not result or not result.value:
-        return f"No people found matching {query!r}."
-    return [_person(u) for u in result.value]
+    pending_cards.get().append(card)
+    return "Card attached."
 
 
-@tool
-async def get_org_context(
-    user: Annotated[
-        str,
-        Field(description="User's Graph id (preferred), UPN, or email. Prefer the id from find_people results."),
-    ],
-) -> dict[str, object] | str:
-    """Get a person's profile, their manager, and their direct reports in one call."""
-    user_item = _require_graph().users.by_user_id(user)
-    profile, manager, reports = await asyncio.gather(
-        user_item.get(),
-        user_item.manager.get(),
-        user_item.direct_reports.get(),
-        return_exceptions=True,
-    )
-
-    if isinstance(profile, BaseException) or not profile:
-        return f"Could not get profile for {user!r}: {profile}"
-
-    return {
-        "profile": _person(profile),
-        "manager": _person(manager) if manager and not isinstance(manager, BaseException) else None,
-        "direct_reports": (
-            [_person(u) for u in reports.value]  # type: ignore
-            if reports and not isinstance(reports, BaseException) and getattr(reports, "value", None)
-            else []
-        ),
-    }
-
-
-@tool
-async def list_team_members(
-    team_or_group_name: Annotated[str, Field(description="Display name of a Team or M365 group")],
-    limit: Annotated[int, Field(description="Max members to return", ge=1, le=50)] = 20,
-) -> list[dict[str, str]] | str:
-    """Resolve a Team/M365 group by display name and return its members."""
-    safe = team_or_group_name.replace("'", "''")
-    group_params = GroupsRequestBuilder.GroupsRequestBuilderGetQueryParameters(
-        filter=f"displayName eq '{safe}'",
-        select=["id", "displayName"],
-        top=1,
-    )
-    group_config = GroupsRequestBuilder.GroupsRequestBuilderGetRequestConfiguration(query_parameters=group_params)
-    groups = await _require_graph().groups.get(request_configuration=group_config)
-    if not groups or not groups.value:
-        return f"No group found with display name {team_or_group_name!r}."
-
-    group_id = groups.value[0].id
-    if not group_id:
-        return f"Group {team_or_group_name!r} has no id."
-
-    members = await _require_graph().groups.by_group_id(group_id).members.get()
-    if not members or not members.value:
-        return f"Group {team_or_group_name!r} has no members."
-
-    return [_person(m) for m in members.value[:limit]]
-
-
-@tool
-async def get_presence(
-    user: Annotated[
-        str,
-        Field(description="User's Graph id (preferred), UPN, or email. Prefer the id from find_people results."),
-    ],
-) -> dict[str, str] | str:
-    """Get a person's current Teams presence (availability + activity)."""
-    try:
-        presence = await _require_graph().users.by_user_id(user).presence.get()
-    except Exception as e:
-        return f"Could not get presence for {user!r}: {e}"
-    if not presence:
-        return f"No presence information for {user!r}."
-    return {
-        "availability": presence.availability or "Unknown",
-        "activity": presence.activity or "Unknown",
-    }
-
-
-tools = [find_people, get_org_context, list_team_members, get_presence]
+tools = [send_welcome_card]

--- a/examples/ai-agentframework/src/local_tools.py
+++ b/examples/ai-agentframework/src/local_tools.py
@@ -22,7 +22,7 @@ async def send_welcome_card(
     """Attach a welcome card with a capabilities overview."""
     card = AdaptiveCard(version="1.5").with_body(
         [
-            TextBlock(text=f"{greeting}! Here are some things I can do:", size="Large", weight="Bolder", wrap=True),
+            TextBlock(text=f"{greeting} Here are some things I can do:", size="Large", weight="Bolder", wrap=True),
             FactSet(
                 facts=[
                     Fact(title="Docs", value="Microsoft Learn search with citations"),

--- a/examples/ai-agentframework/src/local_tools.py
+++ b/examples/ai-agentframework/src/local_tools.py
@@ -12,7 +12,7 @@ from pydantic import Field
 
 # Per-turn card bucket. main.py sets a fresh list at the start of each handler so concurrent turns
 # don't clobber each other. The tool appends into whichever list is active in its context.
-pending_cards: ContextVar[list[AdaptiveCard]] = ContextVar("pending_cards")
+pending_cards: ContextVar[list[AdaptiveCard] | None] = ContextVar("pending_cards", default=None)
 
 
 @tool
@@ -33,7 +33,10 @@ async def send_welcome_card(
             ),
         ]
     )
-    pending_cards.get().append(card)
+    cards = pending_cards.get()
+    if cards is None:
+        return "No active turn context; card could not be attached."
+    cards.append(card)
     return "Card attached."
 
 

--- a/examples/ai-agentframework/src/local_tools.py
+++ b/examples/ai-agentframework/src/local_tools.py
@@ -20,6 +20,9 @@ async def send_welcome_card(
     greeting: Annotated[str, Field(description="The greeting message for the user. eg Hello, John! or Welcome!")],
 ) -> str:
     """Attach a welcome card with a capabilities overview."""
+    cards = pending_cards.get()
+    if cards is None:
+        return "No active turn context; card could not be attached."
     card = AdaptiveCard(version="1.5").with_body(
         [
             TextBlock(text=f"{greeting} Here are some things I can do:", size="Large", weight="Bolder", wrap=True),
@@ -33,9 +36,7 @@ async def send_welcome_card(
             ),
         ]
     )
-    cards = pending_cards.get()
-    if cards is None:
-        return "No active turn context; card could not be attached."
+
     cards.append(card)
     return "Card attached."
 

--- a/examples/ai-agentframework/src/main.py
+++ b/examples/ai-agentframework/src/main.py
@@ -10,7 +10,7 @@ from os import getenv
 
 from agent import agent, tool_logger
 from agent_framework import AgentSession
-from local_tools import bind_app
+from local_tools import pending_cards
 from microsoft_teams.api import (
     AdaptiveCardAttachment,
     CardAction,
@@ -29,14 +29,11 @@ from microsoft_teams.api import (
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.cards import AdaptiveCard, SubmitAction, TextBlock, TextInput
 
-# LOG_LEVEL controls third-party noise. Defaults to WARNING.
-logging.basicConfig(level=getenv("LOG_LEVEL", "WARNING").upper())
+logging.basicConfig(level=getenv("LOG_LEVEL", "INFO").upper())
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 # App is the Teams bot host for this example.
 app = App()
-bind_app(app)
 
 # Per-conversation sessions preserve message history across turns.
 _sessions: dict[str, AgentSession] = {}
@@ -59,6 +56,8 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
     text = ctx.activity.text or ""
     tool_logger.citations = {}
+    cards: list[AdaptiveCard] = []
+    pending_cards.set(cards)
 
     full_text = ""
     async for chunk in agent.run(text, session=_sessions[conversation_id], stream=True):
@@ -66,13 +65,17 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             ctx.stream.emit(chunk.text)
             full_text += chunk.text
 
-    reply = _build_reply(full_text, ctx)
+    reply = _build_reply(full_text, cards, ctx)
     ctx.stream.emit(reply)
 
 
-def _build_reply(full_text: str, ctx: ActivityContext[MessageActivity]) -> MessageActivityInput:
+def _build_reply(
+    full_text: str, cards: list[AdaptiveCard], ctx: ActivityContext[MessageActivity]
+) -> MessageActivityInput:
     # add_ai_generated() adds the "AI-generated" label; add_feedback() enables thumbs up/down.
     reply = MessageActivityInput().add_ai_generated().add_feedback(mode="custom")
+    for card in cards:
+        reply.add_card(card)
     _attach_citations(reply, full_text)
     reply.with_suggested_actions(SuggestedActions(to=[ctx.activity.from_.id], actions=_SUGGESTED_PROMPTS))
     return reply

--- a/uv.lock
+++ b/uv.lock
@@ -483,7 +483,6 @@ dependencies = [
     { name = "agent-framework" },
     { name = "dotenv" },
     { name = "microsoft-teams-apps" },
-    { name = "msgraph-sdk" },
 ]
 
 [package.metadata]
@@ -491,7 +490,6 @@ requires-dist = [
     { name = "agent-framework" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "microsoft-teams-apps", editable = "packages/apps" },
-    { name = "msgraph-sdk", specifier = ">=1.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Looking back, this sample is severely overloaded compared to the other examples. Simplifying the local tools to have one simple welcome adaptive card. I think we should include graph and oauth capabilities with more thought at a later time in a more complex sample.

**Key changes include:**

### Local tool simplification and onboarding improvements
- Replaced all Microsoft Graph-backed local tools (`find_people`, `get_org_context`, `list_team_members`, `get_presence`) with a single local tool, `send_welcome_card`, which attaches a capabilities overview Adaptive Card to greet users. The new tool uses a `ContextVar` to safely manage per-turn card attachments. (`src/local_tools.py`)
- Updated the agent's system prompt to always greet new users with a welcome card, aligning agent behavior with the new onboarding experience. (`src/agent.py`)

### Documentation and environment updates
- Updated the `README.md` to reflect the removal of Microsoft Graph tools, focusing on the new welcome card tool and simplifying instructions for environment variables and prerequisites. Microsoft Graph permissions and related setup steps have been removed. (`README.md`)
- Removed the `msgraph-sdk` dependency from `pyproject.toml` since Graph-backed tools are no longer used. (`pyproject.toml`)

### Codebase cleanup and integration
- Removed all code related to binding the Teams App to Microsoft Graph and cleaned up logging configuration. Updated the message handling flow to collect and attach Adaptive Cards generated by tools to the Teams reply. 