### PR TITLE
fix(deps): bump starlette 1.0.0 -> 1.1.0 for PYSEC-2026-161 (BadHost)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2810,15 +2810,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`uvx pip-audit` flagged a critical CVE in `starlette` 1.0.0 (transitive via `fastapi`). This PR bumps it to **1.1.0** via `uv lock --upgrade-package starlette` (uv picked 1.1.0, well above the 1.0.1 fix).

- **PYSEC-2026-161** / **CVE-2026-48710** / **GHSA-86qp-5c8j-p5mr** — *BadHost*
  - Disclosed 2026-05-22 by X41 D-Sec
  - Severity: 9.8 critical
  - Starlette reconstructs the request URL from the `Host` header without validation. Attackers can inject path segments via the host part, causing `request.url.path` to diverge from the actual routed path. Auth checks that rely on `request.url.path` can be bypassed while routing still hits the protected route.
  - Fix: starlette 1.0.1+; we landed on 1.1.0

Lock-only change. `fastapi 0.135.2`'s starlette constraint already allowed the bump, so no `pyproject.toml` edits.

## Vulnerabilities not addressed in this PR

`pip-audit` and Dependabot alert #5 also flag **jsonpickle 1.4.2** (CVE-2020-22083, GHSA-j66q-qmrc-89rx).

- Transitive via `botbuilder-core 4.17.0`, which pins `jsonpickle<1.5,>=1.2`. We cannot bump jsonpickle without overriding an upstream constraint on an archived library.
- The advisory itself is disputed: *"This CVE is disputed by the project author as intended functionality."* It describes the documented pickle-deserialization-is-dangerous property, not a code defect. First patched version: none.
- Recommendation: treat as accepted risk for now; track separately whether to override the constraint or remove the botbuilder integration.

## Test plan

- [x] `uvx pip-audit -r <exported requirements> --disable-pip --no-deps` — starlette no longer in findings; only jsonpickle remains
- [x] `poe check` (ruff format + lint) — clean
- [x] `poe test` — 609 passed
- [x] `pyright` — 0 errors, 0 warnings