### PR TITLE
Bump version to 2.0.13-dev; RELEASE.md fixes (pipeline ID + tagging docs)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,7 +70,7 @@ To produce a stable release (e.g., `2.0.0` without any suffix):
 
 ## Publishing
 
-The [publish pipeline](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_build?definitionId=49&_a=summary) (`.azdo/publish.yml`) is manually triggered and requires selecting a **Publish Type**: `Internal` or `Public`.
+The [publish pipeline](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_build?definitionId=51&_a=summary) (`.azdo/publish.yml`) is manually triggered and requires selecting a **Publish Type**: `Internal` or `Public`.
 
 1. Go to **Pipelines** > **teams.py** in ADO
 2. Click **Run pipeline**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -88,6 +88,27 @@ The [publish pipeline](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_b
 pip install microsoft-teams-apps==2.0.0
 ```
 
+## Tagging and GitHub Release
+
+After the publish pipeline finishes and packages land on PyPI, tag the release and create a GitHub Release page:
+
+```bash
+# Create a draft release at the release branch tip
+gh release create v<version> -R microsoft/teams.py \
+  --target release --title "v<version>" --draft \
+  --generate-notes --notes-start-tag v<previous-version>
+```
+
+**Note:** GitHub's auto-generated notes walk back from the `release` branch tip. Because the release PR is squash-merged, the auto-list shows only the merge PR. To get the real PR delta from `main`, query by date:
+
+```bash
+gh api -X GET search/issues \
+  -f q='repo:microsoft/teams.py is:pr is:merged base:main merged:>=<previous-release-publish-date>' \
+  --jq '.items[] | "* \(.title) by @\(.user.login) in \(.html_url)"' | tac > /tmp/notes.md
+```
+
+Paste the curated list into the draft, then publish from the GitHub UI (or via `gh release edit --draft=false`) to create the tag.
+
 ## Approvers
 
 The `teams-sdk-publish` environment in Azure DevOps controls who can approve public releases. To modify approvers:

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0.12-dev.{height}",
+  "version": "2.0.13-dev.{height}",
   "versionHeightOffset": 1,
   "publicReleaseRefSpec": [
     "^refs/heads/release$"


### PR DESCRIPTION
## Summary

Post-2.0.12 housekeeping on main.

- `version.json`: `2.0.12-dev.{height}` → `2.0.13-dev.{height}` — dev builds off main now produce `2.0.13.dev1`, `2.0.13.dev2`, etc., starting fresh height counters after the 2.0.12 stable cut. Mirrors PR #429.
- `RELEASE.md`:
  - Publish pipeline `definitionId` 49 → 51 (stale link)
  - New section "Tagging and GitHub Release" covering the post-publish tag + release-page step, including the date-based `gh api` query that surfaces the real PR delta from main (auto-generated notes against the squash-merged release branch only show the release PR itself)

## Test plan

- [x] `cat version.json` shows `2.0.13-dev.{height}`
- [x] `grep definitionId RELEASE.md` shows the corrected ID
- [x] New section renders cleanly in the RELEASE.md preview