### PR TITLE
fix(apps): support AAD v1 issuers in Entra token validation

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -108,7 +108,12 @@ class TokenValidator:
         env = cloud or PUBLIC
         valid_issuers: List[str] = []
         if tenant_id:
+            # Accept both Azure AD v2 (login.microsoftonline.com/.../v2.0) and
+            # v1 (sts.windows.net/.../) issuer formats. Some valid Entra tokens
+            # are still issued with the v1 issuer.
+            # See: https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens
             valid_issuers.append(f"{env.login_endpoint}/{tenant_id}/v2.0")
+            valid_issuers.append(f"https://sts.windows.net/{tenant_id}/")
         else:
             logger.warning(
                 "No tenant_id provided for Entra token validation. "

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -250,7 +250,10 @@ class TestTokenValidator:
     def test_for_entra_initialization(self, validator_entra):
         """Check Entra-specific initialization."""
         options = validator_entra.options
-        assert options.valid_issuers == ["https://login.microsoftonline.com/test-tenant-id/v2.0"]
+        assert options.valid_issuers == [
+            "https://login.microsoftonline.com/test-tenant-id/v2.0",
+            "https://sts.windows.net/test-tenant-id/",
+        ]
         assert options.valid_audiences == ["test-app-id", "api://test-app-id", "api://botid-test-app-id"]
         assert options.jwks_uri == "https://login.microsoftonline.com/test-tenant-id/discovery/v2.0/keys"
         assert options.scope == "user.read"
@@ -384,3 +387,23 @@ class TestTokenValidator:
             assert validator.options.valid_issuers == []
             assert "Issuer validation will be skipped" in caplog.text
 
+    @pytest.mark.asyncio
+    async def test_validate_entra_token_v1_sts_issuer(self, mock_jwks_client):
+        """Validator should accept the Azure AD v1 sts.windows.net issuer."""
+        validator = TokenValidator.for_entra(app_id="test-app-id", tenant_id="test-tenant-id", scope="user.read")
+        validator._jwks_client = mock_jwks_client
+        payload_v1 = {
+            "iss": "https://sts.windows.net/test-tenant-id/",
+            "aud": "test-app-id",
+            "scp": "user.read",
+            "appid": "test-app-id",
+            "tid": "test-tenant-id",
+            "ver": "1.0",
+            "exp": 9999999999,
+            "iat": 1000000000,
+        }
+
+        with patch("jwt.decode", return_value=payload_v1):
+            result = await validator.validate_token("v1.entra.token")
+            assert result["iss"] == "https://sts.windows.net/test-tenant-id/"
+            assert result["ver"] == "1.0"


### PR DESCRIPTION
## Summary

Mirrors [microsoft/teams.ts#556](https://github.com/microsoft/teams.ts/pull/556) in this codebase.

Some valid Microsoft Entra access tokens are issued with the Azure AD v1 issuer format (`https://sts.windows.net/{tenantId}/`) instead of the v2 issuer (`https://login.microsoftonline.com/{tenantId}/v2.0`). Today `TokenValidator.for_entra` only accepts the v2 form, causing valid v1 tokens to be rejected.

## Changes

- `packages/apps/src/microsoft_teams/apps/auth/token_validator.py`: when a `tenant_id` is provided, `TokenValidator.for_entra` now adds both the v2 (`{login_endpoint}/{tenant_id}/v2.0`) and v1 (`https://sts.windows.net/{tenant_id}/`) issuers to `valid_issuers`.
- `packages/apps/tests/test_token_validator.py`:
  - Updated `test_for_entra_initialization` to assert both issuers are present.
  - Added `test_validate_entra_token_v1_sts_issuer` covering acceptance of a v1 `sts.windows.net` issuer through the full validation pipeline.

Note: Unlike the TS PR, this change does not introduce multi-tenant `allowedTenantIds` semantics, since the Python `TokenValidator` doesn't currently expose multi-tenant configuration. The fix is kept narrowly scoped to issuer format acceptance.

Reference: https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens

## Test plan

- `uv run pytest packages/apps/tests/test_token_validator.py -q` — all 27 tests pass, including the new v1 issuer test.
