### PR TITLE
Cache federated identity MSAL clients

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/token_manager.py
+++ b/packages/apps/src/microsoft_teams/apps/token_manager.py
@@ -44,6 +44,7 @@ class TokenManager:
         self._credentials = credentials
         self._cloud = cloud or PUBLIC
         self._confidential_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
+        self._federated_identity_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
         self._managed_identity_client: Optional[ManagedIdentityClient] = None
 
     async def get_bot_token(self) -> Optional[TokenProtocol]:
@@ -126,15 +127,7 @@ class TokenManager:
     ) -> TokenProtocol:
         """Get token using Federated Identity Credentials (two-step flow)."""
 
-        # Step 1: Get MI token from api://AzureADTokenExchange
-        mi_token = await self._acquire_managed_identity_token(credentials)
-
-        # Step 2: Use MI token as client_assertion to get final access token
-        confidential_client = ConfidentialClientApplication(
-            credentials.client_id,
-            client_credential={"client_assertion": mi_token},
-            authority=f"{self._cloud.login_endpoint}/{tenant_id}",
-        )
+        confidential_client = self._get_federated_identity_client(credentials, tenant_id)
 
         token_res: dict[str, Any] = await asyncio.to_thread(
             lambda: confidential_client.acquire_token_for_client([scope])
@@ -144,12 +137,14 @@ class TokenManager:
 
     async def _acquire_managed_identity_token(self, credentials: FederatedIdentityCredentials) -> str:
         """Acquire managed identity token for federated identity credentials."""
+        return await asyncio.to_thread(lambda: self._acquire_managed_identity_token_sync(credentials))
+
+    def _acquire_managed_identity_token_sync(self, credentials: FederatedIdentityCredentials) -> str:
+        """Acquire managed identity token for federated identity credentials."""
         # Use shared method to get or create the managed identity client
         mi_client = self._get_managed_identity_client(credentials)
 
-        mi_token_res: dict[str, Any] = await asyncio.to_thread(
-            lambda: mi_client.acquire_token_for_client(resource="api://AzureADTokenExchange")
-        )
+        mi_token_res: dict[str, Any] = mi_client.acquire_token_for_client(resource="api://AzureADTokenExchange")
 
         if not mi_token_res.get("access_token"):
             logger.error("FIC Step 1 failed: Could not acquire MI token")
@@ -207,6 +202,22 @@ class TokenManager:
             authority=f"{self._cloud.login_endpoint}/{tenant_id}",
         )
         self._confidential_clients_by_tenant[tenant_id] = client
+        return client
+
+    def _get_federated_identity_client(
+        self, credentials: FederatedIdentityCredentials, tenant_id: str
+    ) -> ConfidentialClientApplication:
+        """Get or create ConfidentialClientApplication for FederatedIdentityCredentials."""
+        cached_client = self._federated_identity_clients_by_tenant.get(tenant_id)
+        if cached_client:
+            return cached_client
+
+        client: ConfidentialClientApplication = ConfidentialClientApplication(
+            credentials.client_id,
+            client_credential={"client_assertion": lambda: self._acquire_managed_identity_token_sync(credentials)},
+            authority=f"{self._cloud.login_endpoint}/{tenant_id}",
+        )
+        self._federated_identity_clients_by_tenant[tenant_id] = client
         return client
 
     def _get_managed_identity_client(

--- a/packages/apps/tests/test_token_manager.py
+++ b/packages/apps/tests/test_token_manager.py
@@ -272,9 +272,9 @@ class TestTokenManager:
 
         manager = TokenManager(credentials=mock_credentials)
 
-        # Mock the managed identity token acquisition (step 1)
+        # Mock the managed identity token acquisition used by the lazy client_assertion callback
         mi_token = "mi_token_from_step_1"
-        with patch.object(manager, "_acquire_managed_identity_token", return_value=mi_token):
+        with patch.object(manager, "_acquire_managed_identity_token_sync", return_value=mi_token):
             # Mock ConfidentialClientApplication for step 2
             with patch("microsoft_teams.apps.token_manager.ConfidentialClientApplication") as mock_confidential_app:
                 mock_app_instance = MagicMock()
@@ -287,10 +287,12 @@ class TestTokenManager:
                 assert isinstance(token, JsonWebToken), f"Failed for: {description}"
                 assert str(token) == VALID_TEST_TOKEN, f"Failed for: {description}"
 
-                # Verify ConfidentialClientApplication was called with MI token as client_assertion
+                # Verify ConfidentialClientApplication was called with a lazy client_assertion callback
                 mock_confidential_app.assert_called_once()
                 call_kwargs = mock_confidential_app.call_args[1]
-                assert call_kwargs["client_credential"] == {"client_assertion": mi_token}, f"Failed for: {description}"
+                client_assertion = call_kwargs["client_credential"]["client_assertion"]
+                assert callable(client_assertion), f"Failed for: {description}"
+                assert client_assertion() == mi_token, f"Failed for: {description}"
 
     @pytest.mark.asyncio
     async def test_get_token_with_federated_identity_step1_failure(self):
@@ -304,12 +306,22 @@ class TestTokenManager:
 
         manager = TokenManager(credentials=mock_credentials)
 
-        # Mock step 1 to fail
+        # Mock step 1 to fail when MSAL invokes the lazy client_assertion callback
         with patch.object(
-            manager, "_acquire_managed_identity_token", side_effect=ValueError("MI token acquisition failed")
+            manager, "_acquire_managed_identity_token_sync", side_effect=ValueError("MI token acquisition failed")
         ):
-            with pytest.raises(ValueError) as exc_info:
-                await manager.get_bot_token()
+            with patch("microsoft_teams.apps.token_manager.ConfidentialClientApplication") as mock_confidential_app:
+                mock_app_instance = MagicMock()
+
+                def acquire_token_for_client(_scopes):
+                    client_credential = mock_confidential_app.call_args.kwargs["client_credential"]
+                    client_credential["client_assertion"]()
+
+                mock_app_instance.acquire_token_for_client.side_effect = acquire_token_for_client
+                mock_confidential_app.return_value = mock_app_instance
+
+                with pytest.raises(ValueError) as exc_info:
+                    await manager.get_bot_token()
 
             assert "MI token acquisition failed" in str(exc_info.value)
 
@@ -327,7 +339,7 @@ class TestTokenManager:
 
         # Mock step 1 to succeed
         mi_token = "mi_token_from_step_1"
-        with patch.object(manager, "_acquire_managed_identity_token", return_value=mi_token):
+        with patch.object(manager, "_acquire_managed_identity_token_sync", return_value=mi_token):
             # Mock step 2 to fail
             with patch("microsoft_teams.apps.token_manager.ConfidentialClientApplication") as mock_confidential_app:
                 mock_app_instance = MagicMock()
@@ -471,6 +483,27 @@ class TestTokenManager:
 
         # ManagedIdentityClient should only be constructed once
         mock_mi_client_class.assert_called_once()
+        assert client_first is client_second
+
+    @pytest.mark.asyncio
+    async def test_get_federated_identity_client_uses_cache(self):
+        """Test that _get_federated_identity_client returns cached client on second call."""
+        mock_credentials = FederatedIdentityCredentials(
+            client_id="test-app-client-id",
+            managed_identity_type="user",
+            managed_identity_client_id="test-mi-client-id",
+            tenant_id="test-tenant-id",
+        )
+
+        manager = TokenManager(credentials=mock_credentials)
+
+        with patch("microsoft_teams.apps.token_manager.ConfidentialClientApplication") as mock_msal_class:
+            mock_msal_class.return_value = MagicMock()
+
+            client_first = manager._get_federated_identity_client(mock_credentials, "test-tenant-id")
+            client_second = manager._get_federated_identity_client(mock_credentials, "test-tenant-id")
+
+        mock_msal_class.assert_called_once()
         assert client_first is client_second
 
     @pytest.mark.asyncio

--- a/stubs/msal/__init__.pyi
+++ b/stubs/msal/__init__.pyi
@@ -1,6 +1,8 @@
 """Type stubs for msal"""
 
-from typing import Any
+from typing import Any, Callable, TypeAlias
+
+ClientCredential: TypeAlias = str | dict[str, str | Callable[[], str]] | None
 
 class ConfidentialClientApplication:
     """MSAL Confidential Client Application"""
@@ -9,7 +11,7 @@ class ConfidentialClientApplication:
         self,
         client_id: str,
         *,
-        client_credential: str | dict[str, str] | None = None,
+        client_credential: ClientCredential = None,
         authority: str | None = None,
         **kwargs: Any,
     ) -> None: ...


### PR DESCRIPTION
Cache MSAL clients for federated identity token flow.

Why:
Recreating the MSAL confidential client every token request means we miss MSAL's internal token cache. Reusing the client lets it do its job and avoids extra token exchanges.

Interesting bits:
FIC now passes MSAL a lazy client assertion callback, so the managed identity exchange token is only fetched when MSAL actually needs to hit the wire. Also updated the local MSAL stub because 1.34 supports callables even though our stub only allowed strings.

Reviewer tips:
Start in `packages/apps/src/microsoft_teams/apps/token_manager.py`. The important bit is the new FIC client cache and callback assertion.

Testing:
- `uv run pytest packages/apps/tests/test_token_manager.py`
- `uv run pyright packages/apps/src/microsoft_teams/apps/token_manager.py`
- Manual VM test of the FIC token flow