### PR TITLE
Remove ExperimentalTeamsQuotedReplies markers

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/message/message.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message.py
@@ -76,7 +76,6 @@ class MessageActivity(_MessageBase, ActivityBase):
     text: str = ""  # pyright: ignore [reportGeneralTypeIssues, reportIncompatibleVariableOverride]
     """The text content of the message."""
 
-    @experimental("ExperimentalTeamsQuotedReplies")
     def get_quoted_messages(self) -> list[QuotedReplyEntity]:
         """
         Get all quoted reply entities from this message.
@@ -86,7 +85,6 @@ class MessageActivity(_MessageBase, ActivityBase):
 
         .. warning:: Coming Soon
             This API is coming soon and may change in the future.
-            Diagnostic: ExperimentalTeamsQuotedReplies
         """
         return [e for e in (self.entities or []) if isinstance(e, QuotedReplyEntity)]
 
@@ -436,7 +434,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
         self.channel_data.feedback_loop_enabled = None
         return self
 
-    @experimental("ExperimentalTeamsQuotedReplies")
     def prepend_quote(self, message_id: str) -> Self:
         """
         Prepend a quotedReply entity and placeholder before existing text.
@@ -450,7 +447,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
 
         .. warning:: Coming Soon
             This API is coming soon and may change in the future.
-            Diagnostic: ExperimentalTeamsQuotedReplies
         """
         if not self.entities:
             self.entities = []
@@ -460,7 +456,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
         self.text = f"{placeholder} {self.text}" if has_text else placeholder
         return self
 
-    @experimental("ExperimentalTeamsQuotedReplies")
     def add_quote(self, message_id: str, text: str | None = None) -> Self:
         """
         Add a quoted message reference and append a placeholder to text.
@@ -476,7 +471,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
 
         .. warning:: Coming Soon
             This API is coming soon and may change in the future.
-            Diagnostic: ExperimentalTeamsQuotedReplies
         """
         if not self.entities:
             self.entities = []

--- a/packages/api/src/microsoft_teams/api/activities/message/message.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message.py
@@ -82,9 +82,6 @@ class MessageActivity(_MessageBase, ActivityBase):
 
         Returns:
             List of quoted reply entities, empty if none
-
-        .. warning:: Coming Soon
-            This API is coming soon and may change in the future.
         """
         return [e for e in (self.entities or []) if isinstance(e, QuotedReplyEntity)]
 
@@ -444,9 +441,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
 
         Returns:
             Self for method chaining
-
-        .. warning:: Coming Soon
-            This API is coming soon and may change in the future.
         """
         if not self.entities:
             self.entities = []
@@ -468,9 +462,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
 
         Returns:
             Self for method chaining
-
-        .. warning:: Coming Soon
-            This API is coming soon and may change in the future.
         """
         if not self.entities:
             self.entities = []

--- a/packages/api/src/microsoft_teams/api/models/entity/quoted_reply_entity.py
+++ b/packages/api/src/microsoft_teams/api/models/entity/quoted_reply_entity.py
@@ -11,9 +11,6 @@ from .entity_base import EntityBase
 
 class QuotedReplyData(CustomBaseModel):
     """Data for a quoted reply entity
-
-    .. warning:: Coming Soon
-        This API is coming soon and may change in the future.
     """
 
     message_id: str
@@ -40,9 +37,6 @@ class QuotedReplyData(CustomBaseModel):
 
 class QuotedReplyEntity(EntityBase):
     """Entity containing quoted reply information
-
-    .. warning:: Coming Soon
-        This API is coming soon and may change in the future.
     """
 
     type: Literal["quotedReply"] = "quotedReply"

--- a/packages/api/src/microsoft_teams/api/models/entity/quoted_reply_entity.py
+++ b/packages/api/src/microsoft_teams/api/models/entity/quoted_reply_entity.py
@@ -5,19 +5,15 @@ Licensed under the MIT License.
 
 from typing import Literal, Optional
 
-from microsoft_teams.common.experimental import experimental
-
 from ..custom_base_model import CustomBaseModel
 from .entity_base import EntityBase
 
 
-@experimental("ExperimentalTeamsQuotedReplies")
 class QuotedReplyData(CustomBaseModel):
     """Data for a quoted reply entity
 
     .. warning:: Coming Soon
         This API is coming soon and may change in the future.
-        Diagnostic: ExperimentalTeamsQuotedReplies
     """
 
     message_id: str
@@ -42,13 +38,11 @@ class QuotedReplyData(CustomBaseModel):
     "Whether the message reference has been validated"
 
 
-@experimental("ExperimentalTeamsQuotedReplies")
 class QuotedReplyEntity(EntityBase):
     """Entity containing quoted reply information
 
     .. warning:: Coming Soon
         This API is coming soon and may change in the future.
-        Diagnostic: ExperimentalTeamsQuotedReplies
     """
 
     type: Literal["quotedReply"] = "quotedReply"

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -217,9 +217,6 @@ class ActivityContext(Generic[T]):
 
         Returns:
             The sent activity
-
-        .. warning:: Coming Soon
-            This API is coming soon and may change in the future.
         """
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         if isinstance(activity, MessageActivityInput):

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -38,7 +38,7 @@ from microsoft_teams.api.models.attachment.card_attachment import (
 from microsoft_teams.api.models.oauth import OAuthCard
 from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Storage
-from microsoft_teams.common.experimental import ExperimentalWarning, experimental
+from microsoft_teams.common.experimental import ExperimentalWarning
 from microsoft_teams.common.http.client_token import Token
 
 from ..activity_sender import ActivitySender
@@ -206,7 +206,6 @@ class ActivityContext(Generic[T]):
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         return await self.send(activity)
 
-    @experimental("ExperimentalTeamsQuotedReplies")
     async def quote(self, message_id: str, input: str | ActivityParams) -> SentActivity:
         """
         Send a message to the conversation with a quoted message reference prepended to the text.
@@ -221,7 +220,6 @@ class ActivityContext(Generic[T]):
 
         .. warning:: Coming Soon
             This API is coming soon and may change in the future.
-            Diagnostic: ExperimentalTeamsQuotedReplies
         """
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         if isinstance(activity, MessageActivityInput):


### PR DESCRIPTION
Quoted replies are now GA. Removes all `@experimental("ExperimentalTeamsQuotedReplies")` decorators and diagnostic docstring lines.

## Changes
- `packages/apps/src/microsoft_teams/apps/routing/activity_context.py`
- `packages/api/src/microsoft_teams/api/activities/message/message.py`
- `packages/api/src/microsoft_teams/api/models/entity/quoted_reply_entity.py`

All tests pass (625/625). Lint and type checks clean.