### PR TITLE
Support Entra inbound Agent ID tokens

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/auth/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/__init__.py
@@ -4,6 +4,6 @@ Licensed under the MIT License.
 """
 
 from .remote_function_jwt_middleware import validate_remote_function_request
-from .token_validator import TokenValidator
+from .token_validator import InboundActivityTokenValidator, TokenValidator
 
-__all__ = ["TokenValidator", "validate_remote_function_request"]
+__all__ = ["InboundActivityTokenValidator", "TokenValidator", "validate_remote_function_request"]

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -14,6 +15,7 @@ import jwt
 from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 
 JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
+MAX_ENTRA_VALIDATOR_CACHE_SIZE = 100
 
 logger = logging.getLogger(__name__)
 
@@ -243,10 +245,10 @@ class InboundActivityTokenValidator:
         self._app_id = app_id
         self._cloud = cloud or PUBLIC
         self._service_validator = TokenValidator.for_service(app_id, cloud=self._cloud)
-        self._entra_validators_by_tenant: dict[str, TokenValidator] = {}
+        self._entra_validators_by_tenant: OrderedDict[str, TokenValidator] = OrderedDict()
 
     async def validate_token(self, raw_token: str, service_url: Optional[str] = None) -> Dict[str, Any]:
-        unverified_payload = jwt.decode(raw_token, options={"verify_signature": False})
+        unverified_payload = jwt.decode(raw_token, algorithms=["RS256"], options={"verify_signature": False})
         issuer = unverified_payload.get("iss", "")
         if self._is_entra_issuer(issuer):
             return await self._validate_entra_token(raw_token, unverified_payload)
@@ -272,6 +274,7 @@ class InboundActivityTokenValidator:
     def _get_entra_validator(self, tenant_id: str) -> TokenValidator:
         cached_validator = self._entra_validators_by_tenant.get(tenant_id)
         if cached_validator:
+            self._entra_validators_by_tenant.move_to_end(tenant_id)
             return cached_validator
 
         validator = TokenValidator.for_entra(
@@ -280,4 +283,6 @@ class InboundActivityTokenValidator:
             cloud=self._cloud,
         )
         self._entra_validators_by_tenant[tenant_id] = validator
+        if len(self._entra_validators_by_tenant) > MAX_ENTRA_VALIDATOR_CACHE_SIZE:
+            self._entra_validators_by_tenant.popitem(last=False)
         return validator

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -36,10 +36,6 @@ class JwtValidationOptions:
     """ Optional scope that must be present in the token """
     clock_tolerance: int = JWT_LEEWAY_SECONDS
     """ Allowable clock skew when validating JWTs """
-    app_id: Optional[str] = None
-    """ Optional app ID used to select per-token validators for inbound activities """
-    cloud: CloudEnvironment = PUBLIC
-    """ Cloud environment used to select issuer and JWKS endpoints """
 
 
 class TokenValidator:
@@ -89,8 +85,6 @@ class TokenValidator:
             valid_audiences=cls._default_audiences(app_id),
             jwks_uri=jwks_keys_uri,
             service_url=service_url,
-            app_id=app_id,
-            cloud=env,
         )
         return cls(options)
 
@@ -136,8 +130,6 @@ class TokenValidator:
             valid_audiences=valid_audiences,
             jwks_uri=f"{env.login_endpoint}/{tenant_id}/discovery/v2.0/keys",
             scope=scope,
-            app_id=app_id,
-            cloud=env,
         )
         return cls(options)
 
@@ -248,6 +240,10 @@ class InboundActivityTokenValidator:
         self._entra_validators_by_tenant: dict[str, TokenValidator] = {}
 
     async def validate_token(self, raw_token: str, service_url: Optional[str] = None) -> Dict[str, Any]:
+        if not raw_token:
+            logger.error("No token provided")
+            raise jwt.InvalidTokenError("No token provided")
+
         unverified_payload = jwt.decode(raw_token, algorithms=["RS256"], options={"verify_signature": False})
         issuer = unverified_payload.get("iss", "")
         if self._is_entra_issuer(issuer):

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -16,6 +16,7 @@ from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 
 JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
 MAX_ENTRA_VALIDATOR_CACHE_SIZE = 100
+ENTRA_V1_ISSUER_PREFIX = "https://sts.windows.net/"
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +122,7 @@ class TokenValidator:
             # are still issued with the v1 issuer.
             # See: https://learn.microsoft.com/en-us/entra/identity-platform/access-tokens
             valid_issuers.append(f"{env.login_endpoint}/{tenant_id}/v2.0")
-            valid_issuers.append(f"https://sts.windows.net/{tenant_id}/")
+            valid_issuers.append(f"{ENTRA_V1_ISSUER_PREFIX}{tenant_id}/")
         else:
             logger.warning(
                 "No tenant_id provided for Entra token validation. "
@@ -259,7 +260,7 @@ class InboundActivityTokenValidator:
         if not isinstance(issuer, str):
             return False
 
-        return issuer.startswith(self._cloud.login_endpoint) or issuer.startswith("https://sts.windows.net/")
+        return issuer.startswith(self._cloud.login_endpoint) or issuer.startswith(ENTRA_V1_ISSUER_PREFIX)
 
     async def _validate_entra_token(self, raw_token: str, unverified_payload: Dict[str, Any]) -> Dict[str, Any]:
         tenant_id = unverified_payload.get("tid")

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -34,6 +34,10 @@ class JwtValidationOptions:
     """ Optional scope that must be present in the token """
     clock_tolerance: int = JWT_LEEWAY_SECONDS
     """ Allowable clock skew when validating JWTs """
+    app_id: Optional[str] = None
+    """ Optional app ID used to select per-token validators for inbound activities """
+    cloud: CloudEnvironment = PUBLIC
+    """ Cloud environment used to select issuer and JWKS endpoints """
 
 
 class TokenValidator:
@@ -83,6 +87,8 @@ class TokenValidator:
             valid_audiences=cls._default_audiences(app_id),
             jwks_uri=jwks_keys_uri,
             service_url=service_url,
+            app_id=app_id,
+            cloud=env,
         )
         return cls(options)
 
@@ -128,6 +134,8 @@ class TokenValidator:
             valid_audiences=valid_audiences,
             jwks_uri=f"{env.login_endpoint}/{tenant_id}/discovery/v2.0/keys",
             scope=scope,
+            app_id=app_id,
+            cloud=env,
         )
         return cls(options)
 
@@ -222,3 +230,54 @@ class TokenValidator:
         if required_scope not in scope_set:
             logger.error(f"Token missing required scope: {required_scope}")
             raise jwt.InvalidTokenError(f"Token missing required scope: {required_scope}")
+
+
+class InboundActivityTokenValidator:
+    """Validator for inbound Teams activities.
+
+    Classic bot activities use Bot Framework connector tokens. Agent ID activities use
+    Entra tokens whose audience is the agent identity blueprint app ID.
+    """
+
+    def __init__(self, app_id: str, cloud: Optional[CloudEnvironment] = None):
+        self._app_id = app_id
+        self._cloud = cloud or PUBLIC
+        self._service_validator = TokenValidator.for_service(app_id, cloud=self._cloud)
+        self._entra_validators_by_tenant: dict[str, TokenValidator] = {}
+
+    async def validate_token(self, raw_token: str, service_url: Optional[str] = None) -> Dict[str, Any]:
+        unverified_payload = jwt.decode(raw_token, options={"verify_signature": False})
+        issuer = unverified_payload.get("iss", "")
+        if self._is_entra_issuer(issuer):
+            return await self._validate_entra_token(raw_token, unverified_payload)
+
+        return await self._service_validator.validate_token(raw_token, service_url)
+
+    def _is_entra_issuer(self, issuer: Any) -> bool:
+        if not isinstance(issuer, str):
+            return False
+
+        return issuer.startswith(self._cloud.login_endpoint) or issuer.startswith("https://sts.windows.net/")
+
+    async def _validate_entra_token(self, raw_token: str, unverified_payload: Dict[str, Any]) -> Dict[str, Any]:
+        tenant_id = unverified_payload.get("tid")
+        if not tenant_id or not isinstance(tenant_id, str):
+            raise jwt.InvalidTokenError("Entra inbound token is missing tid")
+
+        validator = self._get_entra_validator(tenant_id)
+        # TODO: Agent ID inbound Entra tokens currently do not include serviceurl. Revisit service URL
+        # validation for this path once the platform defines a signed service URL claim or equivalent.
+        return await validator.validate_token(raw_token)
+
+    def _get_entra_validator(self, tenant_id: str) -> TokenValidator:
+        cached_validator = self._entra_validators_by_tenant.get(tenant_id)
+        if cached_validator:
+            return cached_validator
+
+        validator = TokenValidator.for_entra(
+            self._app_id,
+            tenant_id,
+            cloud=self._cloud,
+        )
+        self._entra_validators_by_tenant[tenant_id] = validator
+        return validator

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import logging
 import re
-from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -15,7 +14,7 @@ import jwt
 from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 
 JWT_LEEWAY_SECONDS = 300  # Allowable clock skew when validating JWTs
-MAX_ENTRA_VALIDATOR_CACHE_SIZE = 100
+_MAX_ENTRA_VALIDATOR_CACHE_SIZE = 100
 ENTRA_V1_ISSUER_PREFIX = "https://sts.windows.net/"
 
 logger = logging.getLogger(__name__)
@@ -246,7 +245,7 @@ class InboundActivityTokenValidator:
         self._app_id = app_id
         self._cloud = cloud or PUBLIC
         self._service_validator = TokenValidator.for_service(app_id, cloud=self._cloud)
-        self._entra_validators_by_tenant: OrderedDict[str, TokenValidator] = OrderedDict()
+        self._entra_validators_by_tenant: dict[str, TokenValidator] = {}
 
     async def validate_token(self, raw_token: str, service_url: Optional[str] = None) -> Dict[str, Any]:
         unverified_payload = jwt.decode(raw_token, algorithms=["RS256"], options={"verify_signature": False})
@@ -275,7 +274,6 @@ class InboundActivityTokenValidator:
     def _get_entra_validator(self, tenant_id: str) -> TokenValidator:
         cached_validator = self._entra_validators_by_tenant.get(tenant_id)
         if cached_validator:
-            self._entra_validators_by_tenant.move_to_end(tenant_id)
             return cached_validator
 
         validator = TokenValidator.for_entra(
@@ -284,6 +282,7 @@ class InboundActivityTokenValidator:
             cloud=self._cloud,
         )
         self._entra_validators_by_tenant[tenant_id] = validator
-        if len(self._entra_validators_by_tenant) > MAX_ENTRA_VALIDATOR_CACHE_SIZE:
-            self._entra_validators_by_tenant.popitem(last=False)
+        if len(self._entra_validators_by_tenant) > _MAX_ENTRA_VALIDATOR_CACHE_SIZE:
+            oldest_tenant_id = next(iter(self._entra_validators_by_tenant))
+            self._entra_validators_by_tenant.pop(oldest_tenant_id)
         return validator

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -13,7 +13,7 @@ from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 from microsoft_teams.api.auth.json_web_token import JsonWebToken
 from pydantic import BaseModel
 
-from ..auth import TokenValidator
+from ..auth import InboundActivityTokenValidator
 from ..events import ActivityEvent, CoreActivity
 from .adapter import HttpRequest, HttpResponse, HttpServerAdapter
 
@@ -43,7 +43,7 @@ class HttpServer:
             raise ValueError("messaging_endpoint must be a non-empty path starting with '/'.")
         self._messaging_endpoint = normalized_endpoint
         self._on_request: Optional[Callable[[ActivityEvent], Awaitable[InvokeResponse[Any]]]] = None
-        self._token_validator: Optional[TokenValidator] = None
+        self._token_validator: Optional[InboundActivityTokenValidator] = None
         self._skip_auth: bool = False
         self._cloud: CloudEnvironment = PUBLIC
         self._initialized: bool = False
@@ -89,7 +89,7 @@ class HttpServer:
 
         app_id = getattr(credentials, "client_id", None) if credentials else None
         if app_id and not skip_auth:
-            self._token_validator = TokenValidator.for_service(
+            self._token_validator = InboundActivityTokenValidator(
                 app_id,
                 cloud=self._cloud,
             )

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -464,6 +464,16 @@ class TestInboundActivityTokenValidator:
             with pytest.raises(jwt.InvalidTokenError, match="missing tid"):
                 await validator.validate_token("entra-token")
 
+    @pytest.mark.asyncio
+    async def test_validate_token_rejects_empty_token_before_routing_decode(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+
+        with patch("jwt.decode") as decode:
+            with pytest.raises(jwt.InvalidTokenError, match="No token provided"):
+                await validator.validate_token("")
+
+        decode.assert_not_called()
+
     def test_get_entra_validator_caches_by_tenant(self):
         validator = InboundActivityTokenValidator("test-app-id")
 

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -7,11 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
-from microsoft_teams.apps.auth.token_validator import (
-    MAX_ENTRA_VALIDATOR_CACHE_SIZE,
-    InboundActivityTokenValidator,
-    TokenValidator,
-)
+from microsoft_teams.apps.auth import token_validator as token_validator_module
+from microsoft_teams.apps.auth.token_validator import InboundActivityTokenValidator, TokenValidator
 
 # pyright: basic
 
@@ -485,9 +482,10 @@ class TestInboundActivityTokenValidator:
         with patch("microsoft_teams.apps.auth.token_validator.TokenValidator.for_entra") as for_entra:
             for_entra.side_effect = lambda _app_id, tenant_id, **_kwargs: MagicMock(name=tenant_id)
 
-            for index in range(MAX_ENTRA_VALIDATOR_CACHE_SIZE + 1):
+            for index in range(token_validator_module._MAX_ENTRA_VALIDATOR_CACHE_SIZE + 1):
                 validator._get_entra_validator(f"tenant-{index}")
 
-        assert len(validator._entra_validators_by_tenant) == MAX_ENTRA_VALIDATOR_CACHE_SIZE
+        assert len(validator._entra_validators_by_tenant) == token_validator_module._MAX_ENTRA_VALIDATOR_CACHE_SIZE
         assert "tenant-0" not in validator._entra_validators_by_tenant
-        assert f"tenant-{MAX_ENTRA_VALIDATOR_CACHE_SIZE}" in validator._entra_validators_by_tenant
+        last_tenant_id = f"tenant-{token_validator_module._MAX_ENTRA_VALIDATOR_CACHE_SIZE}"
+        assert last_tenant_id in validator._entra_validators_by_tenant

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -3,11 +3,11 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
-from microsoft_teams.apps.auth.token_validator import TokenValidator
+from microsoft_teams.apps.auth.token_validator import InboundActivityTokenValidator, TokenValidator
 
 # pyright: basic
 
@@ -407,3 +407,69 @@ class TestTokenValidator:
             result = await validator.validate_token("v1.entra.token")
             assert result["iss"] == "https://sts.windows.net/test-tenant-id/"
             assert result["ver"] == "1.0"
+
+
+class TestInboundActivityTokenValidator:
+    @pytest.mark.asyncio
+    async def test_validate_token_uses_service_validator_for_bot_framework_tokens(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+        validator._service_validator.validate_token = AsyncMock(return_value={"iss": "https://api.botframework.com"})
+
+        with patch("jwt.decode", return_value={"iss": "https://api.botframework.com"}):
+            result = await validator.validate_token("bot-token", "https://service.example")
+
+        assert result == {"iss": "https://api.botframework.com"}
+        validator._service_validator.validate_token.assert_called_once_with("bot-token", "https://service.example")
+
+    @pytest.mark.asyncio
+    async def test_validate_token_uses_entra_validator_for_v2_issuer(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+        validator._service_validator.validate_token = AsyncMock()
+        entra_validator = MagicMock()
+        entra_validator.validate_token = AsyncMock(return_value={"tid": "tenant-id"})
+
+        with patch.object(validator, "_get_entra_validator", return_value=entra_validator) as get_validator:
+            with patch(
+                "jwt.decode",
+                return_value={"iss": "https://login.microsoftonline.com/tenant-id/v2.0", "tid": "tenant-id"},
+            ):
+                result = await validator.validate_token("entra-token", "https://service.example")
+
+        assert result == {"tid": "tenant-id"}
+        get_validator.assert_called_once_with("tenant-id")
+        entra_validator.validate_token.assert_called_once_with("entra-token")
+        validator._service_validator.validate_token.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_validate_token_uses_entra_validator_for_v1_sts_issuer(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+        entra_validator = MagicMock()
+        entra_validator.validate_token = AsyncMock(return_value={"tid": "tenant-id"})
+
+        with patch.object(validator, "_get_entra_validator", return_value=entra_validator) as get_validator:
+            with patch("jwt.decode", return_value={"iss": "https://sts.windows.net/tenant-id/", "tid": "tenant-id"}):
+                result = await validator.validate_token("entra-v1-token")
+
+        assert result == {"tid": "tenant-id"}
+        get_validator.assert_called_once_with("tenant-id")
+        entra_validator.validate_token.assert_called_once_with("entra-v1-token")
+
+    @pytest.mark.asyncio
+    async def test_validate_token_rejects_entra_token_without_tid(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+
+        with patch("jwt.decode", return_value={"iss": "https://login.microsoftonline.com/tenant-id/v2.0"}):
+            with pytest.raises(jwt.InvalidTokenError, match="missing tid"):
+                await validator.validate_token("entra-token")
+
+    def test_get_entra_validator_caches_by_tenant(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+
+        with patch("microsoft_teams.apps.auth.token_validator.TokenValidator.for_entra") as for_entra:
+            for_entra.return_value = MagicMock()
+
+            first = validator._get_entra_validator("tenant-id")
+            second = validator._get_entra_validator("tenant-id")
+
+        assert first is second
+        for_entra.assert_called_once_with("test-app-id", "tenant-id", cloud=validator._cloud)

--- a/packages/apps/tests/test_token_validator.py
+++ b/packages/apps/tests/test_token_validator.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
-from microsoft_teams.apps.auth.token_validator import InboundActivityTokenValidator, TokenValidator
+from microsoft_teams.apps.auth.token_validator import (
+    MAX_ENTRA_VALIDATOR_CACHE_SIZE,
+    InboundActivityTokenValidator,
+    TokenValidator,
+)
 
 # pyright: basic
 
@@ -415,10 +419,11 @@ class TestInboundActivityTokenValidator:
         validator = InboundActivityTokenValidator("test-app-id")
         validator._service_validator.validate_token = AsyncMock(return_value={"iss": "https://api.botframework.com"})
 
-        with patch("jwt.decode", return_value={"iss": "https://api.botframework.com"}):
+        with patch("jwt.decode", return_value={"iss": "https://api.botframework.com"}) as decode:
             result = await validator.validate_token("bot-token", "https://service.example")
 
         assert result == {"iss": "https://api.botframework.com"}
+        decode.assert_called_once_with("bot-token", algorithms=["RS256"], options={"verify_signature": False})
         validator._service_validator.validate_token.assert_called_once_with("bot-token", "https://service.example")
 
     @pytest.mark.asyncio
@@ -473,3 +478,16 @@ class TestInboundActivityTokenValidator:
 
         assert first is second
         for_entra.assert_called_once_with("test-app-id", "tenant-id", cloud=validator._cloud)
+
+    def test_get_entra_validator_cache_is_bounded(self):
+        validator = InboundActivityTokenValidator("test-app-id")
+
+        with patch("microsoft_teams.apps.auth.token_validator.TokenValidator.for_entra") as for_entra:
+            for_entra.side_effect = lambda _app_id, tenant_id, **_kwargs: MagicMock(name=tenant_id)
+
+            for index in range(MAX_ENTRA_VALIDATOR_CACHE_SIZE + 1):
+                validator._get_entra_validator(f"tenant-{index}")
+
+        assert len(validator._entra_validators_by_tenant) == MAX_ENTRA_VALIDATOR_CACHE_SIZE
+        assert "tenant-0" not in validator._entra_validators_by_tenant
+        assert f"tenant-{MAX_ENTRA_VALIDATOR_CACHE_SIZE}" in validator._entra_validators_by_tenant


### PR DESCRIPTION
Adds inbound validation for Agent ID activities using Entra tokens.

Why:
Agent 365 inbound activities can arrive with *Entra access tokens* whose audience is the agent identity blueprint app ID. Classic Bot Framework validation looks at the wrong JWKS for those tokens, so the request is rejected before handlers run.

Interesting bits:
- TokenValidator now owns the inbound activity token branching.
- We do one untrusted JWT parse up front to choose the validation path. This is only routing info (`iss` / `tid`), not authentication. The token is accepted only after the chosen validator does full signature, issuer, audience, and scope validation.
- Entra issuers validate with tenant Entra JWKS and blueprint audience.
- Classic Bot Framework tokens keep the existing service token validation path.
- The per-tenant Entra validator cache is bounded so random tenant IDs can’t grow it forever.

Testing:
- uv run pytest packages/apps/tests/test_token_validator.py::TestInboundActivityTokenValidator::test_validate_token_uses_service_validator_for_bot_framework_tokens packages/apps/tests/test_token_validator.py::TestInboundActivityTokenValidator::test_get_entra_validator_caches_by_tenant packages/apps/tests/test_token_validator.py::TestInboundActivityTokenValidator::test_get_entra_validator_cache_is_bounded
- uv run ruff check packages/apps/src/microsoft_teams/apps/auth/token_validator.py packages/apps/tests/test_token_validator.py
