### PR TITLE
fix: route `app.get_app_graph` + `ctx.*_graph` to sovereign endpoints via `cloud.graph_scope`

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -142,6 +142,7 @@ class App(ActivityHandlerMixin):
             self._token_manager,
             self.options.api_client_settings,
             self.activity_sender,
+            self.cloud,
         )
         self.event_manager = EventManager(self._events)
         self.activity_processor.event_manager = self.event_manager
@@ -616,4 +617,4 @@ class App(ActivityHandlerMixin):
             ImportError: If the graph dependencies are not installed.
 
         """
-        return create_graph_client(lambda: self._get_graph_token(tenant_id))
+        return create_graph_client(lambda: self._get_graph_token(tenant_id), cloud=self.cloud)

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -18,6 +18,7 @@ from microsoft_teams.api import (
     TokenProtocol,
     is_invoke_response,
 )
+from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 from microsoft_teams.api.clients.user.params import GetUserTokenParams
 from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Client, ClientOptions, LocalStorage, Storage
@@ -49,6 +50,7 @@ class ActivityProcessor:
         token_manager: TokenManager,
         api_client_settings: Optional[ApiClientSettings],
         activity_sender: ActivitySender,
+        cloud: CloudEnvironment,
     ) -> None:
         self.router = router
         self.id = id
@@ -58,6 +60,7 @@ class ActivityProcessor:
         self.token_manager = token_manager
         self.api_client_settings = api_client_settings
         self.activity_sender = activity_sender
+        self.cloud = cloud
 
         # This will be set after the EventManager is initialized due to
         # a circular dependency
@@ -126,6 +129,7 @@ class ActivityProcessor:
             self.default_connection_name,
             activity_sender=self.activity_sender,
             app_token=lambda: self.token_manager.get_graph_token(tenant_id),
+            cloud=self.cloud,
         )
 
         send = activityCtx.send

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -18,7 +18,7 @@ from microsoft_teams.api import (
     TokenProtocol,
     is_invoke_response,
 )
-from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 from microsoft_teams.api.clients.user.params import GetUserTokenParams
 from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Client, ClientOptions, LocalStorage, Storage
@@ -50,7 +50,7 @@ class ActivityProcessor:
         token_manager: TokenManager,
         api_client_settings: Optional[ApiClientSettings],
         activity_sender: ActivitySender,
-        cloud: CloudEnvironment,
+        cloud: CloudEnvironment = PUBLIC,
     ) -> None:
         self.router = router
         self.id = id

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -27,6 +27,7 @@ from microsoft_teams.api import (
     TokenExchangeState,
     TokenPostResource,
 )
+from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 from microsoft_teams.api.models.attachment.card_attachment import (
     OAuthCardAttachment,
     card_attachment,
@@ -83,6 +84,7 @@ class ActivityContext(Generic[T]):
         connection_name: str,
         activity_sender: ActivitySender,
         app_token: Token,
+        cloud: CloudEnvironment,
     ):
         self.activity = activity
         self.app_id = app_id
@@ -93,6 +95,7 @@ class ActivityContext(Generic[T]):
         self.user_token = user_token
         self.connection_name = connection_name
         self.is_signed_in = is_signed_in
+        self.cloud = cloud
         self._activity_sender = activity_sender
         self._app_token = app_token
         self.stream = activity_sender.create_stream(conversation_ref)
@@ -123,7 +126,7 @@ class ActivityContext(Generic[T]):
         if self._user_graph is None:
             try:
                 user_token = JsonWebToken(self.user_token)
-                self._user_graph = create_graph_client(user_token)
+                self._user_graph = create_graph_client(user_token, cloud=self.cloud)
             except ImportError:
                 raise
             except Exception as e:
@@ -147,7 +150,7 @@ class ActivityContext(Generic[T]):
         """
         if self._app_graph is None:
             try:
-                self._app_graph = create_graph_client(self._app_token)
+                self._app_graph = create_graph_client(self._app_token, cloud=self.cloud)
             except ImportError:
                 raise
             except Exception as e:

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -27,7 +27,7 @@ from microsoft_teams.api import (
     TokenExchangeState,
     TokenPostResource,
 )
-from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
+from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 from microsoft_teams.api.models.attachment.card_attachment import (
     OAuthCardAttachment,
     card_attachment,
@@ -84,7 +84,7 @@ class ActivityContext(Generic[T]):
         connection_name: str,
         activity_sender: ActivitySender,
         app_token: Token,
-        cloud: CloudEnvironment,
+        cloud: CloudEnvironment = PUBLIC,
     ):
         self.activity = activity
         self.app_id = app_id

--- a/packages/apps/src/microsoft_teams/apps/utils/graph.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/graph.py
@@ -3,15 +3,51 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import logging
+import re
+from typing import Optional
+
+from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 from microsoft_teams.common.http.client_token import Token
 
+logger = logging.getLogger(__name__)
 
-def create_graph_client(token: Token):
-    """Lazy import and create a Graph client with the given token."""
+# Extracts scheme + host (+ optional port) from a URL-like scope such as
+# "https://graph.microsoft.us/.default" -> "https://graph.microsoft.us".
+_GRAPH_BASE_URL_RE = re.compile(r"^(https?://[^/]+)", re.IGNORECASE)
+
+
+def _derive_graph_base_url(cloud: Optional[CloudEnvironment]) -> Optional[str]:
+    """Derive the Graph API base URL from a cloud's graph_scope, or None if unavailable."""
+    if cloud is None:
+        return None
+    scope = (cloud.graph_scope or "").strip()
+    if not scope:
+        return None
+    match = _GRAPH_BASE_URL_RE.match(scope)
+    if match is None:
+        logger.warning(
+            "graph_scope %r is not a URL; Graph calls will route to the public cloud. "
+            "Set graph_scope to an 'https://<host>/.default' value to route to the correct Graph endpoint.",
+            scope,
+        )
+        return None
+    return match.group(1)
+
+
+def create_graph_client(token: Token, cloud: Optional[CloudEnvironment] = None):
+    """Lazy import and create a Graph client with the given token.
+
+    Args:
+        token: The token used to authenticate Graph requests.
+        cloud: Optional cloud environment. When provided (and non-None), the Graph client
+            routes HTTP calls to the cloud's Graph endpoint derived from ``graph_scope``.
+            When ``None``, the public Graph endpoint is used.
+    """
     try:
         from microsoft_teams.graph import get_graph_client
 
-        return get_graph_client(token)
+        return get_graph_client(token, base_url=_derive_graph_base_url(cloud))
     except ImportError as exc:
         raise ImportError(
             "Graph functionality not available. Install with 'pip install microsoft-teams-apps[graph]'"

--- a/packages/apps/src/microsoft_teams/apps/utils/graph.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/graph.py
@@ -21,7 +21,7 @@ def _derive_graph_base_url(cloud: Optional[CloudEnvironment]) -> Optional[str]:
     """Derive the Graph API base URL from a cloud's graph_scope, or None if unavailable."""
     if cloud is None:
         return None
-    scope = (cloud.graph_scope or "").strip()
+    scope = cloud.graph_scope.strip()
     if not scope:
         return None
     match = _GRAPH_BASE_URL_RE.match(scope)

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -314,6 +314,52 @@ class TestActivityContextUserGraph:
             with pytest.raises(RuntimeError, match="Failed to create user graph client"):
                 _ = ctx.user_graph
 
+    def test_user_graph_returns_client_when_signed_in_with_token(self) -> None:
+        """user_graph returns the created Graph client on success."""
+        mock_graph_client = MagicMock()
+        ctx, _ = _create_activity_context(is_signed_in=True, user_token="header.payload.sig")
+
+        with (
+            patch("microsoft_teams.apps.routing.activity_context.JsonWebToken", return_value=MagicMock()),
+            patch(
+                "microsoft_teams.apps.routing.activity_context.create_graph_client",
+                return_value=mock_graph_client,
+            ),
+        ):
+            assert ctx.user_graph is mock_graph_client
+
+    def test_user_graph_returns_cached_client_on_second_access(self) -> None:
+        """user_graph caches the client on first call (lazy initialization)."""
+        mock_graph_client = MagicMock()
+        ctx, _ = _create_activity_context(is_signed_in=True, user_token="header.payload.sig")
+
+        with (
+            patch("microsoft_teams.apps.routing.activity_context.JsonWebToken", return_value=MagicMock()),
+            patch(
+                "microsoft_teams.apps.routing.activity_context.create_graph_client",
+                return_value=mock_graph_client,
+            ) as mock_factory,
+        ):
+            first = ctx.user_graph
+            second = ctx.user_graph
+
+        assert first is second
+        mock_factory.assert_called_once()
+
+    def test_user_graph_re_raises_import_error_without_wrapping(self) -> None:
+        """user_graph re-raises ImportError directly (does not wrap in RuntimeError)."""
+        ctx, _ = _create_activity_context(is_signed_in=True, user_token="header.payload.sig")
+
+        with (
+            patch("microsoft_teams.apps.routing.activity_context.JsonWebToken", return_value=MagicMock()),
+            patch(
+                "microsoft_teams.apps.routing.activity_context.create_graph_client",
+                side_effect=ImportError("graph not installed"),
+            ),
+        ):
+            with pytest.raises(ImportError, match="graph not installed"):
+                _ = ctx.user_graph
+
 
 class TestActivityContextAppGraph:
     """Tests for ActivityContext.app_graph property."""
@@ -368,9 +414,151 @@ class TestActivityContextSignIn:
         assert result == "existing-token-value"
         ctx.api.users.token.get.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_sign_in_sends_oauth_card_when_no_existing_token(self) -> None:
+        """sign_in falls through to OAuth card flow when token API fails, returns None."""
+        mock_activity = MagicMock()
+        mock_activity.channel_id = "msteams"
+        mock_activity.from_.id = "user-001"
+        mock_activity.conversation.is_group = False
+
+        ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        ctx.api.users.token.get = AsyncMock(side_effect=Exception("no token"))
+
+        resource_response = MagicMock()
+        resource_response.token_exchange_resource = MagicMock()
+        resource_response.token_post_resource = MagicMock()
+        resource_response.sign_in_link = "https://login.example.com"
+        ctx.api.bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.MessageActivityInput"),
+            patch("microsoft_teams.apps.routing.activity_context.card_attachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCardAttachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCard"),
+            patch("microsoft_teams.apps.routing.activity_context.CardAction"),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+        ):
+            result = await ctx.sign_in()
+
+        assert result is None
+        ctx.api.bots.sign_in.get_resource.assert_called_once()
+        assert mock_sender.send.called
+
+    @pytest.mark.asyncio
+    async def test_sign_in_creates_one_on_one_conversation_for_group_chat(self) -> None:
+        """For group conversations, sign_in creates a 1:1 conversation before sending the OAuth card."""
+        mock_activity = MagicMock()
+        mock_activity.channel_id = "msteams"
+        mock_activity.from_.id = "user-001"
+        mock_activity.conversation.is_group = True
+        mock_activity.conversation.tenant_id = "tenant-001"
+
+        ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        ctx.api.users.token.get = AsyncMock(side_effect=Exception("no token"))
+
+        one_on_one = MagicMock()
+        one_on_one.id = "1on1-conv-id"
+        ctx.api.conversations.create = AsyncMock(return_value=one_on_one)
+
+        resource_response = MagicMock()
+        resource_response.token_exchange_resource = MagicMock()
+        resource_response.token_post_resource = MagicMock()
+        resource_response.sign_in_link = "https://login.example.com"
+        ctx.api.bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.MessageActivityInput"),
+            patch("microsoft_teams.apps.routing.activity_context.CreateConversationParams"),
+            patch("microsoft_teams.apps.routing.activity_context.card_attachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCardAttachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCard"),
+            patch("microsoft_teams.apps.routing.activity_context.CardAction"),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+        ):
+            result = await ctx.sign_in()
+
+        assert result is None
+        ctx.api.conversations.create.assert_called_once()
+        # one greeting message before the OAuth card, plus the OAuth card itself
+        assert mock_sender.send.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_sign_in_uses_signin_options_connection_name_override(self) -> None:
+        """sign_in respects SignInOptions.connection_name override when fetching the existing token."""
+        from microsoft_teams.apps.routing.activity_context import SignInOptions
+
+        mock_activity = MagicMock()
+        mock_activity.channel_id = "msteams"
+        mock_activity.from_.id = "user-001"
+        mock_activity.conversation.is_group = False
+
+        ctx, _ = _create_activity_context(activity=mock_activity)
+        ctx.api.users.token.get = AsyncMock(side_effect=Exception("no token"))
+
+        resource_response = MagicMock()
+        resource_response.token_exchange_resource = MagicMock()
+        resource_response.token_post_resource = MagicMock()
+        resource_response.sign_in_link = "https://login.example.com"
+        ctx.api.bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+
+        custom_options = SignInOptions(
+            oauth_card_text="Custom prompt",
+            sign_in_button_text="Login",
+            connection_name="custom-connection",
+        )
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "custom-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.MessageActivityInput"),
+            patch("microsoft_teams.apps.routing.activity_context.card_attachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCardAttachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCard"),
+            patch("microsoft_teams.apps.routing.activity_context.CardAction"),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+        ):
+            result = await ctx.sign_in(options=custom_options)
+
+        assert result is None
+        token_get_params = ctx.api.users.token.get.call_args[0][0]
+        assert token_get_params.connection_name == "custom-connection"
+
 
 class TestActivityContextSignOut:
     """Tests for ActivityContext.sign_out()."""
+
+    @pytest.mark.asyncio
+    async def test_sign_out_logs_debug_on_success(self) -> None:
+        """sign_out completes silently and logs a debug message when the API call succeeds."""
+        mock_activity = MagicMock()
+        mock_activity.channel_id = "msteams"
+        mock_activity.from_.id = "user-success"
+
+        ctx, _ = _create_activity_context(activity=mock_activity)
+        ctx.api.users.token.sign_out = AsyncMock(return_value=None)
+
+        with patch.object(ctx.logger, "debug") as mock_log_debug:
+            await ctx.sign_out()
+            mock_log_debug.assert_called_once()
+            logged = mock_log_debug.call_args[0][0]
+            assert "user-success" in logged
 
     @pytest.mark.asyncio
     async def test_sign_out_logs_error_and_does_not_raise_on_failure(self) -> None:

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from microsoft_teams.api import Account, MessageActivityInput, SentActivity
+from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.apps.routing.activity_context import ActivityContext
 
 
@@ -40,6 +41,7 @@ def _create_activity_context(
         connection_name="test-connection",
         activity_sender=mock_activity_sender,
         app_token=MagicMock(),
+        cloud=PUBLIC,
     )
     return ctx, mock_activity_sender
 

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -16,6 +16,7 @@ from microsoft_teams.api import (
     SignInVerifyStateInvokeActivity,
     TokenExchangeInvokeResponse,
 )
+from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.api.models import (
     Account,
     ConversationAccount,
@@ -446,6 +447,7 @@ class TestSignInFailureMiddlewareChain:
             token_manager=MagicMock(),
             api_client_settings=None,
             activity_sender=MagicMock(),
+            cloud=PUBLIC,
         )
 
     @staticmethod
@@ -462,6 +464,7 @@ class TestSignInFailureMiddlewareChain:
             connection_name="graph",
             activity_sender=MagicMock(),
             app_token=MagicMock(),
+            cloud=PUBLIC,
         )
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -158,6 +158,208 @@ class TestActivityProcessor:
         assert result.body == expected_result.body
 
     @pytest.mark.asyncio
+    async def test_process_activity_invokes_plugin_route_when_plugin_qualifies(self, activity_processor):
+        """Plugins with on_activity_event get wrapped in a route that calls plugin.on_activity."""
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-plugin",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        # Plugin with the qualifying attrs (on_activity_event hasattr + callable on_activity)
+        qualifying_plugin = MagicMock()
+        qualifying_plugin.on_activity_event = MagicMock()
+        qualifying_plugin.on_activity = AsyncMock()
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        await activity_processor.process_activity([qualifying_plugin], mock_activity_event)
+
+        qualifying_plugin.on_activity.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_updated_send_emits_activity_sent_event(self, activity_processor):
+        """Handler invoking ctx.send triggers updated_send -> event_manager.on_activity_sent."""
+        from microsoft_teams.api import MessageActivityInput, SentActivity
+
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-send",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        # Activity sender returns a SentActivity from send()
+        sent = SentActivity(id="sent-1", activity_params=MessageActivityInput(text="hi"))
+        activity_processor.activity_sender.send = AsyncMock(return_value=sent)
+
+        # Handler that calls ctx.send to exercise the updated_send wrapper
+        async def calling_handler(ctx):
+            await ctx.send("hi")
+            return None
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[calling_handler])
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_activity_sent = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        await activity_processor.process_activity([], mock_activity_event)
+
+        activity_processor.event_manager.on_activity_sent.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_handlers_emit_activity_sent_events(self, activity_processor):
+        """handle_chunk and handle_close emit on_activity_sent for stream events."""
+        from microsoft_teams.api import MessageActivityInput, SentActivity
+
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-stream",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        mock_stream = activity_processor.activity_sender.create_stream.return_value
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_activity_sent = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        await activity_processor.process_activity([], mock_activity_event)
+
+        # Stream's on_chunk and on_close were registered with the inner handlers.
+        # Invoke them to exercise their bodies.
+        chunk_handler = mock_stream.on_chunk.call_args[0][0]
+        close_handler = mock_stream.on_close.call_args[0][0]
+
+        sent = SentActivity(id="chunk-1", activity_params=MessageActivityInput(text="chunk"))
+        await chunk_handler(sent)
+        await close_handler(sent)
+
+        assert activity_processor.event_manager.on_activity_sent.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_build_context_marks_signed_in_when_token_available(self, activity_processor):
+        """When the token API returns a token, ActivityContext is built with is_signed_in=True."""
+        from unittest.mock import patch
+
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-token",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        # Patch ApiClient so users.token.get returns a successful response
+        token_response = MagicMock()
+        token_response.token = "user-jwt-token"
+        mock_api_client = MagicMock()
+        mock_api_client.users.token.get = AsyncMock(return_value=token_response)
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        with patch("microsoft_teams.apps.app_process.ApiClient", return_value=mock_api_client):
+            await activity_processor.process_activity([], mock_activity_event)
+
+        mock_api_client.users.token.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_activity_raises_when_event_manager_missing(self, activity_processor):
+        """process_activity raises ValueError if event_manager was never initialized."""
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-no-em",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        # Intentionally do NOT set event_manager - keep it as None
+
+        with pytest.raises(ValueError, match="EventManager was not initialized"):
+            await activity_processor.process_activity([], mock_activity_event)
+
+    @pytest.mark.asyncio
+    async def test_process_activity_handles_stream_cancelled(self, activity_processor):
+        """StreamCancelledError from middleware is caught; response status is 200."""
+        from microsoft_teams.apps.plugins import StreamCancelledError
+
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-cancel",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.execute_middleware_chain = AsyncMock(side_effect=StreamCancelledError())
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        result = await activity_processor.process_activity([], mock_activity_event)
+
+        assert result.status == 200
+
+    @pytest.mark.asyncio
     async def test_process_activity_raises_exception(self, activity_processor):
         """Test process_activity raises exception when middleware chain fails."""
         # Setup mocks

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -15,6 +15,7 @@ from microsoft_teams.api import (
     InvokeResponse,
     TokenProtocol,
 )
+from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.apps import ActivityContext, ActivityEvent
 from microsoft_teams.apps.activity_sender import ActivitySender
 from microsoft_teams.apps.app_events import EventManager
@@ -56,6 +57,7 @@ class TestActivityProcessor:
             mock_token_manager,
             None,
             mock_activity_sender,
+            PUBLIC,
         )
 
     @pytest.mark.asyncio
@@ -83,6 +85,7 @@ class TestActivityProcessor:
             connection_name="default_connection",
             activity_sender=mock_activity_sender,
             app_token=lambda: None,
+            cloud=PUBLIC,
         )
 
         handler_one = AsyncMock(spec=ActivityHandler)

--- a/packages/apps/tests/test_optional_graph_dependencies.py
+++ b/packages/apps/tests/test_optional_graph_dependencies.py
@@ -8,7 +8,51 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from microsoft_teams.api.auth.cloud_environment import (
+    CHINA,
+    PUBLIC,
+    US_GOV,
+    US_GOV_DOD,
+    CloudEnvironment,
+)
 from microsoft_teams.apps.routing.activity_context import ActivityContext
+from microsoft_teams.apps.utils.graph import _derive_graph_base_url
+
+
+class TestDeriveGraphBaseUrl:
+    """Tests for the cloud -> Graph base URL derivation used by create_graph_client."""
+
+    def test_none_cloud_returns_none(self) -> None:
+        assert _derive_graph_base_url(None) is None
+
+    @pytest.mark.parametrize(
+        "cloud,expected",
+        [
+            (PUBLIC, "https://graph.microsoft.com"),
+            (US_GOV, "https://graph.microsoft.us"),
+            (US_GOV_DOD, "https://dod-graph.microsoft.us"),
+            (CHINA, "https://microsoftgraph.chinacloudapi.cn"),
+        ],
+    )
+    def test_preset_cloud_derives_base_url(self, cloud: CloudEnvironment, expected: str) -> None:
+        assert _derive_graph_base_url(cloud) == expected
+
+    def test_non_url_scope_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        # Construct a cloud whose graph_scope isn't a URL.
+        class _FakeCloud:
+            graph_scope = "user.read"
+
+        with caplog.at_level("WARNING"):
+            assert _derive_graph_base_url(_FakeCloud()) is None  # type: ignore[arg-type]
+        assert any("not a URL" in record.message for record in caplog.records)
+
+    def test_empty_scope_returns_none_no_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        class _FakeCloud:
+            graph_scope = ""
+
+        with caplog.at_level("WARNING"):
+            assert _derive_graph_base_url(_FakeCloud()) is None  # type: ignore[arg-type]
+        assert not any("not a URL" in record.message for record in caplog.records)
 
 
 class TestOptionalGraphDependencies:
@@ -36,6 +80,7 @@ class TestOptionalGraphDependencies:
             connection_name="test-connection",
             activity_sender=mock_activity_sender,
             app_token=mock_app_token,  # This is needed for app_graph to work
+            cloud=PUBLIC,
         )
 
     def test_app_graph_property_without_graph_available(self) -> None:
@@ -61,7 +106,7 @@ class TestOptionalGraphDependencies:
             if name == "microsoft_teams.graph":
                 # Create a mock module with get_graph_client
                 mock_module = SimpleNamespace()
-                mock_module.get_graph_client = lambda x: "MockGraphClient"  # type: ignore
+                mock_module.get_graph_client = lambda x, base_url=None: "MockGraphClient"  # type: ignore
                 return mock_module
             return __import__(name, *args, **kwargs)
 
@@ -83,6 +128,7 @@ class TestOptionalGraphDependencies:
             connection_name="test-connection",
             activity_sender=MagicMock(),
             app_token=None,
+            cloud=PUBLIC,
         )
 
         # user_graph should raise ValueError when user is not signed in
@@ -102,6 +148,7 @@ class TestOptionalGraphDependencies:
             connection_name="test-connection",
             activity_sender=MagicMock(),
             app_token=None,
+            cloud=PUBLIC,
         )
 
         # user_graph should raise ValueError when no user token is available
@@ -121,6 +168,7 @@ class TestOptionalGraphDependencies:
             connection_name="test-connection",
             activity_sender=MagicMock(),
             app_token=None,  # No app token
+            cloud=PUBLIC,
         )
 
         # app_graph should raise RuntimeError when no app token is available
@@ -173,7 +221,7 @@ class TestAppGetAppGraph:
         mock_client = MagicMock()
         captured_token_arg = []
 
-        def capture_token(token):
+        def capture_token(token, cloud=None):
             captured_token_arg.append(token)
             return mock_client
 

--- a/packages/graph/src/microsoft_teams/graph/graph.py
+++ b/packages/graph/src/microsoft_teams/graph/graph.py
@@ -43,7 +43,7 @@ def get_graph_client(
         graph = get_graph_client("eyJ0eXAiOiJKV1Qi...")
 
         # Sovereign cloud (GCCH)
-        graph = get_graph_client(token, base_url="https://graph.microsoft.us")
+        graph = get_graph_client("eyJ0eXAiOiJKV1Qi...", base_url="https://graph.microsoft.us")
         ```
     """
     try:

--- a/packages/graph/src/microsoft_teams/graph/graph.py
+++ b/packages/graph/src/microsoft_teams/graph/graph.py
@@ -18,6 +18,7 @@ from .auth_provider import AuthProvider
 
 def get_graph_client(
     token: Optional[Token] = None,
+    *,
     base_url: Optional[str] = None,
 ) -> GraphServiceClient:
     """

--- a/packages/graph/src/microsoft_teams/graph/graph.py
+++ b/packages/graph/src/microsoft_teams/graph/graph.py
@@ -6,19 +6,30 @@ Licensed under the MIT License.
 from typing import Optional
 
 from azure.core.exceptions import ClientAuthenticationError
+from kiota_authentication_azure.azure_identity_authentication_provider import (
+    AzureIdentityAuthenticationProvider,
+)
 from microsoft_teams.common.http.client_token import Token
+from msgraph.graph_request_adapter import GraphRequestAdapter
 from msgraph.graph_service_client import GraphServiceClient
 
 from .auth_provider import AuthProvider
 
 
-def get_graph_client(token: Optional[Token] = None) -> GraphServiceClient:
+def get_graph_client(
+    token: Optional[Token] = None,
+    base_url: Optional[str] = None,
+) -> GraphServiceClient:
     """
     Get a configured Microsoft Graph client using a Token.
 
     Args:
         token: Token data (string, StringLike, callable, or None). If None,
                will raise ClientAuthenticationError with a clear message.
+        base_url: Optional Graph API base URL override for sovereign clouds
+               (e.g. "https://graph.microsoft.us" for GCCH). When provided,
+               the client routes HTTP calls to this endpoint + "/v1.0/". When
+               None, the public Graph endpoint is used.
 
     Returns:
         GraphServiceClient: A configured client ready for Microsoft Graph API calls
@@ -28,20 +39,11 @@ def get_graph_client(token: Optional[Token] = None) -> GraphServiceClient:
 
     Example:
         ```python
-        # Using a string token
-        graph = get_graph_client("eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIs...")
+        # Public cloud (default)
+        graph = get_graph_client("eyJ0eXAiOiJKV1Qi...")
 
-
-        # Using a callable that returns a string
-        def get_token():
-            return "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIs..."
-
-
-        graph = get_graph_client(get_token)
-
-        # Make Graph API calls
-        me = await graph.me.get()
-        messages = await graph.me.messages.get()
+        # Sovereign cloud (GCCH)
+        graph = get_graph_client(token, base_url="https://graph.microsoft.us")
         ```
     """
     try:
@@ -53,8 +55,17 @@ def get_graph_client(token: Optional[Token] = None) -> GraphServiceClient:
             )
 
         credential = AuthProvider(token)
-        client = GraphServiceClient(credentials=credential)
-        return client
+
+        if base_url is None:
+            return GraphServiceClient(credentials=credential)
+
+        # Build a custom request adapter with the sovereign base URL.
+        # Normalize: strip any trailing slash on caller's input, then append "/v1.0/"
+        # to match the msgraph-sdk default shape ("https://graph.microsoft.com/v1.0/").
+        auth_provider = AzureIdentityAuthenticationProvider(credential)
+        adapter = GraphRequestAdapter(auth_provider)
+        adapter.base_url = f"{base_url.rstrip('/')}/v1.0/"
+        return GraphServiceClient(request_adapter=adapter)
 
     except Exception as e:
         if isinstance(e, ClientAuthenticationError):

--- a/packages/graph/tests/test_graph.py
+++ b/packages/graph/tests/test_graph.py
@@ -101,6 +101,19 @@ class TestAuthProvider:
         assert isinstance(token, AccessToken)
         assert token.expires_on == exp_time  # Should use JWT expiration, not default
 
+    def test_get_token_with_jwt_missing_exp_claim_uses_default(self) -> None:
+        """JWT without 'exp' claim falls back to 1-hour default expiration."""
+        payload = {"aud": "test"}  # no 'exp'
+        jwt_token = jwt.encode(payload, "secret", algorithm="HS256")
+        credential = AuthProvider(jwt_token)
+
+        token = credential.get_token("https://graph.microsoft.com/.default")
+
+        assert isinstance(token, AccessToken)
+        # Should use default 1-hour expiration (within tolerance)
+        now = int(time.time())
+        assert abs(token.expires_on - (now + 3600)) < 60
+
     def test_get_token_with_non_jwt_uses_default_expiration(self) -> None:
         """Test that non-JWT tokens use default 1-hour expiration."""
 
@@ -315,3 +328,9 @@ class TestGraphClientFactory:
         """Trailing slash on the input base_url is normalized to avoid '//v1.0/'."""
         client = get_graph_client("tok", base_url="https://graph.microsoft.us/")
         assert client.request_adapter.base_url == "https://graph.microsoft.us/v1.0/"
+
+    def test_get_graph_client_wraps_unexpected_exceptions(self) -> None:
+        """Non-auth exceptions during construction are wrapped in ClientAuthenticationError."""
+        # Pass a non-string base_url so .rstrip raises AttributeError (a non-auth exception)
+        with pytest.raises(ClientAuthenticationError, match="Failed to create Microsoft Graph client"):
+            get_graph_client("tok", base_url=12345)  # type: ignore[arg-type]

--- a/packages/graph/tests/test_graph.py
+++ b/packages/graph/tests/test_graph.py
@@ -295,7 +295,7 @@ class TestGraphClientFactory:
         """Without a base_url override, the client routes to the public Graph endpoint."""
         client = get_graph_client("tok")
         assert isinstance(client, GraphServiceClient)
-        assert client.request_adapter.base_url.startswith("https://graph.microsoft.com/")
+        assert client.request_adapter.base_url == "https://graph.microsoft.com/v1.0/"
 
     @pytest.mark.parametrize(
         "base_url,expected_prefix",

--- a/packages/graph/tests/test_graph.py
+++ b/packages/graph/tests/test_graph.py
@@ -290,3 +290,28 @@ class TestGraphClientFactory:
         credential = AuthProvider(failing_token)
         with pytest.raises(ClientAuthenticationError):
             credential.get_token("https://graph.microsoft.com/.default")
+
+    def test_get_graph_client_no_base_url_uses_public_default(self) -> None:
+        """Without a base_url override, the client routes to the public Graph endpoint."""
+        client = get_graph_client("tok")
+        assert isinstance(client, GraphServiceClient)
+        assert client.request_adapter.base_url.startswith("https://graph.microsoft.com")
+
+    @pytest.mark.parametrize(
+        "base_url,expected_prefix",
+        [
+            ("https://graph.microsoft.us", "https://graph.microsoft.us/v1.0/"),
+            ("https://dod-graph.microsoft.us", "https://dod-graph.microsoft.us/v1.0/"),
+            ("https://microsoftgraph.chinacloudapi.cn", "https://microsoftgraph.chinacloudapi.cn/v1.0/"),
+        ],
+    )
+    def test_get_graph_client_routes_to_sovereign_base_url(self, base_url: str, expected_prefix: str) -> None:
+        """Providing base_url routes the client to the sovereign Graph endpoint."""
+        client = get_graph_client("tok", base_url=base_url)
+        assert isinstance(client, GraphServiceClient)
+        assert client.request_adapter.base_url == expected_prefix
+
+    def test_get_graph_client_strips_trailing_slash_on_base_url(self) -> None:
+        """Trailing slash on the input base_url is normalized to avoid '//v1.0/'."""
+        client = get_graph_client("tok", base_url="https://graph.microsoft.us/")
+        assert client.request_adapter.base_url == "https://graph.microsoft.us/v1.0/"

--- a/packages/graph/tests/test_graph.py
+++ b/packages/graph/tests/test_graph.py
@@ -295,7 +295,7 @@ class TestGraphClientFactory:
         """Without a base_url override, the client routes to the public Graph endpoint."""
         client = get_graph_client("tok")
         assert isinstance(client, GraphServiceClient)
-        assert client.request_adapter.base_url.startswith("https://graph.microsoft.com")
+        assert client.request_adapter.base_url.startswith("https://graph.microsoft.com/")
 
     @pytest.mark.parametrize(
         "base_url,expected_prefix",


### PR DESCRIPTION
- `App.get_app_graph()`, `ctx.app_graph`, and `ctx.user_graph` were routing all Microsoft Graph calls to the public-cloud endpoint (`https://graph.microsoft.com`) regardless of the sovereign cloud configured on the app. Sovereign customers (GCCH, DoD, China) would hit the wrong cloud. This PR derives the Graph base URL from `cloud.graph_scope` on `App` and plumbs it through every Graph client the framework constructs.
- Public cloud (default): `graph_scope = "https://graph.microsoft.com/.default"` → derived base URL = `https://graph.microsoft.com` = previous hardcoded default. **Zero behavior change.**
- Sovereign clouds: behavior changes from broken (silently public) to correct (per-cloud). This is the fix.