### PR TITLE
fix(http-stream): wait for in-flight flush before sending final close message

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -131,10 +131,10 @@ class HttpStream(StreamerProtocol):
         self.emit(TypingActivityInput().with_text(text).with_channel_data(ChannelData(stream_type="informative")))
 
     async def _wait_for_id_and_queue(self):
-        """Wait until _id is set and the queue is empty, with a total timeout."""
+        """Wait until _id is set, the queue is empty, and no flush is in progress, with a total timeout."""
 
         async def _poll():
-            while (self._queue or not self._id) and not self._canceled:
+            while (self._queue or not self._id or self._lock.locked()) and not self._canceled:
                 await self._state_changed.wait()
                 self._state_changed.clear()
 
@@ -161,7 +161,9 @@ class HttpStream(StreamerProtocol):
         # Wait until _id is set and queue is empty
         result = await self._wait_for_id_and_queue()
         if not result:
-            logger.warning("Timeout while waiting for _id to be set and queue to be empty, cannot close stream")
+            logger.warning(
+                "Timeout while waiting for _id to be set, queue to be empty, and flush to complete, cannot close stream"
+            )
             return None
 
         has_content = (

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -158,7 +158,7 @@ class HttpStream(StreamerProtocol):
             logger.debug("stream has no content to send, returning None")
             return None
 
-        # Wait until _id is set and queue is empty
+        # Wait until _id is set, queue is empty, and no flush is in progress
         result = await self._wait_for_id_and_queue()
         if not result:
             logger.warning(

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -426,3 +426,30 @@ class TestHttpStream:
             assert result.activity_params.suggested_actions is not None
             assert len(result.activity_params.suggested_actions.actions) == 2
             assert result.activity_params.suggested_actions.actions[0].title == "Option A"
+
+    @pytest.mark.asyncio
+    async def test_close_waits_for_flush_to_complete(self, mock_api_client, conversation_reference):
+        """close() must not send the final message while a flush is still mid-await."""
+        stream = HttpStream(mock_api_client, conversation_reference)
+
+        # Simulate a flush in progress: lock held, _id assigned, text accumulated.
+        # This mirrors the window after the inner queue drain but before SendActivity awaits resolve.
+        await stream._lock.acquire()
+        stream._id = "activity-1"
+        stream._text = "Response text"
+
+        close_task = asyncio.create_task(stream.close())
+
+        # Give close() a chance to enter its wait loop, then confirm it has not sent the final message yet.
+        await asyncio.sleep(0.05)
+        assert mock_api_client.send_call_count == 0
+        assert not close_task.done()
+
+        # Release the lock and signal — close() should now proceed.
+        stream._lock.release()
+        stream._state_changed.set()
+
+        result = await close_task
+        assert result is not None
+        assert mock_api_client.send_call_count == 1
+        assert mock_api_client.sent_activities[0].text == "Response text"


### PR DESCRIPTION
Fixes #418

## Summary

`HttpStream.close()` could send the final stream message while `_flush()` was still mid-await, causing the final message to arrive before in-flight chunks finished sending.

This is the Python parity of [microsoft/teams.ts#553](https://github.com/microsoft/teams.ts/pull/553) (Bug 2 only — Bug 1 from the TS PR does not affect Python; `close()` already calls `with_channel_data()` before `add_stream_final()`).

## Root cause

`_wait_for_id_and_queue()` polled:

```python
while (self._queue or not self._id) and not self._canceled:
```

This checks the queue and `_id` but not whether `_flush()` is currently holding `self._lock`. After the inner `while self._queue` loop drains the queue, `_flush()` awaits `_send_activity(...)` calls under the lock. During those awaits:

- `self._queue` is empty (drained)
- `self._id` is set (after the first chunk)
- `self._lock` is still held

The predicate becomes false, the wait exits, and `close()` proceeds to send the final activity — racing the in-flight chunk.

## Fix

Add `self._lock.locked()` to the wait predicate. The lock primitive is already used in `close()`'s early-return guard at line 157, so this is consistent with existing patterns.

## Test plan

- [x] Added `test_close_waits_for_flush_to_complete` — holds `stream._lock` manually, asserts `close()` does not send the final message until the lock is released.
- [x] All existing http-stream tests still pass (14/14).
- [x] Full apps test suite passes (271 passed).
- [x] `poe check` passes (ruff format + lint).