### PR TITLE
fix: use artifactName for pipelineArtifact inputs in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -230,7 +230,7 @@ extends:
         templateContext:
           inputs:
           - input: pipelineArtifact
-            artifact: pypi-packages
+            artifactName: pypi-packages
             targetPath: $(Pipeline.Workspace)/pypi-packages
         steps:
         - task: UsePythonVersion@0
@@ -276,7 +276,7 @@ extends:
           isProduction: true
           inputs:
           - input: pipelineArtifact
-            artifact: pypi-packages
+            artifactName: pypi-packages
             targetPath: $(Pipeline.Workspace)/pypi-packages
         steps:
         - task: EsrpRelease@10


### PR DESCRIPTION
The 1ES template requires `artifactName` (not `artifact`) for `pipelineArtifact` input declarations in `templateContext`. This was causing:

```
Unexpected value 'artifactName is a required argument for pipelineArtifact input and 1ES.DownloadPipelineArtifact@1 task'
```