### PR TITLE
Mark reactions API as GA and fix sample remove flow

### DIFF
--- a/examples/reactions/src/main.py
+++ b/examples/reactions/src/main.py
@@ -46,19 +46,24 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
         return
 
     # ============================================
-    # Remove Reaction
+    # Remove Reaction (adds first so there's something to remove)
     # ============================================
     if text.startswith("unreact "):
         reaction_type = text[8:].strip()
 
+        await ctx.api.reactions.add(
+            conversation_id=conversation_id,
+            activity_id=activity_id,
+            reaction_type=reaction_type,
+        )
+        await ctx.reply(f"✅ Added {reaction_type} reaction, removing in 2s...")
+        await asyncio.sleep(2)
         await ctx.api.reactions.delete(
             conversation_id=conversation_id,
             activity_id=activity_id,
             reaction_type=reaction_type,
         )
-
-        await ctx.reply(f"✅ Removed {reaction_type} reaction from your message!")
-        print(f"[REACTION] Removed '{reaction_type}' from activity {activity_id}")
+        print(f"[REACTION] Cycled '{reaction_type}' on activity {activity_id}")
         return
 
     # ============================================
@@ -69,9 +74,9 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             "**Message Reactions Bot**\n\n"
             "**Commands:**\n"
             "- `react <type>` - Add a reaction to your message\n"
-            "- `unreact <type>` - Remove a reaction from your message\n\n"
+            "- `unreact <type>` - Add then remove a reaction (2s cycle) to demo deletion\n\n"
             "- `react like` - Adds a 👍 to your message\n"
-            "- `unreact like` - Removes the 👍 from your message"
+            "- `unreact like` - Adds a 👍 then removes it after 2 seconds"
         )
         return
 

--- a/packages/api/src/microsoft_teams/api/clients/reaction/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/reaction/client.py
@@ -5,7 +5,6 @@ Licensed under the MIT License.
 
 from typing import Optional
 
-from microsoft_teams.common.experimental import experimental
 from microsoft_teams.common.http import Client
 
 from ...models.message import MessageReactionType
@@ -13,14 +12,9 @@ from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 
 
-@experimental("ExperimentalTeamsReactions")
 class ReactionClient(BaseClient):
     """
     Client for working with app message reactions for a given conversation/activity.
-
-    .. warning:: Preview
-        This API is in preview and may change in the future.
-        Diagnostic: ExperimentalTeamsReactions
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

Removes the `@experimental("ExperimentalTeamsReactions")` decorator and the `.. warning:: Preview` docstring from `ReactionClient`. The reactions feature is in sync across all three SDKs and the Teams service — no longer preview.

Also fixes the sample's `unreact` command, which previously called `ctx.api.reactions.delete()` on an incoming message that had no reaction. It now adds the reaction first, waits 2 seconds, then deletes — so the demo visibly shows the full add/delete cycle.

## Cross-SDK coordination

Part of the cross-SDK Reactions-GA pass. Sibling PRs:
- microsoft/teams.ts — Mark reactions API as GA
- microsoft/teams.net — Mark reactions API as GA (Libraries + core)
- microsoft/teams-sdk — drop .NET opt-in tip from the reactions guide

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — 403 files already formatted
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run pytest` — 596 passed
- [ ] Smoke run of `examples/reactions` showing the cycle in Teams

## Versioning

No `version.json` change in this PR. Bump happens as part of the release flow per RELEASE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)