### PR TITLE
fix(apps): allow sign-in handlers to override default routes

### DIFF
--- a/packages/apps/scripts/generate_handlers.py
+++ b/packages/apps/scripts/generate_handlers.py
@@ -121,7 +121,7 @@ def generate_method(config: ActivityConfig, config_key: str) -> str:
         def decorator(func: {handler_type}) -> {handler_type}:
             validate_handler_type(func, {input_class_name}, "{method_name}", "{input_class_name}")
             config = ACTIVITY_ROUTES["{config_key}"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -160,13 +160,13 @@ class App(ActivityHandlerMixin):
         self.router.add_handler(
             ACTIVITY_ROUTES["signin.token-exchange"].selector,
             oauth_handlers.sign_in_token_exchange,
-            route_name="signin.token-exchange",
+            route_name=ACTIVITY_ROUTES["signin.token-exchange"].name,
             route_type="system",
         )
         self.router.add_handler(
             ACTIVITY_ROUTES["signin.verify-state"].selector,
             oauth_handlers.sign_in_verify_state,
-            route_name="signin.verify-state",
+            route_name=ACTIVITY_ROUTES["signin.verify-state"].name,
             route_type="system",
         )
         self.on_signin_failure(oauth_handlers.sign_in_failure)

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -157,16 +157,18 @@ class App(ActivityHandlerMixin):
             default_connection_name=self.options.default_connection_name,
             event_emitter=self._events,
         )
+        signin_token_exchange_route = ACTIVITY_ROUTES["signin.token-exchange"]
         self.router.add_handler(
-            ACTIVITY_ROUTES["signin.token-exchange"].selector,
+            signin_token_exchange_route.selector,
             oauth_handlers.sign_in_token_exchange,
-            route_name=ACTIVITY_ROUTES["signin.token-exchange"].name,
+            route_name=signin_token_exchange_route.name,
             route_type="system",
         )
+        signin_verify_state_route = ACTIVITY_ROUTES["signin.verify-state"]
         self.router.add_handler(
-            ACTIVITY_ROUTES["signin.verify-state"].selector,
+            signin_verify_state_route.selector,
             oauth_handlers.sign_in_verify_state,
-            route_name=ACTIVITY_ROUTES["signin.verify-state"].name,
+            route_name=signin_verify_state_route.name,
             route_type="system",
         )
         self.on_signin_failure(oauth_handlers.sign_in_failure)

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -58,6 +58,7 @@ from .options import AppOptions, InternalAppOptions
 from .plugins import PluginBase, PluginStartEvent
 from .routing import ActivityHandlerMixin, ActivityRouter
 from .routing.activity_context import ActivityContext
+from .routing.activity_route_configs import ACTIVITY_ROUTES
 from .token_manager import TokenManager
 from .utils import create_graph_client
 from .utils.thread import to_threaded_conversation_id
@@ -156,8 +157,18 @@ class App(ActivityHandlerMixin):
             default_connection_name=self.options.default_connection_name,
             event_emitter=self._events,
         )
-        self.on_signin_token_exchange(oauth_handlers.sign_in_token_exchange)
-        self.on_signin_verify_state(oauth_handlers.sign_in_verify_state)
+        self.router.add_handler(
+            ACTIVITY_ROUTES["signin.token-exchange"].selector,
+            oauth_handlers.sign_in_token_exchange,
+            route_name="signin.token-exchange",
+            route_type="system",
+        )
+        self.router.add_handler(
+            ACTIVITY_ROUTES["signin.verify-state"].selector,
+            oauth_handlers.sign_in_verify_state,
+            route_name="signin.verify-state",
+            route_type="system",
+        )
         self.on_signin_failure(oauth_handlers.sign_in_failure)
 
         self.entra_token_validator: Optional[TokenValidator] = None

--- a/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
@@ -100,7 +100,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageActivity]) -> BasicHandler[MessageActivity]:
             validate_handler_type(func, MessageActivity, "on_message", "MessageActivity")
             config = ACTIVITY_ROUTES["message"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -125,7 +125,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageDeleteActivity]) -> BasicHandler[MessageDeleteActivity]:
             validate_handler_type(func, MessageDeleteActivity, "on_message_delete", "MessageDeleteActivity")
             config = ACTIVITY_ROUTES["message_delete"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -150,7 +150,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageDeleteActivity]) -> BasicHandler[MessageDeleteActivity]:
             validate_handler_type(func, MessageDeleteActivity, "on_soft_delete_message", "MessageDeleteActivity")
             config = ACTIVITY_ROUTES["soft_delete_message"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -175,7 +175,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageReactionActivity]) -> BasicHandler[MessageReactionActivity]:
             validate_handler_type(func, MessageReactionActivity, "on_message_reaction", "MessageReactionActivity")
             config = ACTIVITY_ROUTES["message_reaction"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -200,7 +200,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageUpdateActivity]) -> BasicHandler[MessageUpdateActivity]:
             validate_handler_type(func, MessageUpdateActivity, "on_message_update", "MessageUpdateActivity")
             config = ACTIVITY_ROUTES["message_update"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -225,7 +225,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageUpdateActivity]) -> BasicHandler[MessageUpdateActivity]:
             validate_handler_type(func, MessageUpdateActivity, "on_undelete_message", "MessageUpdateActivity")
             config = ACTIVITY_ROUTES["undelete_message"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -248,7 +248,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MessageUpdateActivity]) -> BasicHandler[MessageUpdateActivity]:
             validate_handler_type(func, MessageUpdateActivity, "on_edit_message", "MessageUpdateActivity")
             config = ACTIVITY_ROUTES["edit_message"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -269,7 +269,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[CommandSendActivity]) -> BasicHandler[CommandSendActivity]:
             validate_handler_type(func, CommandSendActivity, "on_command", "CommandSendActivity")
             config = ACTIVITY_ROUTES["command"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -294,7 +294,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[CommandResultActivity]) -> BasicHandler[CommandResultActivity]:
             validate_handler_type(func, CommandResultActivity, "on_command_result", "CommandResultActivity")
             config = ACTIVITY_ROUTES["command_result"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -321,7 +321,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, ConversationUpdateActivity, "on_conversation_update", "ConversationUpdateActivity"
             )
             config = ACTIVITY_ROUTES["conversation_update"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -346,7 +346,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_channel_created", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["channel_created"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -371,7 +371,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_channel_deleted", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["channel_deleted"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -396,7 +396,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_channel_renamed", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["channel_renamed"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -421,7 +421,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_channel_restored", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["channel_restored"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -446,7 +446,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_team_archived", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["team_archived"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -471,7 +471,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_team_deleted", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["team_deleted"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -498,7 +498,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, ConversationUpdateActivity, "on_team_hard_deleted", "ConversationUpdateActivity"
             )
             config = ACTIVITY_ROUTES["team_hard_deleted"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -523,7 +523,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_team_renamed", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["team_renamed"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -548,7 +548,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_team_restored", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["team_restored"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -573,7 +573,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ConversationUpdateActivity]) -> BasicHandler[ConversationUpdateActivity]:
             validate_handler_type(func, ConversationUpdateActivity, "on_team_unarchived", "ConversationUpdateActivity")
             config = ACTIVITY_ROUTES["team_unarchived"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -592,7 +592,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[EventActivity]) -> BasicHandler[EventActivity]:
             validate_handler_type(func, EventActivity, "on_event", "EventActivity")
             config = ACTIVITY_ROUTES["event"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -617,7 +617,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[ReadReceiptEventActivity]) -> BasicHandler[ReadReceiptEventActivity]:
             validate_handler_type(func, ReadReceiptEventActivity, "on_read_receipt", "ReadReceiptEventActivity")
             config = ACTIVITY_ROUTES["read_receipt"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -642,7 +642,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MeetingStartEventActivity]) -> BasicHandler[MeetingStartEventActivity]:
             validate_handler_type(func, MeetingStartEventActivity, "on_meeting_start", "MeetingStartEventActivity")
             config = ACTIVITY_ROUTES["meeting_start"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -667,7 +667,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[MeetingEndEventActivity]) -> BasicHandler[MeetingEndEventActivity]:
             validate_handler_type(func, MeetingEndEventActivity, "on_meeting_end", "MeetingEndEventActivity")
             config = ACTIVITY_ROUTES["meeting_end"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -701,7 +701,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MeetingParticipantJoinEventActivity",
             )
             config = ACTIVITY_ROUTES["meeting_participant_join"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -735,7 +735,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MeetingParticipantLeaveEventActivity",
             )
             config = ACTIVITY_ROUTES["meeting_participant_leave"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -765,7 +765,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> InvokeHandler[ConfigFetchInvokeActivity, ConfigInvokeResponse]:
             validate_handler_type(func, ConfigFetchInvokeActivity, "on_config_open", "ConfigFetchInvokeActivity")
             config = ACTIVITY_ROUTES["config.open"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -795,7 +795,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> InvokeHandler[ConfigSubmitInvokeActivity, ConfigInvokeResponse]:
             validate_handler_type(func, ConfigSubmitInvokeActivity, "on_config_submit", "ConfigSubmitInvokeActivity")
             config = ACTIVITY_ROUTES["config.submit"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -822,7 +822,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> VoidInvokeHandler[FileConsentInvokeActivity]:
             validate_handler_type(func, FileConsentInvokeActivity, "on_file_consent", "FileConsentInvokeActivity")
             config = ACTIVITY_ROUTES["file.consent"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -851,7 +851,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, ExecuteActionInvokeActivity, "on_message_execute", "ExecuteActionInvokeActivity"
             )
             config = ACTIVITY_ROUTES["message.execute"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -889,7 +889,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionQueryLinkInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.query-link"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -927,7 +927,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionAnonQueryLinkInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.anon-query-link"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -960,7 +960,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, MessageExtensionQueryInvokeActivity, "on_message_ext_query", "MessageExtensionQueryInvokeActivity"
             )
             config = ACTIVITY_ROUTES["message.ext.query"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -998,7 +998,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionSelectItemInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.select-item"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1036,7 +1036,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionSubmitActionInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.submit"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1074,7 +1074,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionFetchTaskInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.open"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1112,7 +1112,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionQuerySettingUrlInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.query-settings-url"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1150,7 +1150,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionSettingInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.setting"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1185,7 +1185,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageExtensionCardButtonClickedInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.ext.card-button-clicked"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1215,7 +1215,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> InvokeHandler[TabFetchInvokeActivity, TabInvokeResponse]:
             validate_handler_type(func, TabFetchInvokeActivity, "on_tab_open", "TabFetchInvokeActivity")
             config = ACTIVITY_ROUTES["tab.open"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1245,7 +1245,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> InvokeHandler[TabSubmitInvokeActivity, TabInvokeResponse]:
             validate_handler_type(func, TabSubmitInvokeActivity, "on_tab_submit", "TabSubmitInvokeActivity")
             config = ACTIVITY_ROUTES["tab.submit"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1277,7 +1277,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, MessageFetchTaskInvokeActivity, "on_message_fetch_task", "MessageFetchTaskInvokeActivity"
             )
             config = ACTIVITY_ROUTES["message.fetch-task"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1308,7 +1308,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, MessageSubmitActionInvokeActivity, "on_message_submit", "MessageSubmitActionInvokeActivity"
             )
             config = ACTIVITY_ROUTES["message.submit"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1342,7 +1342,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 "MessageSubmitActionInvokeActivity",
             )
             config = ACTIVITY_ROUTES["message.submit.feedback"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1369,7 +1369,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> VoidInvokeHandler[HandoffActionInvokeActivity]:
             validate_handler_type(func, HandoffActionInvokeActivity, "on_handoff_action", "HandoffActionInvokeActivity")
             config = ACTIVITY_ROUTES["handoff.action"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1437,7 +1437,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, SignInTokenExchangeInvokeActivity, "on_signin_token_exchange", "SignInTokenExchangeInvokeActivity"
             )
             config = ACTIVITY_ROUTES["signin.token-exchange"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1468,7 +1468,7 @@ class GeneratedActivityHandlerMixin(ABC):
                 func, SignInVerifyStateInvokeActivity, "on_signin_verify_state", "SignInVerifyStateInvokeActivity"
             )
             config = ACTIVITY_ROUTES["signin.verify-state"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1495,7 +1495,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> VoidInvokeHandler[SignInFailureInvokeActivity]:
             validate_handler_type(func, SignInFailureInvokeActivity, "on_signin_failure", "SignInFailureInvokeActivity")
             config = ACTIVITY_ROUTES["signin.failure"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1525,7 +1525,7 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> InvokeHandler[AdaptiveCardInvokeActivity, AdaptiveCardInvokeResponse]:
             validate_handler_type(func, AdaptiveCardInvokeActivity, "on_card_action", "AdaptiveCardInvokeActivity")
             config = ACTIVITY_ROUTES["card.action"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1544,7 +1544,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[InvokeActivity]) -> BasicHandler[InvokeActivity]:
             validate_handler_type(func, InvokeActivity, "on_invoke", "InvokeActivity")
             config = ACTIVITY_ROUTES["invoke"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1569,7 +1569,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[InstallUpdateActivity]) -> BasicHandler[InstallUpdateActivity]:
             validate_handler_type(func, InstallUpdateActivity, "on_installation_update", "InstallUpdateActivity")
             config = ACTIVITY_ROUTES["installation_update"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1590,7 +1590,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[InstalledActivity]) -> BasicHandler[InstalledActivity]:
             validate_handler_type(func, InstalledActivity, "on_install_add", "InstalledActivity")
             config = ACTIVITY_ROUTES["install.add"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1611,7 +1611,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[UninstalledActivity]) -> BasicHandler[UninstalledActivity]:
             validate_handler_type(func, UninstalledActivity, "on_install_remove", "UninstalledActivity")
             config = ACTIVITY_ROUTES["install.remove"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1630,7 +1630,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[TypingActivity]) -> BasicHandler[TypingActivity]:
             validate_handler_type(func, TypingActivity, "on_typing", "TypingActivity")
             config = ACTIVITY_ROUTES["typing"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:
@@ -1649,7 +1649,7 @@ class GeneratedActivityHandlerMixin(ABC):
         def decorator(func: BasicHandler[Activity]) -> BasicHandler[Activity]:
             validate_handler_type(func, Activity, "on_activity", "Activity")
             config = ACTIVITY_ROUTES["activity"]
-            self.router.add_handler(config.selector, func)
+            self.router.add_handler(config.selector, func, route_name=config.name)
             return func
 
         if handler is not None:

--- a/packages/apps/src/microsoft_teams/apps/routing/router.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/router.py
@@ -20,7 +20,7 @@ RouteType = Literal["system", "user"]
 class RouteEntry:
     selector: RouteSelector
     handler: ActivityHandler
-    route_name: str | None = None
+    route_name: Optional[str] = None
     route_type: RouteType = "user"
 
 
@@ -35,10 +35,14 @@ class ActivityRouter:
         selector: RouteSelector,
         handler: ActivityHandler,
         *,
-        route_name: str | None = None,
+        route_name: Optional[str] = None,
         route_type: RouteType = "user",
     ) -> None:
-        """Add a handler for a specific activity configuration."""
+        """Add handler for activity config.
+
+        Registering `route_type="user"` with matching `route_name` removes
+        previously registered system route of same name so user handler wins.
+        """
         if route_type == "user" and route_name is not None:
             self._routes = [
                 route for route in self._routes if not (route.route_name == route_name and route.route_type == "system")

--- a/packages/apps/src/microsoft_teams/apps/routing/router.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/router.py
@@ -40,8 +40,9 @@ class ActivityRouter:
     ) -> None:
         """Add handler for activity config.
 
-        Registering `route_type="user"` with matching `route_name` removes
-        previously registered system route of same name so user handler wins.
+        Registering `route_type="user"` with matching `route_name` removes any
+        previously registered `route_type="system"` entry with same route name.
+        This lets app-defined handlers override built-in defaults for that route.
         """
         if route_type == "user" and route_name is not None:
             self._routes = [

--- a/packages/apps/src/microsoft_teams/apps/routing/router.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/router.py
@@ -3,7 +3,8 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Any, Awaitable, Callable, List, Optional
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, List, Literal, Optional
 
 from microsoft_teams.api.models import ActivityBase
 
@@ -12,22 +13,50 @@ from .activity_route_configs import RouteSelector
 
 # Type alias for activity handlers
 ActivityHandler = Callable[[ActivityContext[ActivityBase]], Awaitable[Optional[Any]]]
+RouteType = Literal["system", "user"]
+
+
+@dataclass(frozen=True)
+class RouteEntry:
+    selector: RouteSelector
+    handler: ActivityHandler
+    route_name: str | None = None
+    route_type: RouteType = "user"
 
 
 class ActivityRouter:
     """Routes incoming activities to registered handlers using selector functions."""
 
     def __init__(self):
-        self._routes: List[tuple[RouteSelector, ActivityHandler]] = []
+        self._routes: List[RouteEntry] = []
 
-    def add_handler(self, selector: RouteSelector, handler: ActivityHandler) -> None:
+    def add_handler(
+        self,
+        selector: RouteSelector,
+        handler: ActivityHandler,
+        *,
+        route_name: str | None = None,
+        route_type: RouteType = "user",
+    ) -> None:
         """Add a handler for a specific activity configuration."""
-        self._routes.append((selector, handler))
+        if route_type == "user" and route_name is not None:
+            self._routes = [
+                route for route in self._routes if not (route.route_name == route_name and route.route_type == "system")
+            ]
+
+        self._routes.append(
+            RouteEntry(
+                selector=selector,
+                handler=handler,
+                route_name=route_name,
+                route_type=route_type,
+            )
+        )
 
     def select_handlers(self, activity: ActivityBase) -> List[ActivityHandler]:
         """Select all handlers that match the given activity using selector functions."""
         matching_handlers: List[ActivityHandler] = []
-        for selector, handler in self._routes:
-            if selector(activity):
-                matching_handlers.append(handler)
+        for route in self._routes:
+            if route.selector(activity):
+                matching_handlers.append(route.handler)
         return matching_handlers

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -22,6 +22,8 @@ from microsoft_teams.api import (
     MessageActivity,
     MessageActivityInput,
     SentActivity,
+    SignInExchangeToken,
+    SignInTokenExchangeInvokeActivity,
     TokenCredentials,
     TokenProtocol,
     TypingActivity,
@@ -218,7 +220,33 @@ class TestApp:
         assert isinstance(activity_events[0], ActivityEvent)
         # The event contains the core activity
         assert activity_events[0].body.id == core_activity.id
-        assert activity_events[0].body.type == core_activity.type
+
+    def test_custom_signin_token_exchange_handler_replaces_default(self, app_with_options: App) -> None:
+        """Registering a sign-in token exchange handler replaces the built-in default route."""
+
+        async def custom_handler(ctx) -> None:
+            return None
+
+        app_with_options.on_signin_token_exchange(custom_handler)
+
+        activity = SignInTokenExchangeInvokeActivity(
+            type="invoke",
+            id="activity-789",
+            from_=Account(id="user-123", name="Test User", role="user"),
+            recipient=Account(id="bot-456", name="Test Bot", role="bot"),
+            conversation=ConversationAccount(id="conv-456", conversation_type="personal"),
+            channel_id="msteams",
+            name="signin/tokenExchange",
+            value=SignInExchangeToken(
+                id="exchange-id",
+                connection_name="test-connection",
+                token="test-token",
+            ),
+        )
+
+        handlers = app_with_options.router.select_handlers(activity)
+
+        assert handlers == [custom_handler]
 
     @pytest.mark.asyncio
     async def test_multiple_event_handlers(self, app_with_options: App) -> None:

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -220,6 +220,7 @@ class TestApp:
         assert isinstance(activity_events[0], ActivityEvent)
         # The event contains the core activity
         assert activity_events[0].body.id == core_activity.id
+        assert activity_events[0].body.type == core_activity.type
 
     def test_custom_signin_token_exchange_handler_replaces_default(self, app_with_options: App) -> None:
         """Registering a sign-in token exchange handler replaces the built-in default route."""

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -513,6 +513,51 @@ class TestSignInFailureMiddlewareChain:
         assert result is not None and result.status == 200
 
     @pytest.mark.asyncio
+    async def test_developer_signin_override_replaces_system_default(self, router, processor):
+        """User sign-in token exchange handler replaces the default system route."""
+        called = []
+        token_exchange_activity = SignInTokenExchangeInvokeActivity(
+            type="invoke",
+            id="activity-789",
+            from_=Account(id="user-123", name="Test User", role="user"),
+            recipient=Account(id="bot-456", name="Test Bot", role="bot"),
+            conversation=ConversationAccount(id="conv-456", conversation_type="personal"),
+            channel_id="msteams",
+            name="signin/tokenExchange",
+            value=SignInExchangeToken(
+                id="exchange-id",
+                connection_name="test-connection",
+                token="test-token",
+            ),
+        )
+
+        async def system_handler(ctx):
+            called.append("system")
+            await ctx.next()
+            return InvokeResponse(status=200)
+
+        async def developer_handler(ctx):
+            called.append("developer")
+            await ctx.next()
+            return InvokeResponse(status=201)
+
+        config = ACTIVITY_ROUTES["signin.token-exchange"]
+        router.add_handler(
+            config.selector,
+            system_handler,
+            route_name=config.name,
+            route_type="system",
+        )
+        router.add_handler(config.selector, developer_handler, route_name=config.name)
+
+        handlers = router.select_handlers(token_exchange_activity)
+        ctx = self._make_ctx(token_exchange_activity)
+        result = await processor.execute_middleware_chain(ctx, handlers)
+
+        assert called == ["developer"]
+        assert result is not None and result.status == 201
+
+    @pytest.mark.asyncio
     async def test_catchall_on_invoke_without_next_blocks_developer_handler(self, router, processor, failure_activity):
         """A catch-all on_invoke that omits ctx.next() blocks later handlers."""
         called = []


### PR DESCRIPTION
Fixes #159

## Summary

Mirrors the default-route override behavior from [microsoft/teams.ts#317](https://github.com/microsoft/teams.ts/pull/317) for the Python apps router.

Today `App` registers the built-in `signin.token-exchange` and `signin.verify-state` handlers the same way user handlers are registered. If an app later calls `on_signin_token_exchange(...)` or `on_signin_verify_state(...)`, the custom handler is appended instead of replacing the built-in default, so both routes remain active.

This change introduces route metadata in `ActivityRouter`, registers the built-in OAuth handlers as `system` routes, and passes `route_name` through generated handler registrations. When a user handler is registered for the same named route, the matching system default is removed so the app-level override becomes the only handler for that route.

## Changes

- `packages/apps/src/microsoft_teams/apps/routing/router.py`
  - Track route name/type metadata instead of storing bare `(selector, handler)` tuples.
  - Remove matching `system` routes when a `user` route with the same `route_name` is registered.
- `packages/apps/src/microsoft_teams/apps/app.py`
  - Register built-in sign-in token exchange and verify-state handlers directly as `system` routes.
- `packages/apps/scripts/generate_handlers.py`
  - Carry `config.name` into generated `add_handler(...)` calls.
- `packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py`
  - Regenerated to pass `route_name=config.name` for decorator-based registrations.
- `packages/apps/tests/test_app_oauth.py`
  - Add regression proving a user `signin.token-exchange` handler replaces the system default in the middleware chain.
- `packages/apps/tests/test_app.py`
  - Add app-level regression proving `App.on_signin_token_exchange(...)` leaves only the custom handler selected for `signin/tokenExchange`.

## Test plan

- [x] `.venv/bin/ruff format packages/apps/src/microsoft_teams/apps/app.py packages/apps/src/microsoft_teams/apps/routing/router.py packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py packages/apps/scripts/generate_handlers.py packages/apps/tests/test_app.py packages/apps/tests/test_app_oauth.py`
- [x] `.venv/bin/ruff check packages/apps/src/microsoft_teams/apps/app.py packages/apps/src/microsoft_teams/apps/routing/router.py packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py packages/apps/scripts/generate_handlers.py packages/apps/tests/test_app.py packages/apps/tests/test_app_oauth.py`
- [x] `PYTHONPATH=packages/api/src:packages/apps/src:packages/common/src:packages/cards/src:packages/botbuilder/src:packages/graph/src .venv/bin/python -m pytest packages/apps/tests/test_app.py packages/apps/tests/test_app_oauth.py -q`
- [ ] Reviewer eyeball: confirm the new `system` vs `user` route terminology matches the intended public direction for broader route override support.
