### PR TITLE
SuggestedActionSubmitActivity for suggestedAction/submit invoke

### DIFF
--- a/examples/suggested-actions/README.md
+++ b/examples/suggested-actions/README.md
@@ -1,0 +1,34 @@
+# Example: Suggested Action Submit
+
+A bot that demonstrates the `Action.Submit` suggested action and the `suggestedActions/submit` invoke it produces when clicked.
+
+## Behavior
+
+| Trigger | Behavior |
+|---------|----------|
+| Any user message | Bot replies with `Approve` / `Reject` suggested-action chips (`type: "Action.Submit"`, each with a structured `value`) |
+| User clicks a chip | Platform dispatches a `suggestedActions/submit` invoke; bot reads `activity.value` and echoes it back |
+
+## Notes
+
+- `Action.Submit` chips do not post a chat-visible message on the user's behalf — only the bot receives the click as a typed invoke.
+- The chip's `value` is delivered verbatim on `SuggestedActionSubmitInvokeActivity.value`.
+
+## Experimental API
+
+`CardActionType.SUBMIT`, `SuggestedActionSubmitInvokeActivity`, and `on_suggested_action_submit` are marked with `@experimental("ExperimentalTeamsSuggestedAction")` because the underlying platform feature is still rolling out.
+
+This sample opts in by suppressing the warning:
+
+```python
+warnings.filterwarnings("ignore", category=ExperimentalWarning, message=".*ExperimentalTeamsSuggestedAction.*")
+```
+
+When the API stabilizes, the `@experimental` decorator will be removed and the opt-in can be deleted.
+
+## Run
+
+```bash
+cd examples/suggested-actions
+uv run python src/main.py
+```

--- a/examples/suggested-actions/pyproject.toml
+++ b/examples/suggested-actions/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "suggested-actions"
+version = "0.1.0"
+description = "Suggested Action Submit example"
+readme = "README.md"
+requires-python = ">=3.12,<3.15"
+dependencies = [
+    "dotenv>=0.9.9",
+    "microsoft-teams-apps",
+    "microsoft-teams-api",
+]
+
+[tool.uv.sources]
+microsoft-teams-apps = { workspace = true }

--- a/examples/suggested-actions/src/main.py
+++ b/examples/suggested-actions/src/main.py
@@ -1,0 +1,50 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+import json
+import warnings
+
+from microsoft_teams.api import MessageActivity, MessageActivityInput
+from microsoft_teams.api.activities.invoke.suggested_action_submit import SuggestedActionSubmitInvokeActivity
+from microsoft_teams.api.models.card.card_action import CardAction
+from microsoft_teams.api.models.card.card_action_type import CardActionType
+from microsoft_teams.api.models.suggested_actions import SuggestedActions
+from microsoft_teams.apps import ActivityContext, App
+from microsoft_teams.common.experimental import ExperimentalWarning
+
+# SuggestedActionSubmit and on_suggested_action_submit are marked
+# @experimental("ExperimentalTeamsSuggestedAction"). See README.md.
+warnings.filterwarnings("ignore", category=ExperimentalWarning, message=".*ExperimentalTeamsSuggestedAction.*")
+
+app = App()
+
+
+# Reply to any user message with two Action.Submit suggested-action chips.
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    reply = MessageActivityInput(text="Approve or reject the request:").with_suggested_actions(
+        SuggestedActions(
+            to=[],
+            actions=[
+                CardAction(type=CardActionType.SUBMIT, title="Approve", value={"vote": "approve"}),
+                CardAction(type=CardActionType.SUBMIT, title="Reject", value={"vote": "reject"}),
+            ],
+        )
+    )
+    await ctx.send(reply)
+
+
+# Handle the resulting suggestedActions/submit invoke when the user clicks a chip.
+@app.on_suggested_action_submit
+async def handle_suggested_action_submit(ctx: ActivityContext[SuggestedActionSubmitInvokeActivity]) -> None:
+    serialized_value = json.dumps(ctx.activity.value) if ctx.activity.value is not None else "<none>"
+
+    ctx.logger.info(f"[SUGGESTED_ACTION_SUBMIT] value={serialized_value}")
+    await ctx.send(f"Got suggestedActions/submit with value: {serialized_value}")
+
+
+if __name__ == "__main__":
+    asyncio.run(app.start())

--- a/examples/suggested-actions/src/main.py
+++ b/examples/suggested-actions/src/main.py
@@ -40,7 +40,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
 # Handle the resulting suggestedActions/submit invoke when the user clicks a chip.
 @app.on_suggested_action_submit
 async def handle_suggested_action_submit(ctx: ActivityContext[SuggestedActionSubmitInvokeActivity]) -> None:
-    serialized_value = json.dumps(ctx.activity.value) if ctx.activity.value is not None else "<none>"
+    serialized_value = json.dumps(ctx.activity.value)
 
     ctx.logger.info(f"[SUGGESTED_ACTION_SUBMIT] value={serialized_value}")
     await ctx.send(f"Got suggestedActions/submit with value: {serialized_value}")

--- a/packages/api/src/microsoft_teams/api/activities/invoke/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/invoke/__init__.py
@@ -25,6 +25,7 @@ from .message_extension import *  # noqa: F403
 from .message_extension import MessageExtensionInvokeActivity
 from .sign_in import *  # noqa: F403
 from .sign_in import SignInInvokeActivity
+from .suggested_action_submit import SuggestedActionSubmitInvokeActivity
 from .tab import *  # noqa: F403
 from .tab import TabInvokeActivity
 from .task import *  # noqa: F403
@@ -43,6 +44,7 @@ InvokeActivity = Annotated[
         HandoffActionInvokeActivity,
         SignInInvokeActivity,
         AdaptiveCardInvokeActivity,
+        SuggestedActionSubmitInvokeActivity,
     ],
     Field(discriminator="name"),
 ]
@@ -63,6 +65,7 @@ __all__ = [
     "HandoffActionInvokeActivity",
     "SignInInvokeActivity",
     "AdaptiveCardInvokeActivity",
+    "SuggestedActionSubmitInvokeActivity",
 ]
 
 __all__.extend(config.__all__)

--- a/packages/api/src/microsoft_teams/api/activities/invoke/suggested_action_submit.py
+++ b/packages/api/src/microsoft_teams/api/activities/invoke/suggested_action_submit.py
@@ -1,0 +1,25 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Any, Literal, Optional
+
+from microsoft_teams.common.experimental import experimental
+
+from ..invoke_activity import InvokeActivity
+
+
+@experimental("ExperimentalTeamsSuggestedAction")
+class SuggestedActionSubmitInvokeActivity(InvokeActivity):
+    """
+    Sent when the user clicks a suggested action of type Action.Submit.
+
+    The structured payload authored on the suggested action is delivered via value.
+    """
+
+    name: Literal["suggestedActions/submit"] = "suggestedActions/submit"
+    """The name of the invoke operation."""
+
+    value: Optional[Any] = None
+    """The structured value from the suggested action."""

--- a/packages/api/src/microsoft_teams/api/activities/invoke/suggested_action_submit.py
+++ b/packages/api/src/microsoft_teams/api/activities/invoke/suggested_action_submit.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from microsoft_teams.common.experimental import experimental
 
@@ -21,5 +21,5 @@ class SuggestedActionSubmitInvokeActivity(InvokeActivity):
     name: Literal["suggestedActions/submit"] = "suggestedActions/submit"
     """The name of the invoke operation."""
 
-    value: Optional[Any] = None
+    value: Any
     """The structured value from the suggested action."""

--- a/packages/api/src/microsoft_teams/api/models/card/card_action_type.py
+++ b/packages/api/src/microsoft_teams/api/models/card/card_action_type.py
@@ -19,3 +19,4 @@ class CardActionType(str, Enum):
     SIGN_IN = "signin"
     CALL = "call"
     INVOKE = "invoke"
+    SUBMIT = "Action.Submit"

--- a/packages/api/src/microsoft_teams/api/models/card/card_action_type.py
+++ b/packages/api/src/microsoft_teams/api/models/card/card_action_type.py
@@ -20,3 +20,5 @@ class CardActionType(str, Enum):
     CALL = "call"
     INVOKE = "invoke"
     SUBMIT = "Action.Submit"
+    """Suggested action of type Action.Submit. The action's value is delivered to the bot
+    as a suggestedActions/submit invoke without sending a chat-visible message."""

--- a/packages/api/tests/fixtures/suggested_action_submit_invoke_activity.json
+++ b/packages/api/tests/fixtures/suggested_action_submit_invoke_activity.json
@@ -1,0 +1,20 @@
+{
+    "id": "suggestedActionSubmitId",
+    "type": "invoke",
+    "channelId": "channelId",
+    "name": "suggestedActions/submit",
+    "from": {
+        "id": "user-1",
+        "name": "Test User"
+    },
+    "conversation": {
+        "id": "conv-1"
+    },
+    "recipient": {
+        "id": "bot-1",
+        "name": "Test Bot"
+    },
+    "value": {
+        "vote": "approve"
+    }
+}

--- a/packages/api/tests/unit/test_fixtures.py
+++ b/packages/api/tests/unit/test_fixtures.py
@@ -9,11 +9,13 @@ from typing import Type
 
 import pytest
 from microsoft_teams.api.activities.invoke.sign_in import SignInFailureInvokeActivity
+from microsoft_teams.api.activities.invoke.suggested_action_submit import SuggestedActionSubmitInvokeActivity
 from pydantic import BaseModel
 
 # Map fixture filenames to their expected activity types
 FIXTURE_ACTIVITY_MAP = {
     "signin_failure_invoke_activity.json": SignInFailureInvokeActivity,
+    "suggested_action_submit_invoke_activity.json": SuggestedActionSubmitInvokeActivity,
 }
 
 

--- a/packages/api/tests/unit/test_suggested_action_submit.py
+++ b/packages/api/tests/unit/test_suggested_action_submit.py
@@ -40,7 +40,9 @@ class TestSuggestedActionSubmitInvokeActivity:
 
     def test_deserialize_dispatched_from_activity_base(self, fixture_json: dict) -> None:
         """Test that the activity is dispatched correctly from the Activity discriminated union."""
-        activity = ActivityTypeAdapter.validate_python(fixture_json)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ExperimentalWarning)
+            activity = ActivityTypeAdapter.validate_python(fixture_json)
 
         assert isinstance(activity, SuggestedActionSubmitInvokeActivity)
         assert activity.name == "suggestedActions/submit"

--- a/packages/api/tests/unit/test_suggested_action_submit.py
+++ b/packages/api/tests/unit/test_suggested_action_submit.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+from microsoft_teams.api.activities import ActivityTypeAdapter
+from microsoft_teams.api.activities.invoke.suggested_action_submit import SuggestedActionSubmitInvokeActivity
+from microsoft_teams.api.models.card.card_action import CardAction
+from microsoft_teams.api.models.card.card_action_type import CardActionType
+from microsoft_teams.api.models.suggested_actions import SuggestedActions
+from microsoft_teams.common.experimental import ExperimentalWarning
+
+
+@pytest.fixture
+def fixture_json() -> dict:
+    fixture_path = Path(__file__).parent.parent / "fixtures" / "suggested_action_submit_invoke_activity.json"
+    with open(fixture_path) as f:
+        return json.load(f)
+
+
+@pytest.mark.unit
+class TestSuggestedActionSubmitInvokeActivity:
+    """Unit tests for SuggestedActionSubmitInvokeActivity."""
+
+    def test_deserialize_directly(self, fixture_json: dict) -> None:
+        """Test deserializing directly into SuggestedActionSubmitInvokeActivity."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", ExperimentalWarning)
+            activity = SuggestedActionSubmitInvokeActivity.model_validate(fixture_json)
+
+        assert activity.id == "suggestedActionSubmitId"
+        assert activity.channel_id == "channelId"
+        assert activity.name == "suggestedActions/submit"
+        assert activity.value == {"vote": "approve"}
+
+    def test_deserialize_dispatched_from_activity_base(self, fixture_json: dict) -> None:
+        """Test that the activity is dispatched correctly from the Activity discriminated union."""
+        activity = ActivityTypeAdapter.validate_python(fixture_json)
+
+        assert isinstance(activity, SuggestedActionSubmitInvokeActivity)
+        assert activity.name == "suggestedActions/submit"
+        assert activity.value == {"vote": "approve"}
+
+    def test_outgoing_message_with_action_submit_suggested_action(self) -> None:
+        """Test that a message with Action.Submit suggested actions serializes correctly."""
+        actions = [
+            CardAction(type=CardActionType.SUBMIT, title="Approve", value={"vote": "approve"}),
+            CardAction(type=CardActionType.SUBMIT, title="Reject", value={"vote": "reject"}),
+        ]
+        suggested_actions = SuggestedActions(to=[], actions=actions)
+
+        data = suggested_actions.model_dump(by_alias=True)
+
+        assert data["actions"][0]["type"] == "Action.Submit"
+        assert data["actions"][0]["title"] == "Approve"
+        assert data["actions"][0]["value"] == {"vote": "approve"}
+        assert data["actions"][1]["type"] == "Action.Submit"
+        assert data["actions"][1]["title"] == "Reject"
+        assert data["actions"][1]["value"] == {"vote": "reject"}
+
+    def test_experimental_warning_emitted(self, fixture_json: dict) -> None:
+        """Test that the class is marked experimental."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            SuggestedActionSubmitInvokeActivity(
+                id="test",
+                from_={"id": "u1", "name": "U"},
+                conversation={"id": "c1"},
+                recipient={"id": "b1", "name": "B"},
+            )
+
+        experimental_warnings = [x for x in w if issubclass(x.category, ExperimentalWarning)]
+        assert len(experimental_warnings) == 1
+        assert "ExperimentalTeamsSuggestedAction" in str(experimental_warnings[0].message)

--- a/packages/api/tests/unit/test_suggested_action_submit.py
+++ b/packages/api/tests/unit/test_suggested_action_submit.py
@@ -74,6 +74,7 @@ class TestSuggestedActionSubmitInvokeActivity:
                 from_={"id": "u1", "name": "U"},
                 conversation={"id": "c1"},
                 recipient={"id": "b1", "name": "B"},
+                value={"vote": "approve"},
             )
 
         experimental_warnings = [x for x in w if issubclass(x.category, ExperimentalWarning)]

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
@@ -46,6 +46,7 @@ from microsoft_teams.api import (
     SignInFailureInvokeActivity,
     SignInTokenExchangeInvokeActivity,
     SignInVerifyStateInvokeActivity,
+    SuggestedActionSubmitInvokeActivity,
     TabFetchInvokeActivity,
     TabInvokeResponse,
     TabSubmitInvokeActivity,
@@ -485,6 +486,15 @@ ACTIVITY_ROUTES: Dict[str, ActivityConfig] = {
         method_name="on_handoff_action",
         input_model=HandoffActionInvokeActivity,
         selector=lambda activity: activity.type == "invoke" and cast(InvokeActivity, activity).name == "handoff/action",
+        output_model=None,
+        is_invoke=True,
+    ),
+    "suggested_action.submit": ActivityConfig(
+        name="suggested_action.submit",
+        method_name="on_suggested_action_submit",
+        input_model=SuggestedActionSubmitInvokeActivity,
+        selector=lambda activity: activity.type == "invoke"
+        and cast(InvokeActivity, activity).name == "suggestedActions/submit",
         output_model=None,
         is_invoke=True,
     ),

--- a/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
@@ -50,6 +50,7 @@ from microsoft_teams.api.activities import (
     SignInFailureInvokeActivity,
     SignInTokenExchangeInvokeActivity,
     SignInVerifyStateInvokeActivity,
+    SuggestedActionSubmitInvokeActivity,
     TabFetchInvokeActivity,
     TabSubmitInvokeActivity,
     TypingActivity,
@@ -1368,6 +1369,41 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> VoidInvokeHandler[HandoffActionInvokeActivity]:
             validate_handler_type(func, HandoffActionInvokeActivity, "on_handoff_action", "HandoffActionInvokeActivity")
             config = ACTIVITY_ROUTES["handoff.action"]
+            self.router.add_handler(config.selector, func)
+            return func
+
+        if handler is not None:
+            return decorator(handler)
+        return decorator
+
+    @overload
+    def on_suggested_action_submit(
+        self, handler: VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]
+    ) -> VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]: ...
+
+    @overload
+    def on_suggested_action_submit(
+        self,
+    ) -> Callable[
+        [VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]],
+        VoidInvokeHandler[SuggestedActionSubmitInvokeActivity],
+    ]: ...
+
+    def on_suggested_action_submit(
+        self, handler: Optional[VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]] = None
+    ) -> VoidInvokeHandlerUnion[SuggestedActionSubmitInvokeActivity]:
+        """Register a suggested_action.submit activity handler."""
+
+        def decorator(
+            func: VoidInvokeHandler[SuggestedActionSubmitInvokeActivity],
+        ) -> VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]:
+            validate_handler_type(
+                func,
+                SuggestedActionSubmitInvokeActivity,
+                "on_suggested_action_submit",
+                "SuggestedActionSubmitInvokeActivity",
+            )
+            config = ACTIVITY_ROUTES["suggested_action.submit"]
             self.router.add_handler(config.selector, func)
             return func
 


### PR DESCRIPTION
Adds support for `suggestedActions/submit` invoke activity - dispatched by the platform when a user clicks an `Action.Submit` suggested-action click.

- New `SuggestedActionSubmitInvokeActivity` model and `on_suggested_action_submit` handler.
- New `CardActionType.SUBMIT` enum value for constructing outbound suggested-action chips.
- Marked `@experimental("ExperimentalTeamsSuggestedAction")` until the platform feature stabilizes.
- New `examples/suggested-actions` sample app.


<img width="1017" height="243" alt="image" src="https://github.com/user-attachments/assets/6a55d339-9cef-4d88-ae9d-0654388b1335" />
