### PR TITLE
docs: update integration test runbook link to ADO wiki + close httpx client

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -44,4 +44,4 @@ pytest tests/integration -k "test_create_activity" -v
 
 For provisioning, secret rotation, and troubleshooting:
 
-👉 [INTEGRATION-TESTS.md](https://github.com/microsoft/teams-sdk/blob/main/INTEGRATION-TESTS.md)
+👉 [Integration Test Runbook](https://dev.azure.com/DomoreexpGithub/Github_Pipelines/_wiki/wikis/Github%20Pipelines%20Wiki/1/Teams-SDK-Integration-Test-Runbook) (internal only)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,4 +135,7 @@ async def fixture():
 
     yield f
 
-    await credential.close()
+    try:
+        await credential.close()
+    finally:
+        await http_client.http.aclose()


### PR DESCRIPTION
Updates the integration test README runbook link to point to the internal ADO wiki. Also closes the httpx client in fixture teardown to avoid resource warnings.