### PR TITLE
fix(apps): log inbound activities at info, warn on missing Authorization

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -95,11 +95,18 @@ class HttpServer:
             body = request["body"]
             headers = request["headers"]
 
+            entry_type = body.get("type", "unknown")
+            entry_id = body.get("id", "unknown")
+            logger.info("received activity: type=%s, id=%s", entry_type, entry_id)
+
             # Validate JWT token
             authorization = headers.get("authorization") or headers.get("Authorization") or ""
 
             if self._token_validator and not self._skip_auth:
                 if not authorization.startswith("Bearer "):
+                    logger.warning(
+                        "inbound activity rejected: missing or malformed Authorization header (responding 401)"
+                    )
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 
                 raw_token = authorization.removeprefix("Bearer ")

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import logging
+import re
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, Optional, cast
 
@@ -17,6 +18,14 @@ from ..events import ActivityEvent, CoreActivity
 from .adapter import HttpRequest, HttpResponse, HttpServerAdapter
 
 logger = logging.getLogger(__name__)
+
+_LOG_CONTROL_CHARS = re.compile(r"[\r\n\t\x00-\x1f\x7f]")
+
+
+def _safe_log_field(value: object) -> str:
+    """Strip control characters and cap length so an attacker-controlled activity
+    field cannot forge multi-line log entries (log injection)."""
+    return _LOG_CONTROL_CHARS.sub("", str(value if value is not None else "unknown"))[:64]
 
 
 class HttpServer:
@@ -95,8 +104,8 @@ class HttpServer:
             body = request["body"]
             headers = request["headers"]
 
-            entry_type = body.get("type", "unknown")
-            entry_id = body.get("id", "unknown")
+            entry_type = _safe_log_field(body.get("type"))
+            entry_id = _safe_log_field(body.get("id"))
             logger.info("received activity: type=%s, id=%s", entry_type, entry_id)
 
             # Validate JWT token
@@ -105,7 +114,10 @@ class HttpServer:
             if self._token_validator and not self._skip_auth:
                 if not authorization.startswith("Bearer "):
                     logger.warning(
-                        "inbound activity rejected: missing or malformed Authorization header (responding 401)"
+                        "inbound activity rejected (type=%s, id=%s): missing or malformed "
+                        "Authorization header (responding 401)",
+                        entry_type,
+                        entry_id,
                     )
                     return HttpResponse(status=401, body={"error": "Unauthorized"})
 

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -106,7 +106,6 @@ class HttpServer:
 
             entry_type = _safe_log_field(body.get("type"))
             entry_id = _safe_log_field(body.get("id"))
-            logger.info("received activity: type=%s, id=%s", entry_type, entry_id)
 
             # Validate JWT token
             authorization = headers.get("authorization") or headers.get("Authorization") or ""


### PR DESCRIPTION
## Summary
- Add a warn-level log on the missing-or-malformed Bearer token branch, replacing a previously silent 401.
- Cross-SDK consistency fix: same diagnostic gap exists in teams.ts (companion PR: microsoft/teams.ts#568).

## Test plan
- [x] `uv run poe check` (ruff format + ruff check, all pass)
- [x] `uv run pyright src/microsoft_teams/apps/http/http_server.py` (0 errors)
- [x] `uv run poe test` (580/580 pass)
- [ ] Reviewer eyeball: confirm log message wording