### PR TITLE
ci: add weekly SDL pipeline for CodeQL/CredScan compliance

### DIFF
--- a/.azdo/sdl.yml
+++ b/.azdo/sdl.yml
@@ -1,0 +1,45 @@
+# =============================================================================
+# Weekly SDL pipeline — ensures CodeQL and other SDL tools run on the default
+# branch at least once per week (SFI-PS2.1 Continuous SDL compliance).
+# The 1ES.Official template auto-injects CodeQL 3000 and CredScan.
+# Interpreted languages (JS/TS, Python) are scanned automatically in the
+# SDL Sources stage — no build step required.
+# =============================================================================
+
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 8 * * 1"
+  displayName: Weekly SDL
+  branches:
+    include:
+      - main
+  always: true
+
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: 1ES-Teams-Windows-2022-DomoreexpGithub
+      os: windows
+    stages:
+    - stage: SDL
+      displayName: SDL Analysis
+      jobs:
+      - job: sdl
+        displayName: SDL Scan
+        pool:
+          name: 1ES-Teams-Windows-2022-DomoreexpGithub
+          os: windows
+        steps:
+        - checkout: self
+          displayName: 'Checkout'


### PR DESCRIPTION
Adds a scheduled ADO pipeline (`.azdo/sdl.yml`) using the `1ES.Official.PipelineTemplate` that runs weekly on `main`.

**Why:** The publish pipeline is manually triggered and cannot guarantee CodeQL/CredScan run regularly on the default branch. This pipeline ensures continuous SDL compliance independent of release cadence.

**How it works:** The 1ES Official template auto-injects CodeQL 3000 and CredScan in the SDL Sources stage. For interpreted languages, scanning is automatic based on file detection — no build step is needed.

**Schedule:** Mondays at 08:00 UTC (`always: true` ensures it runs even without code changes).

**Note:** After merging, a pipeline definition must be created in ADO (DomoreexpGithub/Github_Pipelines) pointing to this YAML file for the schedule to activate.

**Related:**
- https://github.com/microsoft/teams.py/pull/366
- https://github.com/microsoft/teams.ts/pull/607
- https://github.com/microsoft/teams.ts/pull/608 (TS counterpart)