### PR TITLE
Remove upper bound on requires-python to unblock downstream consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
 
     env:
       NBGV_REQUIRED: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14", "3.15"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     env:
       NBGV_REQUIRED: "1"

--- a/examples/a2a-test/pyproject.toml
+++ b/examples/a2a-test/pyproject.toml
@@ -3,7 +3,7 @@ name = "a2a-test"
 version = "0.1.0"
 description = "Two Teams bots talking to each other via the official a2a-sdk, exchanging Adaptive Cards"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/ai-agentframework/README.md
+++ b/examples/ai-agentframework/README.md
@@ -16,7 +16,7 @@ A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-fram
 
 ## Prerequisites
 
-- Python >= 3.11, < 3.15
+- Python >= 3.11
 - UV >= 0.8.11
 - An Azure OpenAI resource with a deployed model
 - A Teams bot registration (App ID + password)

--- a/examples/ai-agentframework/pyproject.toml
+++ b/examples/ai-agentframework/pyproject.toml
@@ -3,7 +3,7 @@ name = "ai-agentframework"
 version = "0.1.0"
 description = "Microsoft Teams bot using the agent-framework library"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/botbuilder/pyproject.toml
+++ b/examples/botbuilder/pyproject.toml
@@ -3,7 +3,7 @@ name = "botbuilder"
 version = "0.1.0"
 description = "Botbuilder sample"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "botbuilder-core>=4.14.0",

--- a/examples/cards/pyproject.toml
+++ b/examples/cards/pyproject.toml
@@ -3,7 +3,7 @@ name = "cards"
 version = "0.1.0"
 description = "app testing adaptive cards"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/dialogs/pyproject.toml
+++ b/examples/dialogs/pyproject.toml
@@ -3,7 +3,7 @@ name = "dialogs"
 version = "0.1.0"
 description = "a test testing out dialogs/task-modules"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/echo/pyproject.toml
+++ b/examples/echo/pyproject.toml
@@ -3,7 +3,7 @@ name = "echo"
 version = "0.1.0"
 description = "Echo app"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/graph/pyproject.toml
+++ b/examples/graph/pyproject.toml
@@ -3,7 +3,7 @@ name = "graph"
 version = "0.1.0"
 description = "demo app to test Azure Graph integration"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "microsoft-teams-apps>=0.1.0",
     "microsoft-teams-graph>=0.1.0",

--- a/examples/http-adapters/pyproject.toml
+++ b/examples/http-adapters/pyproject.toml
@@ -3,7 +3,7 @@ name = "http-adapters"
 version = "0.1.0"
 description = "Examples showing custom HttpServerAdapter and non-managed server patterns"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/mcp-server/pyproject.toml
+++ b/examples/mcp-server/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcp-server"
 version = "0.1.0"
 description = "Human-in-the-loop MCP tools backed by Teams bot proactive messaging"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "mcp>=1.13.1",

--- a/examples/meetings/pyproject.toml
+++ b/examples/meetings/pyproject.toml
@@ -3,7 +3,7 @@ name = "meetings"
 version = "0.1.0"
 description = "Meetings app"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/message-extensions/pyproject.toml
+++ b/examples/message-extensions/pyproject.toml
@@ -3,7 +3,7 @@ name = "message-extensions"
 version = "0.1.0"
 description = "message extension tests"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/oauth/pyproject.toml
+++ b/examples/oauth/pyproject.toml
@@ -3,7 +3,7 @@ name = "oauth"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/proactive-messaging/pyproject.toml
+++ b/examples/proactive-messaging/pyproject.toml
@@ -3,7 +3,7 @@ name = "proactive-messaging"
 version = "0.1.0"
 description = "Example showing proactive messaging without running a server"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/quoting/pyproject.toml
+++ b/examples/quoting/pyproject.toml
@@ -3,7 +3,7 @@ name = "quoting"
 version = "0.1.0"
 description = "Quoting example - demonstrates various ways to quote previous messages in conversations"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/reactions/pyproject.toml
+++ b/examples/reactions/pyproject.toml
@@ -3,7 +3,7 @@ name = "reactions"
 version = "0.1.0"
 description = "Message reactions example"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/stream/pyproject.toml
+++ b/examples/stream/pyproject.toml
@@ -3,7 +3,7 @@ name = "stream"
 version = "0.1.0"
 description = "Streaming test app that emits messages on install"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/suggested-actions/pyproject.toml
+++ b/examples/suggested-actions/pyproject.toml
@@ -3,7 +3,7 @@ name = "suggested-actions"
 version = "0.1.0"
 description = "Suggested Action Submit example"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/tab/pyproject.toml
+++ b/examples/tab/pyproject.toml
@@ -3,7 +3,7 @@ name = "tab"
 version = "0.1.0"
 description = "Tab app"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/targeted-messages/pyproject.toml
+++ b/examples/targeted-messages/pyproject.toml
@@ -3,7 +3,7 @@ name = "targeted-messages"
 version = "0.1.0"
 description = "Targeted messages example - demonstrates ephemeral messages visible only to specific recipients"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/examples/threading/pyproject.toml
+++ b/examples/threading/pyproject.toml
@@ -2,7 +2,7 @@
 name = "threading"
 version = "0.1.0"
 description = "Threading test bot"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 authors = [
     { name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }
 ]
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "pydantic>=2.0.0",
     "microsoft-teams-common",

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "The app package for a Microsoft Teams agent"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"

--- a/packages/botbuilder/pyproject.toml
+++ b/packages/botbuilder/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "BotBuilder plugin for Microsoft Teams"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"

--- a/packages/cards/pyproject.toml
+++ b/packages/cards/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 authors = [
     { name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }
 ]
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 [dependency-groups]
 dev = [
     "coverage>=7.8.0",

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 authors = [
     { name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }
 ]
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "httpx>=0.28.1",
 ]

--- a/packages/graph/pyproject.toml
+++ b/packages/graph/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 keywords = ["microsoft", "teams", "ai", "bot", "agents", "graph"]
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "azure-core>=1.31.0",
     "msgraph-sdk>=1.30.0,<2.0.0",

--- a/templates/examples/{{cookiecutter.example_app_name}}/pyproject.toml
+++ b/templates/examples/{{cookiecutter.example_app_name}}/pyproject.toml
@@ -3,7 +3,7 @@ name = "{{cookiecutter.example_app_name}}"
 version = "{{cookiecutter.version}}"
 description = "{{cookiecutter.project_short_description}}"
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",

--- a/templates/package/{{cookiecutter.pypi_package_name}}/pyproject.toml
+++ b/templates/package/{{cookiecutter.pypi_package_name}}/pyproject.toml
@@ -4,7 +4,7 @@ dynamic = ["version"]
 description = "{{cookiecutter.project_short_description}}"
 authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
 readme = "README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.11,<4.0"
 repository = "https://github.com/microsoft/teams.py"
 keywords = ["microsoft", "teams", "ai", "bot", "agents"]
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -1,10 +1,9 @@
 version = 1
 revision = 3
-requires-python = ">=3.11, <3.15"
+requires-python = ">=3.11, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version == '3.12.*'",
-    "python_full_version < '3.12'",
+    "python_full_version < '3.13'",
 ]
 
 [manifest]


### PR DESCRIPTION
## Summary

* Update `requires-python` upper bound from `<3.15` to `<4.0` across all package metadata.

## Why

The `<3.15` upper bound blocks downstream projects from resolving dependencies when targeting Python 3.15 or later — even when running on a perfectly stable Python version. Upper bounds on the interpreter version are a signal of a *known* incompatibility, not a testing gap. For the latter, CI is the right tool.

As raised in [discussion #2782](https://github.com/microsoft/teams-sdk/discussions/2782): if a team chooses to run a pre-release Python, that's their call. The SDK shouldn't make that decision for them via package metadata.

## Interesting bits

* No functional changes — purely metadata. If a future Python version does introduce a breaking change, a temporary upper bound can be added at that point with a concrete reason.

## Tips for reviewers

* All changes are `requires-python` fields in `pyproject.toml` files — no logic touched.

## Testing

* Existing test suite passes unchanged; this PR does not introduce new Python version coverage in CI. A follow-up to add 3.15 to the CI matrix once it stabilises would be a natural next step.