### PR TITLE
Bump version to 2.0.12-dev

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.1-dev.{height}",
+  "version": "2.0.12-dev.{height}",
   "versionHeightOffset": 1,
   "publicReleaseRefSpec": [
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary
- Bumps `version.json` from `2.0.1-dev.{height}` to `2.0.12-dev.{height}` to align with TS/NET after the 2.0.11 release

## Test plan
- [ ] Verify next CI build picks up `2.0.12.devN` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)