### PR TITLE
test: add integration tests for Teams Python SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 
 # Environments
 .env
+.env.*
+!.env.example
 .venv
 env/
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,6 @@ Integration tests live in `tests/integration/` and make real API calls against t
 
 ```bash
 uv sync --all-packages --group dev --group integration
-export $(cat tests/integration/.env.botid-prod | xargs)
+set -a; source tests/integration/.env.botid-prod; set +a
 pytest tests/integration -v
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,17 @@ Please refer to this sub-module's root repo Contributing guide at [Teams SDK Con
 ## Multi-Language SDK
 
 The Teams SDK is maintained across three languages: **Python**, **TypeScript**, and **.NET**. When proposing new features, please discuss them in a language-agnostic way in [GitHub Discussions](https://github.com/microsoft/teams-sdk/discussions). This ensures that features can be implemented consistently across all three SDKs and benefits the entire Teams developer community.
+
+## Integration Tests
+
+Integration tests live in `tests/integration/` and make real API calls against the Teams Bot Framework service.
+
+**When to add:** If your change affects what goes on the wire (URL, headers, body, auth token) or how a response is parsed, add an integration test. See the [cross-SDK runbook](https://github.com/microsoft/teams-sdk/blob/main/INTEGRATION-TESTS.md) for full guidelines.
+
+**Running locally:**
+
+```bash
+uv sync --all-packages --group dev --group integration
+export $(cat tests/integration/.env.botid-prod | xargs)
+pytest tests/integration -v
+```

--- a/packages/api/src/microsoft_teams/api/models/team_details.py
+++ b/packages/api/src/microsoft_teams/api/models/team_details.py
@@ -19,7 +19,7 @@ class TeamDetails(CustomBaseModel):
     name: Optional[str] = None
     "Name of team."
 
-    type: Literal["standard", "sharedChannel", "privateChannel"]
+    type: Optional[Literal["standard", "sharedChannel", "privateChannel"]] = None
     "The type of the team. Valid values are standard, sharedChannel and privateChannel."
 
     aad_group_id: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=6.0.0",
 ]
+integration = [
+    "azure-identity>=1.17.0",
+    "python-dotenv>=1.0.0",
+]
 release = [
     "hatch-teams-build",
 ]

--- a/tests/integration/.env.example
+++ b/tests/integration/.env.example
@@ -1,0 +1,21 @@
+# Integration Tests — .env template
+# Copy to .env.botid-prod (or similar) and fill in values.
+# These files are gitignored.
+
+AZURE_TENANT_ID=<your-tenant-id>
+AZURE_CLIENT_ID=<your-bot-client-id>
+AZURE_CLIENT_SECRET=<your-bot-client-secret>
+
+TEST_SERVICE_URL=https://smba.trafficmanager.net/amer/<your-tenant-id>/
+TEST_CONVERSATION_ID=19:...@thread.tacv2
+TEST_USER_ID=29:...
+TEST_USER_ID_2=29:...
+TEST_TEAM_ID=19:...@thread.tacv2
+TEST_CHANNEL_ID=19:...@thread.tacv2
+TEST_MEETING_ID=MCM...
+TEST_TENANT_ID=<your-tenant-id>
+
+# Optional — for agentic identity tests
+# TEST_AGENTIC_APP_ID=<agentic-app-id>
+# TEST_AGENTIC_USER_ID=<agentic-user-id>
+# AZURE_SCOPE=https://botapi.skype.com/.default

--- a/tests/integration/.env.example
+++ b/tests/integration/.env.example
@@ -13,7 +13,6 @@ TEST_USER_ID_2=29:...
 TEST_TEAM_ID=19:...@thread.tacv2
 TEST_CHANNEL_ID=19:...@thread.tacv2
 TEST_MEETING_ID=MCM...
-TEST_TENANT_ID=<your-tenant-id>
 
 # Optional — for agentic identity tests
 # TEST_AGENTIC_APP_ID=<agentic-app-id>

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -4,7 +4,7 @@ This directory contains integration tests that make real API calls against the T
 
 ## Prerequisites
 
-- Python >= 3.12
+- Python >= 3.11
 - UV installed
 - A `.env.botid-prod` file with valid credentials (see `.env.example`)
 
@@ -19,10 +19,7 @@ uv sync --all-packages --group dev --group integration
 
 ```bash
 # From repo root — load env and run
-dotenv -f tests/integration/.env.botid-prod run -- pytest tests/integration -v
-
-# Or export vars manually
-export $(cat tests/integration/.env.botid-prod | xargs)
+set -a; source tests/integration/.env.botid-prod; set +a
 pytest tests/integration -v
 
 # Run a specific test file
@@ -34,8 +31,7 @@ pytest tests/integration -k "test_create_activity" -v
 
 ## Architecture
 
-- **`conftest.py`** — Shared fixture with async token acquisition (azure-identity), member caching, and config loading.
-- Tests use a singleton fixture pattern — auth and member lookup happen once per session.
+- **`conftest.py`** — Per-test fixture that creates a fresh credential and API client on each test's event loop. Config and member lists are cached at module level to avoid repeated API calls.
 - Tests are async (`pytest-asyncio` with `asyncio_mode = "auto"`).
 
 ## Known Limitations

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,51 @@
+# Integration Tests
+
+This directory contains integration tests that make real API calls against the Teams Bot Framework service.
+
+## Prerequisites
+
+- Python >= 3.12
+- UV installed
+- A `.env.botid-prod` file with valid credentials (see `.env.example`)
+
+## Setup
+
+```bash
+# From repo root — install all deps including integration group
+uv sync --all-packages --group dev --group integration
+```
+
+## Running Tests
+
+```bash
+# From repo root — load env and run
+dotenv -f tests/integration/.env.botid-prod run -- pytest tests/integration -v
+
+# Or export vars manually
+export $(cat tests/integration/.env.botid-prod | xargs)
+pytest tests/integration -v
+
+# Run a specific test file
+pytest tests/integration/test_activities.py -v
+
+# Run a specific test
+pytest tests/integration -k "test_create_activity" -v
+```
+
+## Architecture
+
+- **`conftest.py`** — Shared fixture with async token acquisition (azure-identity), member caching, and config loading.
+- Tests use a singleton fixture pattern — auth and member lookup happen once per session.
+- Tests are async (`pytest-asyncio` with `asyncio_mode = "auto"`).
+
+## Known Limitations
+
+- **Agentic identity**: Reactions and paged members are not supported.
+- **Canary ring**: Reactions return 404, paged members return empty.
+- **Throttling**: Member caching prevents 429s but full-suite runs may still hit rate limits.
+
+## Cross-SDK Runbook
+
+For provisioning, secret rotation, and troubleshooting:
+
+👉 [INTEGRATION-TESTS.md](https://github.com/microsoft/teams-sdk/blob/main/INTEGRATION-TESTS.md)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -123,8 +123,9 @@ async def fixture():
         members = await api.conversations.members(config.conversation_id).get_all()
         bot_prefix = f"28:{config.client_id}"
         _cached_members = [m for m in members if m.id and not m.id.startswith(bot_prefix)]
-        if _cached_members:
-            _cached_member_mri_1 = _cached_members[0].id
+        if not _cached_members:
+            raise RuntimeError("No non-bot members found in conversation — tests require at least one human member")
+        _cached_member_mri_1 = _cached_members[0].id
         if len(_cached_members) > 1:
             _cached_member_mri_2 = _cached_members[1].id
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,137 @@
+"""
+Integration test fixture for Microsoft Teams Python SDK.
+
+Provides shared authentication and configuration for all integration tests.
+Uses azure-identity for token acquisition and caches conversation
+members to avoid 429 throttling.
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest_asyncio
+from azure.identity.aio import ClientSecretCredential
+from dotenv import load_dotenv
+from microsoft_teams.api import ApiClient
+from microsoft_teams.common.http import Client, ClientOptions
+
+
+@dataclass
+class TestConfig:
+    tenant_id: str
+    client_id: str
+    client_secret: str
+    service_url: str
+    conversation_id: str
+    user_id: str
+    team_id: str
+    channel_id: str
+    meeting_id: str
+    user_id_2: Optional[str] = None
+    agentic_app_id: Optional[str] = None
+    agentic_user_id: Optional[str] = None
+    scope: str = "https://api.botframework.com/.default"
+
+
+@dataclass
+class TestFixture:
+    config: TestConfig
+    api: ApiClient
+    credential: ClientSecretCredential
+    cached_members: list = field(default_factory=list)
+    member_mri_1: Optional[str] = None
+    member_mri_2: Optional[str] = None
+
+    @property
+    def is_canary(self) -> bool:
+        return "canary" in self.config.service_url.lower()
+
+    @property
+    def is_agentic(self) -> bool:
+        return self.config.agentic_app_id is not None and self.config.agentic_app_id != ""
+
+
+# Module-level cache (persists across tests in the same process)
+_cached_config: Optional[TestConfig] = None
+_cached_members: Optional[list] = None
+_cached_member_mri_1: Optional[str] = None
+_cached_member_mri_2: Optional[str] = None
+
+
+def _load_config() -> TestConfig:
+    """Load test configuration from environment variables."""
+    global _cached_config
+    if _cached_config is not None:
+        return _cached_config
+
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    for env_file in [".env.botid-prod", ".env"]:
+        env_path = os.path.join(test_dir, env_file)
+        if os.path.exists(env_path):
+            load_dotenv(env_path)
+            break
+
+    def env(name: str, fallback: Optional[str] = None) -> str:
+        value = os.environ.get(name, fallback)
+        if not value:
+            raise RuntimeError(f"Missing required env var: {name}")
+        return value
+
+    _cached_config = TestConfig(
+        tenant_id=env("AZURE_TENANT_ID"),
+        client_id=env("AZURE_CLIENT_ID"),
+        client_secret=env("AZURE_CLIENT_SECRET"),
+        service_url=env("TEST_SERVICE_URL"),
+        conversation_id=env("TEST_CONVERSATION_ID"),
+        user_id=env("TEST_USER_ID"),
+        team_id=env("TEST_TEAM_ID"),
+        channel_id=env("TEST_CHANNEL_ID"),
+        meeting_id=env("TEST_MEETING_ID"),
+        user_id_2=os.environ.get("TEST_USER_ID_2"),
+        agentic_app_id=os.environ.get("TEST_AGENTIC_APP_ID"),
+        agentic_user_id=os.environ.get("TEST_AGENTIC_USER_ID"),
+        scope=os.environ.get("AZURE_SCOPE", "https://api.botframework.com/.default"),
+    )
+    return _cached_config
+
+
+@pytest_asyncio.fixture
+async def fixture():
+    """Per-test fixture — creates a fresh credential + client on the current event loop."""
+    global _cached_members, _cached_member_mri_1, _cached_member_mri_2
+
+    config = _load_config()
+
+    credential = ClientSecretCredential(
+        tenant_id=config.tenant_id,
+        client_id=config.client_id,
+        client_secret=config.client_secret,
+    )
+
+    async def token_factory() -> str:
+        t = await credential.get_token(config.scope)
+        return t.token
+
+    http_client = Client(ClientOptions(token=token_factory))
+    api = ApiClient(service_url=config.service_url, options=http_client)
+
+    f = TestFixture(config=config, api=api, credential=credential)
+
+    # Cache members once (avoids 429 throttling)
+    if _cached_members is None:
+        members = await api.conversations.members(config.conversation_id).get_all()
+        bot_prefix = f"28:{config.client_id}"
+        _cached_members = [m for m in members if m.id and not m.id.startswith(bot_prefix)]
+        if _cached_members:
+            _cached_member_mri_1 = _cached_members[0].id
+        if len(_cached_members) > 1:
+            _cached_member_mri_2 = _cached_members[1].id
+
+    f.cached_members = _cached_members or []
+    f.member_mri_1 = _cached_member_mri_1
+    f.member_mri_2 = _cached_member_mri_2
+
+    yield f
+
+    await credential.close()

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/integration/test_activities.py
+++ b/tests/integration/test_activities.py
@@ -1,0 +1,74 @@
+"""Integration tests for activity operations (send, update, reply, delete)."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from microsoft_teams.api.activities import MessageActivityInput
+
+
+
+
+class TestActivities:
+    """Tests for conversation activity CRUD operations."""
+
+    @pytest.mark.asyncio
+    async def test_create_activity(self, fixture):
+        """Send a message activity and verify it returns an ID."""
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        activity = MessageActivityInput().with_text(
+            f"[PY Integration] create at {datetime.now(timezone.utc).isoformat()}"
+        )
+        result = await api.conversations.activities(conv_id).create(activity)
+        assert result.id is not None
+        assert result.id != ""
+
+    @pytest.mark.asyncio
+    async def test_update_activity(self, fixture):
+        """Send then update an activity."""
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        activity = MessageActivityInput().with_text(
+            f"[PY Integration] update-original at {datetime.now(timezone.utc).isoformat()}"
+        )
+        sent = await api.conversations.activities(conv_id).create(activity)
+
+        updated = MessageActivityInput().with_text(
+            f"[PY Integration] update-edited at {datetime.now(timezone.utc).isoformat()}"
+        )
+        result = await api.conversations.activities(conv_id).update(sent.id, updated)
+        assert result.id is not None
+
+    @pytest.mark.asyncio
+    async def test_reply_to_activity(self, fixture):
+        """Send a message then reply to it."""
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        original = MessageActivityInput().with_text(
+            f"[PY Integration] reply-original at {datetime.now(timezone.utc).isoformat()}"
+        )
+        sent = await api.conversations.activities(conv_id).create(original)
+
+        reply = MessageActivityInput().with_text(
+            f"[PY Integration] reply at {datetime.now(timezone.utc).isoformat()}"
+        )
+        result = await api.conversations.activities(conv_id).reply(sent.id, reply)
+        assert result.id is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_activity(self, fixture):
+        """Send then delete an activity."""
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        activity = MessageActivityInput().with_text(
+            f"[PY Integration] delete-me at {datetime.now(timezone.utc).isoformat()}"
+        )
+        sent = await api.conversations.activities(conv_id).create(activity)
+
+        # Should not raise
+        await api.conversations.activities(conv_id).delete(sent.id)

--- a/tests/integration/test_activities.py
+++ b/tests/integration/test_activities.py
@@ -3,10 +3,7 @@
 from datetime import datetime, timezone
 
 import pytest
-
 from microsoft_teams.api.activities import MessageActivityInput
-
-
 
 
 class TestActivities:
@@ -23,7 +20,7 @@ class TestActivities:
         )
         result = await api.conversations.activities(conv_id).create(activity)
         assert result.id is not None
-        assert result.id != ""
+        assert result.id != "DO_NOT_USE_PLACEHOLDER_ID"
 
     @pytest.mark.asyncio
     async def test_update_activity(self, fixture):
@@ -41,6 +38,7 @@ class TestActivities:
         )
         result = await api.conversations.activities(conv_id).update(sent.id, updated)
         assert result.id is not None
+        assert result.id != "DO_NOT_USE_PLACEHOLDER_ID"
 
     @pytest.mark.asyncio
     async def test_reply_to_activity(self, fixture):
@@ -53,11 +51,10 @@ class TestActivities:
         )
         sent = await api.conversations.activities(conv_id).create(original)
 
-        reply = MessageActivityInput().with_text(
-            f"[PY Integration] reply at {datetime.now(timezone.utc).isoformat()}"
-        )
+        reply = MessageActivityInput().with_text(f"[PY Integration] reply at {datetime.now(timezone.utc).isoformat()}")
         result = await api.conversations.activities(conv_id).reply(sent.id, reply)
         assert result.id is not None
+        assert result.id != "DO_NOT_USE_PLACEHOLDER_ID"
 
     @pytest.mark.asyncio
     async def test_delete_activity(self, fixture):

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -1,0 +1,42 @@
+"""Integration tests for conversation creation (1:1 and group)."""
+
+import pytest
+
+from microsoft_teams.api.clients.conversation.params import CreateConversationParams
+from microsoft_teams.api.models import Account
+
+
+
+
+class TestConversations:
+    """Tests for creating conversations."""
+
+    @pytest.mark.asyncio
+    async def test_create_personal_conversation(self, fixture):
+        """Create a 1:1 conversation with a user."""
+        api = fixture.api
+
+        assert fixture.member_mri_1 is not None, "No cached members available"
+        params = CreateConversationParams(
+            members=[Account(id=fixture.member_mri_1)],
+            tenant_id=fixture.config.tenant_id,
+        )
+        result = await api.conversations.create(params)
+        assert result.id is not None
+        assert result.id != ""
+
+    @pytest.mark.asyncio
+    async def test_create_group_conversation(self, fixture):
+        """Create a group conversation with a single member + bot pattern."""
+        api = fixture.api
+
+        assert fixture.member_mri_1 is not None, "No cached members available"
+        # Service rejects multiple members via Bot+Members pattern.
+        # Use single non-bot member with channel_data containing tenant.
+        params = CreateConversationParams(
+            members=[Account(id=fixture.member_mri_1)],
+            channel_data={"tenant": {"id": fixture.config.tenant_id}},
+        )
+        result = await api.conversations.create(params)
+        assert result.id is not None
+        assert result.id != ""

--- a/tests/integration/test_conversations.py
+++ b/tests/integration/test_conversations.py
@@ -1,11 +1,8 @@
 """Integration tests for conversation creation (1:1 and group)."""
 
 import pytest
-
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
 from microsoft_teams.api.models import Account
-
-
 
 
 class TestConversations:

--- a/tests/integration/test_members.py
+++ b/tests/integration/test_members.py
@@ -1,0 +1,42 @@
+"""Integration tests for member operations (get all, get by ID, get paged)."""
+
+import pytest
+
+
+
+
+class TestMembers:
+    """Tests for conversation member operations."""
+
+    @pytest.mark.asyncio
+    async def test_get_all_members(self, fixture):
+        """Get all members of a conversation."""
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        members = await api.conversations.members(conv_id).get_all()
+        assert len(members) > 0
+        assert members[0].id is not None
+
+    @pytest.mark.asyncio
+    async def test_get_member_by_id(self, fixture):
+        """Get a specific member by their MRI."""
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        assert fixture.member_mri_1 is not None, "No cached members available"
+        member = await api.conversations.members(conv_id).get(fixture.member_mri_1)
+        assert member.id == fixture.member_mri_1
+
+    @pytest.mark.asyncio
+    async def test_get_paged_members(self, fixture):
+        """Get members with paging."""
+        if fixture.is_canary or fixture.is_agentic:
+            pytest.skip("Paged members not supported on canary/agentic")
+
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        result = await api.conversations.members(conv_id).get_paged(page_size=2)
+        assert result.members is not None
+        assert len(result.members) > 0

--- a/tests/integration/test_members.py
+++ b/tests/integration/test_members.py
@@ -3,8 +3,6 @@
 import pytest
 
 
-
-
 class TestMembers:
     """Tests for conversation member operations."""
 

--- a/tests/integration/test_teams_and_reactions.py
+++ b/tests/integration/test_teams_and_reactions.py
@@ -1,10 +1,7 @@
 """Integration tests for teams and reactions operations."""
 
 import pytest
-
 from microsoft_teams.api.activities import MessageActivityInput
-
-
 
 
 class TestTeams:
@@ -46,6 +43,7 @@ class TestReactions:
         # Send a message to react to
         activity = MessageActivityInput().with_text("[PY Integration] reaction target")
         sent = await api.conversations.activities(conv_id).create(activity)
+        assert sent.id != "DO_NOT_USE_PLACEHOLDER_ID", "Activity creation returned placeholder ID"
 
         # Add reaction
         await api.reactions.add(conv_id, sent.id, "like")

--- a/tests/integration/test_teams_and_reactions.py
+++ b/tests/integration/test_teams_and_reactions.py
@@ -13,9 +13,6 @@ class TestTeams:
     @pytest.mark.asyncio
     async def test_get_team_details(self, fixture):
         """Get details of the test team."""
-        # TODO: TeamDetails.type is required but service doesn't always return it.
-        # Fix the model (make type Optional) then remove this skip.
-        pytest.skip("TeamDetails model requires 'type' field but service omits it")
         api = fixture.api
         team_id = fixture.config.team_id
 

--- a/tests/integration/test_teams_and_reactions.py
+++ b/tests/integration/test_teams_and_reactions.py
@@ -1,0 +1,57 @@
+"""Integration tests for teams and reactions operations."""
+
+import pytest
+
+from microsoft_teams.api.activities import MessageActivityInput
+
+
+
+
+class TestTeams:
+    """Tests for team details and channels."""
+
+    @pytest.mark.asyncio
+    async def test_get_team_details(self, fixture):
+        """Get details of the test team."""
+        # TODO: TeamDetails.type is required but service doesn't always return it.
+        # Fix the model (make type Optional) then remove this skip.
+        pytest.skip("TeamDetails model requires 'type' field but service omits it")
+        api = fixture.api
+        team_id = fixture.config.team_id
+
+        details = await api.teams.get_by_id(team_id)
+        assert details.id is not None
+
+    @pytest.mark.asyncio
+    async def test_get_team_channels(self, fixture):
+        """Get channels for the test team."""
+        api = fixture.api
+        team_id = fixture.config.team_id
+
+        channels = await api.teams.get_conversations(team_id)
+        assert len(channels) > 0
+
+
+class TestReactions:
+    """Tests for adding and removing reactions."""
+
+    @pytest.mark.asyncio
+    async def test_add_and_delete_reaction(self, fixture):
+        """Add a reaction to an activity then remove it."""
+        if fixture.is_agentic:
+            pytest.skip("Reactions not supported with agentic identity")
+        if fixture.is_canary:
+            pytest.skip("Reactions return 404 on canary")
+
+        api = fixture.api
+        conv_id = fixture.config.conversation_id
+
+        # Send a message to react to
+        activity = MessageActivityInput().with_text("[PY Integration] reaction target")
+        sent = await api.conversations.activities(conv_id).create(activity)
+
+        # Add reaction
+        await api.reactions.add(conv_id, sent.id, "like")
+
+        # Remove reaction
+        await api.reactions.delete(conv_id, sent.id, "like")

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,10 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
+integration = [
+    { name = "azure-identity", specifier = ">=1.17.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+]
 release = [{ name = "hatch-teams-build", directory = "tools/hatch-teams-build" }]
 
 [[package]]


### PR DESCRIPTION
Adds 12 integration tests that make real API calls against the Teams Bot Framework service.

**Tests:**
- Activities: create, update, reply, delete (4)
- Members: get all, get by ID, get paged (3)
- Conversations: create 1:1, create group (2)
- Teams: get details, get channels (2)
- Reactions: add and delete (1)

**Also fixes:**
- `TeamDetails.type` was incorrectly marked as required — service doesn't always return it. Now `Optional`.

**Setup:**
```bash
uv sync --all-packages --group dev --group integration
export $(cat tests/integration/.env.botid-prod | xargs)
pytest tests/integration -v
```

See [cross-SDK runbook](https://github.com/microsoft/teams-sdk/blob/main/INTEGRATION-TESTS.md) for provisioning and troubleshooting.