### PR TITLE
Add proactive message update example

### DIFF
--- a/examples/proactive-messaging/src/main.py
+++ b/examples/proactive-messaging/src/main.py
@@ -1,25 +1,26 @@
 """
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
-
-Proactive Messaging Example
-===========================
-This example demonstrates how to send proactive messages to Teams users
-without running a server. This is useful for:
-- Scheduled notifications
-- Alert systems
-- Background jobs that need to notify users
-- Webhook handlers that send messages
-
-Key points:
-- Uses app.initialize() instead of app.start() (no HTTP server)
-- Directly sends messages using app.send()
-- Requires a conversation ID (from previous interactions or from the Teams API)
 """
+
+# Proactive Messaging Example
+# ===========================
+# This example demonstrates how to send proactive messages to Teams users
+# without running a server. This is useful for:
+# - Scheduled notifications
+# - Alert systems
+# - Background jobs that need to notify users
+# - Webhook handlers that send messages
+#
+# Key points:
+# - Uses app.initialize() instead of app.start() (no HTTP server)
+# - Directly sends messages using app.send()
+# - Requires a conversation ID (from previous interactions or from the Teams API)
 
 import argparse
 import asyncio
 
+from microsoft_teams.api import MessageActivityInput
 from microsoft_teams.apps import App
 from microsoft_teams.cards import ActionSet, AdaptiveCard, OpenUrlAction, TextBlock
 
@@ -68,6 +69,30 @@ async def send_proactive_card(app: App, conversation_id: str) -> None:
     print(f"✓ Card sent successfully! Activity ID: {result.id}")
 
 
+async def send_and_update_proactive_message(app: App, conversation_id: str) -> None:
+    """
+    Send a message proactively and then update it proactively.
+
+    Args:
+        app: The initialized App instance
+        conversation_id: The Teams conversation ID
+    """
+    # First, send a message proactively
+    original_text = "Status: Pending... (sent proactively without a running server)"
+    print(f"Sending message to update: {original_text}")
+    result = await app.send(conversation_id, original_text)
+    activity_id = result.id
+    print(f"✓ Original message sent! Activity ID: {activity_id}")
+
+    # Wait so the user can see the original
+    await asyncio.sleep(3)
+
+    # Now update the same message proactively using the ConversationClient
+    updated = MessageActivityInput(text="Status: Complete ✅ (updated proactively without a running server)")
+    await app.api.conversations.activities(conversation_id).update(activity_id, updated)
+    print(f"✓ Message updated successfully! Activity ID: {activity_id}")
+
+
 async def main():
     """
     Main function demonstrating proactive messaging.
@@ -102,6 +127,12 @@ async def main():
 
     # Example 2: Send an Adaptive Card
     await send_proactive_card(app, args.conversation_id)
+
+    # Wait a bit between messages
+    await asyncio.sleep(2)
+
+    # Example 3: Update an existing message
+    await send_and_update_proactive_message(app, args.conversation_id)
 
     print("\n✓ All proactive messages sent successfully!")
 

--- a/examples/proactive-messaging/src/main.py
+++ b/examples/proactive-messaging/src/main.py
@@ -1,21 +1,21 @@
 """
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
-"""
 
-# Proactive Messaging Example
-# ===========================
-# This example demonstrates how to send proactive messages to Teams users
-# without running a server. This is useful for:
-# - Scheduled notifications
-# - Alert systems
-# - Background jobs that need to notify users
-# - Webhook handlers that send messages
-#
-# Key points:
-# - Uses app.initialize() instead of app.start() (no HTTP server)
-# - Directly sends messages using app.send()
-# - Requires a conversation ID (from previous interactions or from the Teams API)
+Proactive Messaging Example
+===========================
+This example demonstrates how to send proactive messages to Teams users
+without running a server. This is useful for:
+- Scheduled notifications
+- Alert systems
+- Background jobs that need to notify users
+- Webhook handlers that send messages
+
+Key points:
+- Uses app.initialize() instead of app.start() (no HTTP server)
+- Directly sends messages using app.send()
+- Requires a conversation ID (from previous interactions or from the Teams API)
+"""
 
 import argparse
 import asyncio


### PR DESCRIPTION
## Summary
- Add Example 3 to the proactive-messaging sample showing how to send a message and then update it using the ConversationClient
- Demonstrates the send-then-update pattern for proactive messaging without a running server

## Test plan
- [x] Run `uv run src/main.py <conversation_id>` and verify all 3 examples work
- [x] Confirm the third message shows "Status: Pending..." then updates to "Status: Complete"