### PR TITLE
fix(build): pick PEP 440-compatible nbgv field, avoid trailing .height

### DIFF
--- a/tools/hatch-teams-build/src/hatch_teams_build/version_source.py
+++ b/tools/hatch-teams-build/src/hatch_teams_build/version_source.py
@@ -11,12 +11,19 @@ import warnings
 from typing import Any
 
 from hatchling.version.source.plugin.interface import VersionSourceInterface
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 logger = logging.getLogger(__name__)
 
 FALLBACK_VERSION = "0.0.0"
-_VERSION_FIELD_NAMES = ("CloudBuildNumber", "AssemblyInformationalVersion", "Version")
+# Field priority for picking a PEP 440-compatible version from nbgv's output.
+#   - SemVer2 is the right choice on release ("2.0.13"). On non-release branches it
+#     emits a "+gHASH" suffix that's not PEP 440-valid, so we fall through.
+#   - CloudBuildNumber is the fallback for dev/non-release builds where nbgv emits
+#     "2.0.13-dev.11+eaec265930" (PEP 440-valid). Avoid as a primary on release —
+#     it would give "2.0.13.4" because nbgv appends git height as a 4th component.
+#   - SimpleVersion is the final fallback (loses dev info but always parses).
+_VERSION_FIELD_NAMES = ("SemVer2", "CloudBuildNumber", "SimpleVersion")
 
 
 def _normalize_version(version: str) -> str:
@@ -37,10 +44,16 @@ def _get_nbgv_version(root: str) -> dict[str, Any]:
 def _select_version(version_data: dict[str, Any]) -> str:
     for field_name in _VERSION_FIELD_NAMES:
         value = version_data.get(field_name)
-        if isinstance(value, str) and value:
-            return value
+        if not isinstance(value, str) or not value:
+            continue
+        try:
+            Version(value)
+        except InvalidVersion:
+            logger.debug("nbgv field %s value %r is not PEP 440-compatible, trying next", field_name, value)
+            continue
+        return value
 
-    raise RuntimeError("nbgv did not return a usable version field")
+    raise RuntimeError("nbgv did not return a PEP 440-compatible version in any expected field")
 
 
 class TeamsBuildVersionSource(VersionSourceInterface):

--- a/tools/hatch-teams-build/src/hatch_teams_build/version_source.py
+++ b/tools/hatch-teams-build/src/hatch_teams_build/version_source.py
@@ -21,7 +21,7 @@ FALLBACK_VERSION = "0.0.0"
 #     emits the commit hash as an extra prerelease segment (e.g. "2.0.13-dev.11.geaec265930"),
 #     which is not PEP 440-valid, so we fall through.
 #   - CloudBuildNumber is the fallback for dev/non-release builds where nbgv emits
-#     "2.0.13-dev.11+eaec265930" (PEP 440-valid — the "+geaec265930" is a local
+#     "2.0.13-dev.11+eaec265930" (PEP 440-valid — the "+eaec265930" is a local
 #     version segment). Avoid as a primary on release — it would give "2.0.13.4"
 #     because nbgv appends git height as a 4th component.
 #   - SimpleVersion is the final fallback (loses dev info but always parses).

--- a/tools/hatch-teams-build/src/hatch_teams_build/version_source.py
+++ b/tools/hatch-teams-build/src/hatch_teams_build/version_source.py
@@ -18,10 +18,12 @@ logger = logging.getLogger(__name__)
 FALLBACK_VERSION = "0.0.0"
 # Field priority for picking a PEP 440-compatible version from nbgv's output.
 #   - SemVer2 is the right choice on release ("2.0.13"). On non-release branches it
-#     emits a "+gHASH" suffix that's not PEP 440-valid, so we fall through.
+#     emits the commit hash as an extra prerelease segment (e.g. "2.0.13-dev.11.geaec265930"),
+#     which is not PEP 440-valid, so we fall through.
 #   - CloudBuildNumber is the fallback for dev/non-release builds where nbgv emits
-#     "2.0.13-dev.11+eaec265930" (PEP 440-valid). Avoid as a primary on release —
-#     it would give "2.0.13.4" because nbgv appends git height as a 4th component.
+#     "2.0.13-dev.11+eaec265930" (PEP 440-valid — the "+geaec265930" is a local
+#     version segment). Avoid as a primary on release — it would give "2.0.13.4"
+#     because nbgv appends git height as a 4th component.
 #   - SimpleVersion is the final fallback (loses dev info but always parses).
 _VERSION_FIELD_NAMES = ("SemVer2", "CloudBuildNumber", "SimpleVersion")
 


### PR DESCRIPTION
## Summary

Fix the hatch build plugin so released package versions don't have a trailing `.height` component (we just shipped `2.0.13.4` when we meant `2.0.13`).

## Why

I introduced this in PR #445 when migrating off the 3.12-only `nbgv-python` wrapper. The plugin picked nbgv's `CloudBuildNumber` field, which works fine on `main` (`2.0.13-dev.11+eaec265930`) but on `release` it expands to `2.0.13.4` because nbgv appends git height as a 4th version component when `version.json` has a plain three-part version. PyPI then got `microsoft-teams-apps==2.0.13.4` instead of `2.0.13`.

## What changed

Field priority is now `SemVer2` → `CloudBuildNumber` → `SimpleVersion`, with a PEP 440 validity check that walks past unparseable fields. End result:

- **release**: `SemVer2` is `2.0.13` (plain stable) — picked
- **main**: `SemVer2` is `2.0.13-dev.11.geaec265930` (not PEP 440 due to trailing `.gHASH`) — falls through to `CloudBuildNumber` `2.0.13-dev.11+eaec265930` (PEP 440-valid via local-version `+`)

## Reviewer tips

Diff is small — just the field list + a try/except in `_select_version`. The comment block explains the rationale so future folks don't reintroduce the bug.

## Testing

Verified both code paths locally:

```
# main
$ NBGV_REQUIRED=1 uv build --package microsoft-teams-apps --sdist
Successfully built dist/microsoft_teams_apps-2.0.13.dev11+eaec265930.tar.gz

# release (simulated by checking the field selection logic against
# nbgv output captured from the release branch)
SemVer2=2.0.13 -> picked, parses as PEP 440 2.0.13
```

Will be visible end-to-end on the next release (`2.0.14`).
