### PR TITLE
fix: parse attachments in MessageUpdateActivity (#414)

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/message/message_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message_update.py
@@ -4,9 +4,9 @@ Licensed under the MIT License.
 """
 
 from datetime import datetime
-from typing import Any, Literal, Optional
+from typing import Any, List, Literal, Optional
 
-from ...models import ActivityBase, ChannelData
+from ...models import ActivityBase, Attachment, AttachmentLayout, ChannelData
 from ...models.custom_base_model import CustomBaseModel
 
 MessageEventType = Literal["undeleteMessage", "editMessage"]
@@ -32,6 +32,12 @@ class _MessageUpdateBase(CustomBaseModel):
 
     summary: Optional[str] = None
     """The text to display if the channel cannot render cards."""
+
+    attachment_layout: Optional[AttachmentLayout] = None
+    """The layout hint for multiple attachments. Default: list."""
+
+    attachments: Optional[List[Attachment]] = None
+    """Attachments included in the updated message."""
 
     expiration: Optional[datetime] = None
     """

--- a/packages/api/src/microsoft_teams/api/activities/message/message_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message_update.py
@@ -34,7 +34,7 @@ class _MessageUpdateBase(CustomBaseModel):
     """The text to display if the channel cannot render cards."""
 
     attachment_layout: Optional[AttachmentLayout] = None
-    """The layout hint for multiple attachments. Default: list."""
+    """The layout hint for multiple attachments. Optional, omitted when not provided."""
 
     attachments: Optional[List[Attachment]] = None
     """Attachments included in the updated message."""

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -621,6 +621,72 @@ class TestMessageUpdateActivity:
         assert activity.expiration == expiration
         assert activity.value == {"custom": "data"}
 
+    def test_message_update_with_attachments_from_json(self):
+        """Test that inbound messageUpdate with attachments parses them as Attachment objects"""
+        payload = {
+            "type": "messageUpdate",
+            "id": "msg-123",
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-456", "conversationType": "personal"},
+            "recipient": {"id": "bot-789", "name": "Test Bot"},
+            "channelData": {"eventType": "editMessage"},
+            "attachments": [{"contentType": "text/html", "content": "hey\n\n"}],
+        }
+
+        activity = ActivityTypeAdapter.validate_python(payload)
+
+        assert isinstance(activity, MessageUpdateActivity)
+        assert activity.attachments is not None
+        assert len(activity.attachments) == 1
+        # Verify it's an Attachment object, not a raw dict
+        assert isinstance(activity.attachments[0], Attachment)
+        assert activity.attachments[0].content_type == "text/html"
+        assert activity.attachments[0].content == "hey\n\n"
+
+    def test_message_update_with_multiple_attachments(self):
+        """Test that messageUpdate with multiple attachments are all parsed correctly"""
+        payload = {
+            "type": "messageUpdate",
+            "id": "msg-456",
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-456", "conversationType": "personal"},
+            "recipient": {"id": "bot-789", "name": "Test Bot"},
+            "channelData": {"eventType": "editMessage"},
+            "attachments": [
+                {"contentType": "text/html", "content": "first"},
+                {"contentType": "application/json", "content": '{"key": "value"}'},
+            ],
+        }
+
+        activity = ActivityTypeAdapter.validate_python(payload)
+
+        assert isinstance(activity, MessageUpdateActivity)
+        assert activity.attachments is not None
+        assert len(activity.attachments) == 2
+        assert all(isinstance(att, Attachment) for att in activity.attachments)
+        assert activity.attachments[0].content_type == "text/html"
+        assert activity.attachments[1].content_type == "application/json"
+
+    def test_message_update_with_attachment_layout(self):
+        """Test that messageUpdate with attachment_layout is parsed correctly"""
+        payload = {
+            "type": "messageUpdate",
+            "id": "msg-789",
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-456", "conversationType": "personal"},
+            "recipient": {"id": "bot-789", "name": "Test Bot"},
+            "channelData": {"eventType": "editMessage"},
+            "attachmentLayout": "carousel",
+            "attachments": [{"contentType": "text/html", "content": "card1"}],
+        }
+
+        activity = ActivityTypeAdapter.validate_python(payload)
+
+        assert isinstance(activity, MessageUpdateActivity)
+        assert activity.attachment_layout == "carousel"
+        assert activity.attachments is not None
+        assert len(activity.attachments) == 1
+
 
 class TestMessageReactionActivity:
     """Test MessageReactionActivity functionality"""

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -621,17 +621,24 @@ class TestMessageUpdateActivity:
         assert activity.expiration == expiration
         assert activity.value == {"custom": "data"}
 
-    def test_message_update_with_attachments_from_json(self):
-        """Test that inbound messageUpdate with attachments parses them as Attachment objects"""
+    def _make_message_update_payload(self, msg_id: str = "msg-123", **overrides) -> dict:
+        """Helper factory to create messageUpdate payloads with sensible defaults."""
         payload = {
             "type": "messageUpdate",
-            "id": "msg-123",
+            "id": msg_id,
             "from": {"id": "user-123", "name": "Test User"},
             "conversation": {"id": "conv-456", "conversationType": "personal"},
             "recipient": {"id": "bot-789", "name": "Test Bot"},
             "channelData": {"eventType": "editMessage"},
-            "attachments": [{"contentType": "text/html", "content": "hey\n\n"}],
         }
+        payload.update(overrides)
+        return payload
+
+    def test_message_update_with_attachments_from_json(self):
+        """Test that inbound messageUpdate with attachments parses them as Attachment objects."""
+        payload = self._make_message_update_payload(
+            attachments=[{"contentType": "text/html", "content": "hey\n\n"}]
+        )
 
         activity = ActivityTypeAdapter.validate_python(payload)
 
@@ -644,19 +651,14 @@ class TestMessageUpdateActivity:
         assert activity.attachments[0].content == "hey\n\n"
 
     def test_message_update_with_multiple_attachments(self):
-        """Test that messageUpdate with multiple attachments are all parsed correctly"""
-        payload = {
-            "type": "messageUpdate",
-            "id": "msg-456",
-            "from": {"id": "user-123", "name": "Test User"},
-            "conversation": {"id": "conv-456", "conversationType": "personal"},
-            "recipient": {"id": "bot-789", "name": "Test Bot"},
-            "channelData": {"eventType": "editMessage"},
-            "attachments": [
+        """Test that messageUpdate with multiple attachments is parsed correctly."""
+        payload = self._make_message_update_payload(
+            msg_id="msg-456",
+            attachments=[
                 {"contentType": "text/html", "content": "first"},
                 {"contentType": "application/json", "content": '{"key": "value"}'},
             ],
-        }
+        )
 
         activity = ActivityTypeAdapter.validate_python(payload)
 
@@ -668,17 +670,12 @@ class TestMessageUpdateActivity:
         assert activity.attachments[1].content_type == "application/json"
 
     def test_message_update_with_attachment_layout(self):
-        """Test that messageUpdate with attachment_layout is parsed correctly"""
-        payload = {
-            "type": "messageUpdate",
-            "id": "msg-789",
-            "from": {"id": "user-123", "name": "Test User"},
-            "conversation": {"id": "conv-456", "conversationType": "personal"},
-            "recipient": {"id": "bot-789", "name": "Test Bot"},
-            "channelData": {"eventType": "editMessage"},
-            "attachmentLayout": "carousel",
-            "attachments": [{"contentType": "text/html", "content": "card1"}],
-        }
+        """Test that messageUpdate with attachment_layout is parsed correctly."""
+        payload = self._make_message_update_payload(
+            msg_id="msg-789",
+            attachmentLayout="carousel",
+            attachments=[{"contentType": "text/html", "content": "card1"}],
+        )
 
         activity = ActivityTypeAdapter.validate_python(payload)
 


### PR DESCRIPTION
Fixes #414

attachments field was missing from MessageUpdateActivity so
edited messages with attachments silently dropped them. added
the same Optional[List[Attachment]] field that MessageActivity has.

added a regression test.