### PR TITLE
docs(examples): show anonymous-mode startup warning by default

### DIFF
--- a/examples/botbuilder/src/main.py
+++ b/examples/botbuilder/src/main.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 import asyncio
 import datetime
+import logging
 import sys
 import traceback
 
@@ -19,6 +20,10 @@ from config import DefaultConfig
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.botbuilder import BotBuilderPlugin
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 config = DefaultConfig()
 adapter = CloudAdapter(ConfigurationBotFrameworkAuthentication(config))

--- a/examples/botbuilder/src/main.py
+++ b/examples/botbuilder/src/main.py
@@ -6,7 +6,6 @@ Licensed under the MIT License.
 import asyncio
 import datetime
 import logging
-import sys
 import traceback
 
 from botbuilder.core import TurnContext
@@ -24,6 +23,7 @@ from microsoft_teams.botbuilder import BotBuilderPlugin
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 config = DefaultConfig()
 adapter = CloudAdapter(ConfigurationBotFrameworkAuthentication(config))
@@ -31,7 +31,7 @@ adapter = CloudAdapter(ConfigurationBotFrameworkAuthentication(config))
 
 # Catch-all for errors.
 async def on_error(context: TurnContext, error: Exception):
-    print(f"\n [on_turn_error] unhandled error: {error}", file=sys.stderr)
+    logger.error(f"[on_turn_error] unhandled error: {error}")
     traceback.print_exc()
 
     # Send a message to the user

--- a/examples/cards/src/main.py
+++ b/examples/cards/src/main.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 from datetime import datetime
 
 from microsoft_teams.api import AdaptiveCardInvokeActivity, MessageActivity, MessageActivityInput
@@ -23,6 +24,10 @@ from microsoft_teams.cards import (
     ToggleInput,
 )
 from microsoft_teams.cards.core import Choice, ChoiceSetInput, DateInput, TextInput
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/cards/src/main.py
+++ b/examples/cards/src/main.py
@@ -28,6 +28,7 @@ from microsoft_teams.cards.core import Choice, ChoiceSetInput, DateInput, TextIn
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 
@@ -190,7 +191,7 @@ def create_feedback_card() -> AdaptiveCard:
 @app.on_message_pattern("card")
 async def handle_card_message(ctx: ActivityContext[MessageActivity]):
     """Handle card request messages - specific action routing."""
-    print(f"[CARD] Card with specific action routing requested by: {ctx.activity.from_}")
+    logger.info(f"[CARD] Card with specific action routing requested by: {ctx.activity.from_}")
     card = create_basic_adaptive_card()
     await ctx.send(card)
 
@@ -198,7 +199,7 @@ async def handle_card_message(ctx: ActivityContext[MessageActivity]):
 @app.on_message_pattern("generic")
 async def handle_generic_card_message(ctx: ActivityContext[MessageActivity]):
     """Handle generic card request messages - global handler."""
-    print(f"[GENERIC] Card with global handler requested by: {ctx.activity.from_}")
+    logger.info(f"[GENERIC] Card with global handler requested by: {ctx.activity.from_}")
     card = create_generic_execute_card()
     await ctx.send(card)
 
@@ -206,7 +207,7 @@ async def handle_generic_card_message(ctx: ActivityContext[MessageActivity]):
 @app.on_message_pattern("json")
 async def handle_validate_card_message(ctx: ActivityContext[MessageActivity]):
     """Handle model validation card request messages."""
-    print(f"[VALIDATE] Model validate card requested by: {ctx.activity.from_}")
+    logger.info(f"[VALIDATE] Model validate card requested by: {ctx.activity.from_}")
     card = create_model_validate_card()
     message = MessageActivityInput(text="Hello text!").add_card(card)
     await ctx.send(message)
@@ -251,7 +252,7 @@ async def handle_form(ctx: ActivityContext[MessageActivity]):
 @app.on_message_pattern("profile")
 async def handle_profile_card(ctx: ActivityContext[MessageActivity]):
     """Handle profile card request messages."""
-    print(f"[PROFILE] Profile card requested by: {ctx.activity.from_}")
+    logger.info(f"[PROFILE] Profile card requested by: {ctx.activity.from_}")
     card = create_profile_card()
     await ctx.send(card)
 
@@ -259,7 +260,7 @@ async def handle_profile_card(ctx: ActivityContext[MessageActivity]):
 @app.on_message_pattern("validation")
 async def handle_validation_card(ctx: ActivityContext[MessageActivity]):
     """Handle profile validation card request messages."""
-    print(f"[VALIDATION] Profile validation card requested by: {ctx.activity.from_}")
+    logger.info(f"[VALIDATION] Profile validation card requested by: {ctx.activity.from_}")
     card = create_profile_card_input_validation()
     await ctx.send(card)
 
@@ -267,7 +268,7 @@ async def handle_validation_card(ctx: ActivityContext[MessageActivity]):
 @app.on_message_pattern("feedback")
 async def handle_feedback_card(ctx: ActivityContext[MessageActivity]):
     """Handle feedback card request messages."""
-    print(f"[FEEDBACK] Feedback card requested by: {ctx.activity.from_}")
+    logger.info(f"[FEEDBACK] Feedback card requested by: {ctx.activity.from_}")
     card = create_feedback_card()
     await ctx.send(card)
 
@@ -276,7 +277,7 @@ async def handle_feedback_card(ctx: ActivityContext[MessageActivity]):
 async def handle_all_execute_actions(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -> AdaptiveCardInvokeResponse:
     """Handle all Action.Execute events without specific action routing (global handler)."""
     data = ctx.activity.value.action.data
-    print(f"[GLOBAL HANDLER] Received Action.Execute data: {data}")
+    logger.info(f"[GLOBAL HANDLER] Received Action.Execute data: {data}")
     await ctx.send(f"Global handler processed Action.Execute. Data: {data}")
     return AdaptiveCardActionMessageResponse(
         status_code=200,
@@ -290,7 +291,7 @@ async def handle_submit_basic(ctx: ActivityContext[AdaptiveCardInvokeActivity]) 
     """Handle basic card submission - specific action routing."""
     data = ctx.activity.value.action.data
     notify_value = data.get("notify", "false")
-    print(f"[SPECIFIC HANDLER] Received submit_basic action. Notify: {notify_value}")
+    logger.info(f"[SPECIFIC HANDLER] Received submit_basic action. Notify: {notify_value}")
     await ctx.send(f"Specific handler: submit_basic. Notify setting: {notify_value}")
     return AdaptiveCardActionMessageResponse(
         status_code=200,
@@ -303,7 +304,7 @@ async def handle_submit_basic(ctx: ActivityContext[AdaptiveCardInvokeActivity]) 
 async def handle_submit_feedback(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -> AdaptiveCardInvokeResponse:
     """Handle feedback submission."""
     data = ctx.activity.value.action.data
-    print("Received submit_feedback action data:", data)
+    logger.info("Received submit_feedback action data: %s", data)
     feedback_text = data.get("feedback", "No feedback provided")
     await ctx.send(f"Feedback received: {feedback_text}")
     return AdaptiveCardActionMessageResponse(
@@ -317,7 +318,7 @@ async def handle_submit_feedback(ctx: ActivityContext[AdaptiveCardInvokeActivity
 async def handle_create_task(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -> AdaptiveCardInvokeResponse:
     """Handle task creation."""
     data = ctx.activity.value.action.data
-    print("Received create_task action data:", data)
+    logger.info("Received create_task action data: %s", data)
     title = data.get("title", "Untitled")
     priority = data.get("priority", "medium")
     due_date = data.get("due_date", "No date")
@@ -333,7 +334,7 @@ async def handle_create_task(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -
 async def handle_save_profile(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -> AdaptiveCardInvokeResponse:
     """Handle profile save."""
     data = ctx.activity.value.action.data
-    print("Received save_profile action data:", data)
+    logger.info("Received save_profile action data: %s", data)
     entity_id = data.get("entity_id")
     name = data.get("name", "Unknown")
     email = data.get("email", "No email")
@@ -360,8 +361,8 @@ async def handle_save_profile(ctx: ActivityContext[AdaptiveCardInvokeActivity]) 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Handle general message activities."""
-    print(f"[GENERAL] Message received: {ctx.activity.text}")
-    print(f"[GENERAL] From: {ctx.activity.from_}")
+    logger.info(f"[GENERAL] Message received: {ctx.activity.text}")
+    logger.info(f"[GENERAL] From: {ctx.activity.from_}")
 
     if "reply" in ctx.activity.text.lower():
         await ctx.reply("Hello! How can I assist you today?")

--- a/examples/echo/src/main.py
+++ b/examples/echo/src/main.py
@@ -14,6 +14,7 @@ from microsoft_teams.apps import ActivityContext, App
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 
@@ -27,8 +28,8 @@ async def handle_greeting(ctx: ActivityContext[MessageActivity]) -> None:
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Handle message activities using the new generated handler system."""
-    print(f"[GENERATED onMessage] Message received: {ctx.activity.text}")
-    print(f"[GENERATED onMessage] From: {ctx.activity.from_}")
+    logger.info(f"[GENERATED onMessage] Message received: {ctx.activity.text}")
+    logger.info(f"[GENERATED onMessage] From: {ctx.activity.from_}")
     await ctx.reply(TypingActivityInput())
 
     if "reply" in ctx.activity.text.lower():

--- a/examples/echo/src/main.py
+++ b/examples/echo/src/main.py
@@ -4,11 +4,16 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 import re
 
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/meetings/src/main.py
+++ b/examples/meetings/src/main.py
@@ -20,6 +20,7 @@ from microsoft_teams.cards import AdaptiveCard, OpenUrlAction, TextBlock
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 

--- a/examples/meetings/src/main.py
+++ b/examples/meetings/src/main.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 
 from microsoft_teams.api.activities.event import (
     MeetingEndEventActivity,
@@ -15,6 +16,10 @@ from microsoft_teams.api.activities.message import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.cards import AdaptiveCard, OpenUrlAction, TextBlock
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/message-extensions/src/main.py
+++ b/examples/message-extensions/src/main.py
@@ -56,6 +56,7 @@ from typing_extensions import Any, Dict
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 

--- a/examples/message-extensions/src/main.py
+++ b/examples/message-extensions/src/main.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 import os
 from pathlib import Path
 from typing import cast
@@ -51,6 +52,10 @@ from microsoft_teams.api.models import (
 from microsoft_teams.api.models.card.thumbnail_card import ThumbnailCard
 from microsoft_teams.apps import ActivityContext, App
 from typing_extensions import Any, Dict
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/proactive-messaging/src/main.py
+++ b/examples/proactive-messaging/src/main.py
@@ -19,10 +19,15 @@ Key points:
 
 import argparse
 import asyncio
+import logging
 
 from microsoft_teams.api import MessageActivityInput
 from microsoft_teams.apps import App
 from microsoft_teams.cards import ActionSet, AdaptiveCard, OpenUrlAction, TextBlock
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 
 async def send_proactive_message(app: App, conversation_id: str, message: str) -> None:

--- a/examples/proactive-messaging/src/main.py
+++ b/examples/proactive-messaging/src/main.py
@@ -28,6 +28,7 @@ from microsoft_teams.cards import ActionSet, AdaptiveCard, OpenUrlAction, TextBl
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 async def send_proactive_message(app: App, conversation_id: str, message: str) -> None:
@@ -39,13 +40,13 @@ async def send_proactive_message(app: App, conversation_id: str, message: str) -
         conversation_id: The Teams conversation ID to send the message to
         message: The message text to send
     """
-    print(f"Sending proactive message to conversation: {conversation_id}")
-    print(f"Message: {message}")
+    logger.info(f"Sending proactive message to conversation: {conversation_id}")
+    logger.info(f"Message: {message}")
 
     # Send the message
     result = await app.send(conversation_id, message)
 
-    print(f"✓ Message sent successfully! Activity ID: {result.id}")
+    logger.info(f"✓ Message sent successfully! Activity ID: {result.id}")
 
 
 async def send_proactive_card(app: App, conversation_id: str) -> None:
@@ -67,11 +68,11 @@ async def send_proactive_card(app: App, conversation_id: str) -> None:
         ],
     )
 
-    print(f"Sending proactive card to conversation: {conversation_id}")
+    logger.info(f"Sending proactive card to conversation: {conversation_id}")
 
     result = await app.send(conversation_id, card)
 
-    print(f"✓ Card sent successfully! Activity ID: {result.id}")
+    logger.info(f"✓ Card sent successfully! Activity ID: {result.id}")
 
 
 async def send_and_update_proactive_message(app: App, conversation_id: str) -> None:
@@ -84,10 +85,10 @@ async def send_and_update_proactive_message(app: App, conversation_id: str) -> N
     """
     # First, send a message proactively
     original_text = "Status: Pending... (sent proactively without a running server)"
-    print(f"Sending message to update: {original_text}")
+    logger.info(f"Sending message to update: {original_text}")
     result = await app.send(conversation_id, original_text)
     activity_id = result.id
-    print(f"✓ Original message sent! Activity ID: {activity_id}")
+    logger.info(f"✓ Original message sent! Activity ID: {activity_id}")
 
     # Wait so the user can see the original
     await asyncio.sleep(3)
@@ -95,7 +96,7 @@ async def send_and_update_proactive_message(app: App, conversation_id: str) -> N
     # Now update the same message proactively using the ConversationClient
     updated = MessageActivityInput(text="Status: Complete ✅ (updated proactively without a running server)")
     await app.api.conversations.activities(conversation_id).update(activity_id, updated)
-    print(f"✓ Message updated successfully! Activity ID: {activity_id}")
+    logger.info(f"✓ Message updated successfully! Activity ID: {activity_id}")
 
 
 async def main():
@@ -118,9 +119,9 @@ async def main():
 
     # Initialize the app without starting the HTTP server
     # This sets up credentials, token manager, and activity sender
-    print("Initializing app (without starting server)...")
+    logger.info("Initializing app (without starting server)...")
     await app.initialize()
-    print("✓ App initialized\n")
+    logger.info("✓ App initialized\n")
 
     # Example 1: Send a simple text message
     await send_proactive_message(
@@ -139,7 +140,7 @@ async def main():
     # Example 3: Update an existing message
     await send_and_update_proactive_message(app, args.conversation_id)
 
-    print("\n✓ All proactive messages sent successfully!")
+    logger.info("\n✓ All proactive messages sent successfully!")
 
 
 if __name__ == "__main__":

--- a/examples/quoting/src/main.py
+++ b/examples/quoting/src/main.py
@@ -13,6 +13,7 @@ from microsoft_teams.apps import ActivityContext, App
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 

--- a/examples/quoting/src/main.py
+++ b/examples/quoting/src/main.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 
 from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/reactions/src/main.py
+++ b/examples/reactions/src/main.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 """
 Example: Message Reactions

--- a/examples/reactions/src/main.py
+++ b/examples/reactions/src/main.py
@@ -13,6 +13,7 @@ from microsoft_teams.apps import ActivityContext, App
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 """
 Example: Message Reactions
@@ -47,7 +48,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
         )
 
         await ctx.reply(f"✅ Added {reaction_type} reaction to your message!")
-        print(f"[REACTION] Added '{reaction_type}' to activity {activity_id}")
+        logger.info(f"[REACTION] Added '{reaction_type}' to activity {activity_id}")
         return
 
     # ============================================
@@ -68,7 +69,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             activity_id=activity_id,
             reaction_type=reaction_type,
         )
-        print(f"[REACTION] Cycled '{reaction_type}' on activity {activity_id}")
+        logger.info(f"[REACTION] Cycled '{reaction_type}' on activity {activity_id}")
         return
 
     # ============================================

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -13,6 +13,7 @@ from microsoft_teams.apps import ActivityContext, App
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 from random import random
 
 from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
 from microsoft_teams.apps import ActivityContext, App
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/suggested-actions/src/main.py
+++ b/examples/suggested-actions/src/main.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 import asyncio
 import json
+import logging
 import warnings
 
 from microsoft_teams.api import MessageActivity, MessageActivityInput
@@ -14,6 +15,10 @@ from microsoft_teams.api.models.card.card_action_type import CardActionType
 from microsoft_teams.api.models.suggested_actions import SuggestedActions
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.common.experimental import ExperimentalWarning
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 # SuggestedActionSubmit and on_suggested_action_submit are marked
 # @experimental("ExperimentalTeamsSuggestedAction"). See README.md.

--- a/examples/suggested-actions/src/main.py
+++ b/examples/suggested-actions/src/main.py
@@ -19,6 +19,7 @@ from microsoft_teams.common.experimental import ExperimentalWarning
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # SuggestedActionSubmit and on_suggested_action_submit are marked
 # @experimental("ExperimentalTeamsSuggestedAction"). See README.md.

--- a/examples/tab/src/main.py
+++ b/examples/tab/src/main.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import Any
 
 from microsoft_teams.apps import App, FunctionContext
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 app.tab("test", str(Path("Web/dist").resolve()))

--- a/examples/tab/src/main.py
+++ b/examples/tab/src/main.py
@@ -13,6 +13,7 @@ from microsoft_teams.apps import App, FunctionContext
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 app.tab("test", str(Path("Web/dist").resolve()))

--- a/examples/targeted-messages/src/main.py
+++ b/examples/targeted-messages/src/main.py
@@ -13,6 +13,7 @@ from microsoft_teams.apps import ActivityContext, App
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 """
 Example: Targeted Messages
@@ -72,13 +73,13 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
                     updated_message.id = message_id
 
                     await ctx.api.conversations.activities(conversation_id).update_targeted(message_id, updated_message)
-                    print("[UPDATE] Updated targeted message")
+                    logger.info("[UPDATE] Updated targeted message")
                 except Exception as err:
-                    print(f"[UPDATE] Error: {err}")
+                    logger.error(f"[UPDATE] Error: {err}")
 
             asyncio.create_task(update_after_delay())
 
-        print("[UPDATE] Scheduled update in 3 seconds")
+        logger.info("[UPDATE] Scheduled update in 3 seconds")
 
     elif "test delete" in text:
         # DELETE: Send a targeted message, then delete it after 3 seconds
@@ -97,18 +98,18 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
                 await asyncio.sleep(3)
                 try:
                     await ctx.api.conversations.activities(conversation_id).delete_targeted(message_id)
-                    print("[DELETE] Deleted targeted message")
+                    logger.info("[DELETE] Deleted targeted message")
                 except Exception as err:
-                    print(f"[DELETE] Error: {err}")
+                    logger.error(f"[DELETE] Error: {err}")
 
             asyncio.create_task(delete_after_delay())
 
-        print("[DELETE] Scheduled delete in 3 seconds")
+        logger.info("[DELETE] Scheduled delete in 3 seconds")
 
     elif "test public" in text:
         # PUBLIC: Send a public message visible to everyone in the chat.
         await ctx.send(MessageActivityInput(text="📋 Here is the public result — everyone can see this!"))
-        print("[PUBLIC] Sent public message")
+        logger.info("[PUBLIC] Sent public message")
 
     elif "test send" in text:
         # SEND: Send a targeted message visible only to the sender.
@@ -116,7 +117,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             text="👋 This is a **targeted message** — only YOU can see this!"
         ).with_recipient(activity.from_, is_targeted=True)
         await ctx.send(targeted_message)
-        print("[SEND] Sent targeted message")
+        logger.info("[SEND] Sent targeted message")
 
     elif "test inbound" in text:
         # INBOUND: Detect whether the inbound message was itself targeted at the bot
@@ -127,7 +128,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             if is_targeted_inbound
             else "ℹ️ Your message was delivered to me as a regular (broadcast) message."
         )
-        print(f"[INBOUND] is_targeted={is_targeted_inbound}")
+        logger.info(f"[INBOUND] is_targeted={is_targeted_inbound}")
 
     elif "help" in text:
         await ctx.send(

--- a/examples/targeted-messages/src/main.py
+++ b/examples/targeted-messages/src/main.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 from datetime import datetime, timezone
 
 from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext, App
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 """
 Example: Targeted Messages

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 import asyncio
+import logging
 
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App, to_threaded_conversation_id
+
+# Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
+# emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
+logging.basicConfig(level=logging.INFO)
 
 app = App()
 

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -13,6 +13,7 @@ from microsoft_teams.apps import ActivityContext, App, to_threaded_conversation_
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
 logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = App()
 


### PR DESCRIPTION
## Summary

When a PY example app starts without credentials (`CLIENT_ID` / `CLIENT_SECRET` / `TENANT_ID`), the SDK emits a `logger.warning(...)` from `microsoft_teams.apps.http.http_server` telling the developer that the bot will accept unauthenticated requests. Python's root logger has no handler by default, so WARNING records from non-root loggers never reach stdout. A developer running `uv run python src/main.py` therefore sees only uvicorn's INFO lines and is left to discover anonymous mode some other way.

This adds a single `logging.basicConfig(level=logging.INFO)` call near the top of each example's `main.py` so the warning (and any other SDK INFO/WARNING messages) surfaces on stdout alongside uvicorn's output.

### Scope

- `examples/echo` was patched first (commit 1) as the canonical first-run example
- All other examples that did not already configure logging were patched in commit 2: `botbuilder`, `cards`, `meetings`, `message-extensions`, `proactive-messaging`, `quoting`, `reactions`, `stream`, `suggested-actions`, `tab`, `targeted-messages`, `threading`
- Six examples already had their own logging setup and were left untouched: `ai-agentframework`, `dialogs`, `graph`, `mcp-server`, `oauth`

### Before

```
INFO:     Started server process [12345]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:3978 (Press CTRL+C to quit)
```

### After

```
WARNING:microsoft_teams.apps.app:TENANT_ID is not set, assuming multi-tenant app
WARNING:microsoft_teams.apps.http.http_server:No credentials configured (CLIENT_ID / CLIENT_SECRET / TENANT_ID). Bot will accept unauthenticated requests on /api/messages.
INFO:microsoft_teams.apps.app:Teams app initialized successfully
INFO:microsoft_teams.apps.app:Teams app started successfully
INFO:     Started server process [12345]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:3978 (Press CTRL+C to quit)
```

## Test plan

- [x] ``uv run poe check`` passes (ruff format + ruff check) across all 13 modified files
- [x] Verified empirically on `examples/echo` with no `.env`: the `No credentials configured ...` WARNING line appears on stdout at startup
- [x] Confirmed uvicorn INFO lines still render unchanged
- [ ] Reviewer to spot-check one of the other patched examples