### PR TITLE
Fix allowlist plumbing through through TokenValidator

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -170,6 +170,7 @@ class App(ActivityHandlerMixin):
                 self.credentials.tenant_id,
                 application_id_uri=self.options.application_id_uri,
                 cloud=self.cloud,
+                additional_allowed_domains=self.options.additional_allowed_domains,
             )
 
     @property

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -73,16 +73,23 @@ class TokenValidator:
     JWT token validator using PyJWKClient for simplified validation.
     """
 
-    def __init__(self, jwt_validation_options: JwtValidationOptions, cloud: Optional[CloudEnvironment] = None):
+    def __init__(
+        self,
+        jwt_validation_options: JwtValidationOptions,
+        cloud: Optional[CloudEnvironment] = None,
+        additional_allowed_domains: Optional[List[str]] = None,
+    ):
         """
         Initialize the token validator.
 
         Args:
             jwt_validation_options: Configuration for JWT validation
             cloud: Optional cloud environment for service URL validation
+            additional_allowed_domains: Additional service URL domains accepted beyond the cloud preset.
         """
         self.options = jwt_validation_options
         self.cloud = cloud or PUBLIC
+        self.additional_allowed_domains = additional_allowed_domains
         self._jwks_client = jwt.PyJWKClient(jwt_validation_options.jwks_uri)
 
     @staticmethod
@@ -96,6 +103,7 @@ class TokenValidator:
         app_id: str,
         service_url: Optional[str] = None,
         cloud: Optional[CloudEnvironment] = None,
+        additional_allowed_domains: Optional[List[str]] = None,
     ) -> TokenValidator:
         """Create a validator for Bot Framework service tokens.
 
@@ -105,6 +113,7 @@ class TokenValidator:
             app_id: The bot's Microsoft App ID (used for audience validation)
             service_url: Optional service URL to validate against token claims
             cloud: Optional cloud environment for sovereign cloud support
+            additional_allowed_domains: Additional service URL domains accepted beyond the cloud preset.
         """
         env = cloud or PUBLIC
         jwks_keys_uri = re.sub(r"/openidconfiguration$", "/keys", env.openid_metadata_url)
@@ -115,7 +124,7 @@ class TokenValidator:
             jwks_uri=jwks_keys_uri,
             service_url=service_url,
         )
-        return cls(options, cloud=env)
+        return cls(options, cloud=env, additional_allowed_domains=additional_allowed_domains)
 
     @classmethod
     def for_entra(
@@ -125,6 +134,7 @@ class TokenValidator:
         scope: Optional[str] = None,
         application_id_uri: Optional[str] = None,
         cloud: Optional[CloudEnvironment] = None,
+        additional_allowed_domains: Optional[List[str]] = None,
     ) -> TokenValidator:
         """Create a validator for Entra ID tokens.
 
@@ -135,6 +145,7 @@ class TokenValidator:
             application_id_uri: Optional Application ID URI from Azure portal.
                 Matches webApplicationInfo.resource in the app manifest.
             cloud: Optional cloud environment for sovereign cloud support
+            additional_allowed_domains: Additional service URL domains accepted beyond the cloud preset.
         """
         env = cloud or PUBLIC
         valid_issuers: List[str] = []
@@ -155,7 +166,7 @@ class TokenValidator:
             jwks_uri=f"{env.login_endpoint}/{tenant_id}/discovery/v2.0/keys",
             scope=scope,
         )
-        return cls(options)
+        return cls(options, cloud=env, additional_allowed_domains=additional_allowed_domains)
 
     async def validate_token(
         self, raw_token: str, service_url: Optional[str] = None, scope: Optional[str] = None
@@ -200,7 +211,9 @@ class TokenValidator:
 
             # Validate service URL against allowed domains
             effective_service_url = service_url or self.options.service_url
-            if effective_service_url and not is_allowed_service_url(effective_service_url, self.cloud):
+            if effective_service_url and not is_allowed_service_url(
+                effective_service_url, self.cloud, self.additional_allowed_domains
+            ):
                 logger.error(f"Rejected service URL: {effective_service_url}")
                 raise jwt.InvalidTokenError("Service URL is not from an allowed domain")
 

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -85,11 +85,16 @@ class TokenValidator:
         Args:
             jwt_validation_options: Configuration for JWT validation
             cloud: Optional cloud environment for service URL validation
-            additional_allowed_domains: Additional service URL domains accepted beyond the cloud preset.
+            additional_allowed_domains: Additional service URL hostnames accepted beyond the cloud
+                preset. Entries must be bare hostnames matched exactly (case-insensitive) — wildcard
+                patterns like ``"*.example.com"``, URL suffixes, or full URLs are NOT supported.
+                Pass ``["*"]`` as the sole wildcard to accept any hostname.
         """
         self.options = jwt_validation_options
         self.cloud = cloud or PUBLIC
-        self.additional_allowed_domains = additional_allowed_domains
+        self.additional_allowed_domains = (
+            list(additional_allowed_domains) if additional_allowed_domains is not None else None
+        )
         self._jwks_client = jwt.PyJWKClient(jwt_validation_options.jwks_uri)
 
     @staticmethod
@@ -113,7 +118,10 @@ class TokenValidator:
             app_id: The bot's Microsoft App ID (used for audience validation)
             service_url: Optional service URL to validate against token claims
             cloud: Optional cloud environment for sovereign cloud support
-            additional_allowed_domains: Additional service URL domains accepted beyond the cloud preset.
+            additional_allowed_domains: Additional service URL hostnames accepted beyond the cloud
+                preset. Entries must be bare hostnames matched exactly (case-insensitive) — wildcard
+                patterns like ``"*.example.com"``, URL suffixes, or full URLs are NOT supported.
+                Pass ``["*"]`` as the sole wildcard to accept any hostname.
         """
         env = cloud or PUBLIC
         jwks_keys_uri = re.sub(r"/openidconfiguration$", "/keys", env.openid_metadata_url)
@@ -145,7 +153,10 @@ class TokenValidator:
             application_id_uri: Optional Application ID URI from Azure portal.
                 Matches webApplicationInfo.resource in the app manifest.
             cloud: Optional cloud environment for sovereign cloud support
-            additional_allowed_domains: Additional service URL domains accepted beyond the cloud preset.
+            additional_allowed_domains: Additional service URL hostnames accepted beyond the cloud
+                preset. Entries must be bare hostnames matched exactly (case-insensitive) — wildcard
+                patterns like ``"*.example.com"``, URL suffixes, or full URLs are NOT supported.
+                Pass ``["*"]`` as the sole wildcard to accept any hostname.
         """
         env = cloud or PUBLIC
         valid_issuers: List[str] = []

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -88,7 +88,11 @@ class HttpServer:
 
         app_id = getattr(credentials, "client_id", None) if credentials else None
         if app_id and not skip_auth:
-            self._token_validator = TokenValidator.for_service(app_id, cloud=self._cloud)
+            self._token_validator = TokenValidator.for_service(
+                app_id,
+                cloud=self._cloud,
+                additional_allowed_domains=self._additional_allowed_domains,
+            )
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
 
         self._adapter.register_route("POST", self._messaging_endpoint, self.handle_request)

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -241,6 +241,28 @@ class TestHttpServer:
         result = await server.handle_request(request)
         assert result["status"] == 200
 
+    def test_initialize_forwards_allowlist_to_token_validator(self, mock_adapter):
+        """With skip_auth=False and credentials, the allowlist must reach TokenValidator.
+
+        Regression: HttpServer.initialize() previously constructed TokenValidator.for_service()
+        without passing additional_allowed_domains, so the token-validation service-URL check
+        ignored user-configured domains.
+        """
+        server = HttpServer(mock_adapter)
+        credentials = MagicMock(client_id="test-app-id")
+
+        with patch("microsoft_teams.apps.http.http_server.TokenValidator.for_service") as mock_for_service:
+            mock_for_service.return_value = MagicMock()
+            server.initialize(
+                credentials=credentials,
+                skip_auth=False,
+                additional_allowed_domains=["canary.botapi.skype.com"],
+            )
+
+        mock_for_service.assert_called_once()
+        _, kwargs = mock_for_service.call_args
+        assert kwargs.get("additional_allowed_domains") == ["canary.botapi.skype.com"]
+
 
 class TestFastAPIAdapter:
     """Test cases for FastAPIAdapter."""

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -507,3 +507,73 @@ class TestTokenValidator:
         from microsoft_teams.apps.auth.token_validator import is_allowed_service_url
 
         assert is_allowed_service_url("https://anything.example.com", PUBLIC, ["*"]) is True
+
+    # ----- additional_allowed_domains plumbing through validate_token -----
+
+    @pytest.mark.asyncio
+    async def test_validate_token_honors_additional_allowed_domains(self, mock_jwks_client):
+        """validate_token must accept a service URL listed in additional_allowed_domains.
+
+        Regression: for_service previously dropped the allowlist, so non-default channels
+        (canary, custom) were rejected even when the user configured them.
+        """
+        validator = TokenValidator.for_service("test-app-id", additional_allowed_domains=["canary.botapi.skype.com"])
+        validator._jwks_client = mock_jwks_client
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "https://canary.botapi.skype.com/amer",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token("valid.jwt.token", "https://canary.botapi.skype.com/amer")
+            assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_validate_token_rejects_when_domain_not_in_allowlist(self, mock_jwks_client):
+        """Sanity check: without additional_allowed_domains, canary is rejected."""
+        validator = TokenValidator.for_service("test-app-id")
+        validator._jwks_client = mock_jwks_client
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "https://canary.botapi.skype.com/amer",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        with patch("jwt.decode", return_value=payload):
+            with pytest.raises(jwt.InvalidTokenError, match="Service URL is not from an allowed domain"):
+                await validator.validate_token("valid.jwt.token", "https://canary.botapi.skype.com/amer")
+
+    @pytest.mark.asyncio
+    async def test_validate_token_wildcard_allows_arbitrary_domain(self, mock_jwks_client):
+        """additional_allowed_domains=['*'] must disable the allowlist check at validate_token level."""
+        validator = TokenValidator.for_service("test-app-id", additional_allowed_domains=["*"])
+        validator._jwks_client = mock_jwks_client
+        payload = {
+            "iss": "https://api.botframework.com",
+            "aud": "test-app-id",
+            "serviceurl": "https://anything.example.com/",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+        with patch("jwt.decode", return_value=payload):
+            result = await validator.validate_token("valid.jwt.token", "https://anything.example.com/")
+            assert isinstance(result, dict)
+
+    def test_for_service_stores_additional_allowed_domains(self):
+        """Factory must surface the allowlist on the instance so validate_token can use it."""
+        validator = TokenValidator.for_service(
+            "test-app-id", additional_allowed_domains=["a.example.com", "b.example.com"]
+        )
+        assert validator.additional_allowed_domains == ["a.example.com", "b.example.com"]
+
+    def test_for_entra_stores_additional_allowed_domains(self):
+        """Same plumbing check for the Entra factory."""
+        validator = TokenValidator.for_entra(
+            app_id="test-app-id",
+            tenant_id="test-tenant-id",
+            additional_allowed_domains=["custom.example.com"],
+        )
+        assert validator.additional_allowed_domains == ["custom.example.com"]

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -577,3 +577,12 @@ class TestTokenValidator:
             additional_allowed_domains=["custom.example.com"],
         )
         assert validator.additional_allowed_domains == ["custom.example.com"]
+
+    def test_init_copies_additional_allowed_domains(self):
+        """Mutating the caller's list after construction must not change validator behavior."""
+        caller_list = ["a.example.com"]
+        validator = TokenValidator.for_service("test-app-id", additional_allowed_domains=caller_list)
+
+        caller_list.append("b.example.com")
+
+        assert validator.additional_allowed_domains == ["a.example.com"]


### PR DESCRIPTION
`App(additional_allowed_domains=[...])` was silently ignored at the token-validation layer, rejecting user-approved service URLs (e.g. `canary.botapi.skype.com`) before they ever reached the allowlist-aware check in `HttpServer.handle_request`.

Fix threads the allowlist through `TokenValidator.__init__`, both factory methods (`for_service`, `for_entra`), and the `validate_token` call site. Updates `HttpServer.initialize` and `App.__init__` to forward the option.

## Why unit tests missed it

  All existing `additional_allowed_domains` tests used `skip_auth=True`, which bypasses the `TokenValidator` code path entirely. The helper function `is_allowed_service_url` had direct tests with 3 args, so the function itself was fine — just no test proved the code *calling* it in the auth-on path was also using 3 args. E2E validation was against default service url, which is in the built-in allowlist and doesn't need the knob. The intersection of "auth on" AND "non-default service URL" had zero coverage.

  ## Tests

  `test_token_validator.py`:
  - `test_validate_token_honors_additional_allowed_domains` — canary accepted when in allowlist
  - `test_validate_token_rejects_when_domain_not_in_allowlist` — baseline: canary rejected without the knob
  - `test_validate_token_wildcard_allows_arbitrary_domain` — `["*"]` disables the check at the token-validation layer
  - `test_for_service_stores_additional_allowed_domains` / `test_for_entra_stores_additional_allowed_domains` — factory plumbing

  `test_http_server.py`:
  - `test_initialize_forwards_allowlist_to_token_validator` — spies `TokenValidator.for_service` and asserts it's called *with* the allowlist (catches the exact regression
  class)

  All 67 tests pass.

  ## Test plan

  - [x] Unit: `uv run pytest packages/apps/tests/test_token_validator.py packages/apps/tests/test_http_server.py` — 67/67
  - [x] Lint/format: `uv run poe check` — clean
  - [x] Type check: `uv run pyright` — no new errors
  - [x] E2E on canary: verified activity from `https://canary.botapi.skype.com/amer/...` passes token validation and reaches `onMessage` (previously 401'd)
  - [x] E2E regression: default `smba.trafficmanager.net` still works