### PR TITLE
Deprecate ai, openai, mcpplugin, and a2a packages

### DIFF
--- a/packages/a2aprotocol/README.md
+++ b/packages/a2aprotocol/README.md
@@ -1,5 +1,8 @@
 # Microsoft Teams A2A
 
+> [!WARNING]
+> **Deprecated** — This package was originally in preview, but we have decided to stop maintaining it before General Availability. We recommend using the official [A2A Python SDK](https://github.com/a2aproject/a2a-python) instead, which provides better long-term support for Agent-to-Agent protocol integrations.
+
 <p>
     <a href="https://pypi.org/project/microsoft-teams-a2a/" target="_blank">
         <img src="https://img.shields.io/pypi/v/microsoft-teams-a2a" />

--- a/packages/a2aprotocol/pyproject.toml
+++ b/packages/a2aprotocol/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.12,<3.15"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
 dependencies = [
     "a2a-sdk[core,http-server]>=0.3.7",
     "microsoft-teams-ai",

--- a/packages/a2aprotocol/src/microsoft_teams/a2a/__init__.py
+++ b/packages/a2aprotocol/src/microsoft_teams/a2a/__init__.py
@@ -15,7 +15,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 warnings.warn(
     "microsoft-teams-a2a is deprecated and will no longer be maintained. "
     "Use the official A2A Python SDK instead: https://github.com/a2aproject/a2a-python",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=2,
 )
 

--- a/packages/a2aprotocol/src/microsoft_teams/a2a/__init__.py
+++ b/packages/a2aprotocol/src/microsoft_teams/a2a/__init__.py
@@ -4,12 +4,20 @@ Licensed under the MIT License.
 """
 
 import logging
+import warnings
 
 from . import chat_prompt, server
 from .chat_prompt import *  # noqa: F403
 from .server import *  # noqa: F401, F403
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+warnings.warn(
+    "microsoft-teams-a2a is deprecated and will no longer be maintained. "
+    "Use the official A2A Python SDK instead: https://github.com/a2aproject/a2a-python",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # Combine all exports from submodules
 __all__: list[str] = []

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,7 +1,7 @@
 # Microsoft Teams SDK
 
 > [!WARNING]
-> **Deprecated** — This package was originally in preview, but we have decided to stop maintaining it before General Availability. We recommend using the [Agent Framework](https://microsoft.github.io/teams-sdk/python/in-depth-guides/ai/) instead, which provides better long-term support for building AI-powered Teams applications.
+> **Deprecated** — This package was originally in preview, but we have decided to stop maintaining it before General Availability. We recommend using the [Agent Framework](https://learn.microsoft.com/en-us/agent-framework/overview/?pivots=programming-language-python) instead, which provides better long-term support for building AI-powered Teams applications.
 
 <p>
     <a href="https://pypi.org/project/microsoft-teams-ai/" target="_blank">
@@ -18,7 +18,7 @@
 AI-powered conversational experiences for Microsoft Teams applications.
 Provides prompt management, action planning, and model integration for building intelligent Teams bots.
 
-[📖 Documentation](https://microsoft.github.io/teams-sdk/python/in-depth-guides/ai/)
+[📖 Documentation](https://learn.microsoft.com/en-us/agent-framework/overview/?pivots=programming-language-python)
 
 ## Installation
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,5 +1,8 @@
 # Microsoft Teams SDK
 
+> [!WARNING]
+> **Deprecated** — This package was originally in preview, but we have decided to stop maintaining it before General Availability. We recommend using the [Agent Framework](https://microsoft.github.io/teams-sdk/python/in-depth-guides/ai/) instead, which provides better long-term support for building AI-powered Teams applications.
+
 <p>
     <a href="https://pypi.org/project/microsoft-teams-ai/" target="_blank">
         <img src="https://img.shields.io/pypi/v/microsoft-teams-ai" />

--- a/packages/ai/pyproject.toml
+++ b/packages/ai/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.12,<3.15"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
 dependencies = [
     "microsoft-teams-common",
 ]

--- a/packages/ai/src/microsoft_teams/ai/__init__.py
+++ b/packages/ai/src/microsoft_teams/ai/__init__.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import logging
+import warnings
 
 from .ai_model import AIModel
 from .chat_prompt import ChatPrompt, ChatSendResult
@@ -12,6 +13,13 @@ from .memory import ListMemory, Memory
 from .message import FunctionMessage, Message, ModelMessage, SystemMessage, UserMessage
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+warnings.warn(
+    "microsoft-teams-ai is deprecated and will no longer be maintained. "
+    "Use the Agent Framework instead: https://microsoft.github.io/teams-sdk/python/in-depth-guides/ai/",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = [
     "ChatSendResult",

--- a/packages/ai/src/microsoft_teams/ai/__init__.py
+++ b/packages/ai/src/microsoft_teams/ai/__init__.py
@@ -16,8 +16,8 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 warnings.warn(
     "microsoft-teams-ai is deprecated and will no longer be maintained. "
-    "Use the Agent Framework instead: https://microsoft.github.io/teams-sdk/python/in-depth-guides/ai/",
-    DeprecationWarning,
+    "Use the Agent Framework instead: https://learn.microsoft.com/en-us/agent-framework/overview/?pivots=programming-language-python",
+    FutureWarning,
     stacklevel=2,
 )
 

--- a/packages/mcpplugin/README.md
+++ b/packages/mcpplugin/README.md
@@ -1,5 +1,8 @@
 # Microsoft Teams MCP Plugin
 
+> [!WARNING]
+> **Deprecated** — This package was originally in preview, but we have decided to stop maintaining it before General Availability. We recommend using the official [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) instead, which provides better long-term support for Model Context Protocol integrations.
+
 <p>
     <a href="https://pypi.org/project/microsoft-teams-mcpplugin/" target="_blank">
         <img src="https://img.shields.io/pypi/v/microsoft-teams-mcpplugin" />

--- a/packages/mcpplugin/pyproject.toml
+++ b/packages/mcpplugin/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.12,<3.15"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
 dependencies = [
     "mcp>=1.13.1",
     "microsoft-teams-common",

--- a/packages/mcpplugin/src/microsoft_teams/mcpplugin/__init__.py
+++ b/packages/mcpplugin/src/microsoft_teams/mcpplugin/__init__.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import logging
+import warnings
 
 from . import models
 from .ai_plugin import McpClientPlugin, McpClientPluginParams, McpToolDetails
@@ -11,6 +12,13 @@ from .models import *  # noqa: F403
 from .server_plugin import McpServerPlugin
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+warnings.warn(
+    "microsoft-teams-mcpplugin is deprecated and will no longer be maintained. "
+    "Use the official MCP Python SDK instead: https://github.com/modelcontextprotocol/python-sdk",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__: list[str] = ["McpClientPlugin", "McpClientPluginParams", "McpToolDetails", "McpServerPlugin"]
 __all__.extend(models.__all__)

--- a/packages/mcpplugin/src/microsoft_teams/mcpplugin/__init__.py
+++ b/packages/mcpplugin/src/microsoft_teams/mcpplugin/__init__.py
@@ -16,7 +16,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 warnings.warn(
     "microsoft-teams-mcpplugin is deprecated and will no longer be maintained. "
     "Use the official MCP Python SDK instead: https://github.com/modelcontextprotocol/python-sdk",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=2,
 )
 

--- a/packages/openai/README.md
+++ b/packages/openai/README.md
@@ -1,5 +1,8 @@
 # Microsoft Teams OpenAI
 
+> [!WARNING]
+> **Deprecated** — This package was originally in preview, but we have decided to stop maintaining it before General Availability. We recommend using the official [OpenAI Python SDK](https://github.com/openai/openai-python) instead, which provides better long-term support for OpenAI integrations.
+
 <p>
     <a href="https://pypi.org/project/microsoft-teams-openai/" target="_blank">
         <img src="https://img.shields.io/pypi/v/microsoft-teams-openai" />

--- a/packages/openai/pyproject.toml
+++ b/packages/openai/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.12,<3.15"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"
+classifiers = [
+    "Development Status :: 7 - Inactive",
+]
 dependencies = [
     "microsoft-teams-ai",
     "microsoft-teams-common",

--- a/packages/openai/src/microsoft_teams/openai/__init__.py
+++ b/packages/openai/src/microsoft_teams/openai/__init__.py
@@ -14,7 +14,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 warnings.warn(
     "microsoft-teams-openai is deprecated and will no longer be maintained. "
     "Use the official OpenAI Python SDK instead: https://github.com/openai/openai-python",
-    DeprecationWarning,
+    FutureWarning,
     stacklevel=2,
 )
 

--- a/packages/openai/src/microsoft_teams/openai/__init__.py
+++ b/packages/openai/src/microsoft_teams/openai/__init__.py
@@ -4,10 +4,18 @@ Licensed under the MIT License.
 """
 
 import logging
+import warnings
 
 from .completions_model import OpenAICompletionsAIModel
 from .responses_chat_model import OpenAIResponsesAIModel
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+warnings.warn(
+    "microsoft-teams-openai is deprecated and will no longer be maintained. "
+    "Use the official OpenAI Python SDK instead: https://github.com/openai/openai-python",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 __all__ = ["OpenAICompletionsAIModel", "OpenAIResponsesAIModel"]


### PR DESCRIPTION
## Summary
- These packages were in preview but we've decided to stop maintaining them before GA
- Added `[!WARNING]` deprecation banners to each package's README with links to recommended replacements
- Added runtime `DeprecationWarning` on import so users get notified in their terminal
- Added `Development Status :: 7 - Inactive` trove classifier to each `pyproject.toml`

**Recommended replacements:**
- `microsoft-teams-ai` → [Agent Framework](https://microsoft.github.io/teams-sdk/python/in-depth-guides/ai/)
- `microsoft-teams-mcpplugin` → [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
- `microsoft-teams-a2a` → [A2A Python SDK](https://github.com/a2aproject/a2a-python)
- `microsoft-teams-openai` → [OpenAI Python SDK](https://github.com/openai/openai-python)

## Test plan
- [ ] `poe check` passes (ruff + format)
- [ ] pyright passes
- [ ] Verify deprecation warnings show when importing any of the four packages
- [ ] Verify README banners render correctly on GitHub