### PR TITLE
feat: warn when bot starts without credentials

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -94,6 +94,12 @@ class HttpServer:
                 cloud=self._cloud,
             )
             logger.debug("JWT validation enabled for %s", self._messaging_endpoint)
+        elif not app_id:
+            logger.warning(
+                "No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). "
+                "Bot will accept unauthenticated requests on %s.",
+                self._messaging_endpoint,
+            )
 
         self._adapter.register_route("POST", self._messaging_endpoint, self.handle_request)
         self._initialized = True

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -74,6 +74,28 @@ class TestHttpServer:
         assert call_args[0][0] == "POST"
         assert call_args[0][1] == "/bot/incoming"
 
+    def test_initialize_warns_when_no_credentials(self, server, caplog):
+        """Bot started without credentials should log a warning about anonymous traffic."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="microsoft_teams.apps.http.http_server"):
+            server.initialize(credentials=None)
+
+        assert any("No credentials configured" in record.message for record in caplog.records)
+
+    def test_initialize_does_not_warn_with_credentials(self, server, caplog):
+        """Bot started with credentials should not log the anonymous warning."""
+        import logging
+
+        creds = MagicMock()
+        creds.client_id = "test-app"
+        creds.tenant_id = "test-tenant"
+
+        with caplog.at_level(logging.WARNING, logger="microsoft_teams.apps.http.http_server"):
+            server.initialize(credentials=creds)
+
+        assert not any("No credentials configured" in record.message for record in caplog.records)
+
     def test_on_request_setter(self, server):
         """Test on_request callback setter."""
 


### PR DESCRIPTION
## Summary

- Add a startup warning in `HttpServer.initialize()` when no `CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID` is configured, so customers running anonymously know their bot accepts unauthenticated requests on `/api/messages`.
- 2 new unit tests in `test_http_server.py` covering: warning fires when no creds, warning does not fire when creds present.

## Why

Part of the DevTools deprecation rollout. The recommended local-testing path with Microsoft 365 Agents Playground is anonymous mode (no creds configured). The new warning makes that mode explicit at startup, so customers don't ship anonymous-mode bots to production by accident, and so the migration from DevTools to Playground produces a clear signal.

Behavior is unchanged. This is pure observability.

## Test plan

- [x] `pytest tests/test_http_server.py` (22/22 passing)
- [x] Confirmed warning text matches the wording used in teams.ts and teams.net for cross-SDK consistency
- [x] Verified at runtime by initializing `App()` without credentials. Output:
  ```
  [WARNING] microsoft_teams.apps.http.http_server: No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). Bot will accept unauthenticated requests on /api/messages.
  ```
  Note: Uvicorn's `dictConfig` replaces the default root-logger handler at server-startup, so consumers running through Uvicorn need their own logging config (or `logging.basicConfig(level=WARNING)`) to see this warning. Customers using the standard Agents templates already have logging configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)