### PR TITLE
Add Teams message history API

### DIFF
--- a/examples/history/README.md
+++ b/examples/history/README.md
@@ -1,0 +1,37 @@
+# Example: Message History
+
+A bot that demonstrates the `ctx.get_history(...)` and `app.get_history(...)` APIs backed by Microsoft Graph.
+
+## Commands
+
+| Command | Behavior |
+|---------|----------|
+| `history` | Reads the 5 most recent messages for the current chat or channel context using `ctx.get_history(5)` |
+| `history ctx <n>` | Reads the last `<n>` messages from the current context |
+| `history chat <chat-id> [n]` | Reads chat history using `app.get_history(n=n, chat_id=chat_id)` |
+| `history channel <team-aad-group-id> <channel-id> [n]` | Reads channel history using `app.get_history(n=n, team_aad_group_id=team_aad_group_id, channel_id=channel_id)` |
+| `history thread <team-aad-group-id> <channel-id> <thread-id> [n]` | Reads channel thread replies using `app.get_history(..., thread_id=thread_id)` |
+| `help` | Shows available commands |
+
+## Required Graph permissions
+
+This example uses app-only Microsoft Graph calls. Grant and admin-consent the app permissions needed for the surfaces you test:
+
+- Channel history: `ChannelMessage.Read.All`
+- Chat history: `Chat.Read.All` or the more specific chat message permission your tenant requires
+
+## Run
+
+```bash
+uv run python src/main.py
+```
+
+## Environment Variables
+
+Create a `.env` file:
+
+```text
+CLIENT_ID=<your-azure-bot-app-id>
+CLIENT_SECRET=<your-azure-bot-app-secret>
+TENANT_ID=<your-tenant-id>
+```

--- a/examples/history/pyproject.toml
+++ b/examples/history/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "history"
+version = "0.1.0"
+description = "Message history test bot"
+readme = "README.md"
+requires-python = ">=3.11,<4.0"
+dependencies = [
+    "dotenv>=0.9.9",
+    "microsoft-teams-apps",
+    "microsoft-teams-api",
+    "microsoft-teams-graph",
+]
+
+[tool.uv.sources]
+microsoft-teams-apps = { workspace = true }
+microsoft-teams-api = { workspace = true }
+microsoft-teams-graph = { workspace = true }

--- a/examples/history/src/main.py
+++ b/examples/history/src/main.py
@@ -44,11 +44,17 @@ def _read_attr(value: Any, *names: str) -> Any:
 
 
 def _message_sender(message: Any) -> str:
-    return (
+    sender = (
         _read_attr(message, "from_", "user", "display_name")
         or _read_attr(message, "from_", "application", "display_name")
         or "Unknown"
     )
+    if sender == "Unknown":
+        logger.info(
+            "Unknown history sender payload: %s",
+            message.model_dump(by_alias=True, exclude_none=True) if hasattr(message, "model_dump") else message,
+        )
+    return sender
 
 
 def _message_text(message: Any) -> str:

--- a/examples/history/src/main.py
+++ b/examples/history/src/main.py
@@ -1,0 +1,156 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+import logging
+import re
+from typing import Any
+
+from microsoft_teams.api import MessageActivity
+from microsoft_teams.api.activities.typing import TypingActivityInput
+from microsoft_teams.apps import ActivityContext, App
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = App()
+
+
+def _parse_count(raw: str | None, default: int = 5) -> int:
+    if raw is None:
+        return default
+
+    count = int(raw)
+    if count < 1:
+        raise ValueError("count must be greater than 0")
+
+    return count
+
+
+def _command_parts(text: str) -> list[str]:
+    without_mentions = re.sub(r"<at>.*?</at>", "", text, flags=re.IGNORECASE).strip()
+    return without_mentions.split()
+
+
+def _read_attr(value: Any, *names: str) -> Any:
+    current = value
+    for name in names:
+        current = getattr(current, name, None)
+        if current is None:
+            return None
+    return current
+
+
+def _message_sender(message: Any) -> str:
+    return (
+        _read_attr(message, "from_", "user", "display_name")
+        or _read_attr(message, "from_", "application", "display_name")
+        or "Unknown"
+    )
+
+
+def _message_text(message: Any) -> str:
+    content = _read_attr(message, "body", "content") or "(no content)"
+    text = re.sub(r"<[^>]+>", "", str(content)).strip()
+    return re.sub(r"\s+", " ", text) or "(no content)"
+
+
+def _format_history(title: str, messages: list[Any]) -> str:
+    if not messages:
+        return f"**{title}**\n\nNo messages returned."
+
+    lines = [f"**{title}**", ""]
+    for index, message in enumerate(messages, 1):
+        sender = _message_sender(message)
+        text = _message_text(message)
+        created = getattr(message, "created_date_time", None)
+        timestamp = f" ({created})" if created else ""
+        lines.append(f"{index}. **{sender}**{timestamp}: {text[:240]}")
+
+    return "\n\n".join(lines)
+
+
+async def _send_history(ctx: ActivityContext[MessageActivity], title: str, messages: list[Any]) -> None:
+    await ctx.reply(_format_history(title, messages))
+
+
+def _history_error_guidance(error: Exception) -> str:
+    error_text = str(error)
+    if "ChannelMessage.Read.All" in error_text or "Missing role permissions" in error_text:
+        return (
+            "Channel history requires the Microsoft Graph **Application** permission "
+            "`ChannelMessage.Read.All` with admin consent. After granting it, restart "
+            "the bot so it gets a fresh app token containing the new role."
+        )
+
+    return "Check that Graph app permissions are granted and that the IDs match the command scope."
+
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    await ctx.reply(TypingActivityInput())
+
+    text = ctx.activity.text or ""
+    parts = _command_parts(text)
+    normalized_text = " ".join(parts).lower()
+
+    if "history" not in normalized_text and "help" not in normalized_text:
+        await ctx.reply('Say "help" for message history commands.')
+        return
+
+    if "help" in normalized_text:
+        await ctx.reply(
+            "**Message History Test Bot**\n\n"
+            "**Commands:**\n\n"
+            "- `history` - current context history with `ctx.get_history(5)`\n\n"
+            "- `history ctx <n>` - current context history with a custom count\n\n"
+            "- `history chat <chat-id> [n]` - app-level chat history\n\n"
+            "- `history channel <team-aad-group-id> <channel-id> [n]` - app-level channel history\n\n"
+            "- `history thread <team-aad-group-id> <channel-id> <thread-id> [n]` - app-level channel thread replies"
+        )
+        return
+
+    try:
+        history_index = next(index for index, part in enumerate(parts) if part.lower() == "history")
+        args = parts[history_index + 1 :]
+        scope = args[0].lower() if args else "ctx"
+
+        if scope == "ctx":
+            count = _parse_count(args[1] if len(args) > 1 else None)
+            await _send_history(ctx, "Current context history", await ctx.get_history(count))
+            return
+
+        if scope == "chat" and len(args) >= 2:
+            count = _parse_count(args[2] if len(args) > 2 else None)
+            messages = await app.get_history(n=count, chat_id=args[1])
+            await _send_history(ctx, f"Chat history for {args[1]}", messages)
+            return
+
+        if scope == "channel" and len(args) >= 3:
+            count = _parse_count(args[3] if len(args) > 3 else None)
+            messages = await app.get_history(n=count, team_aad_group_id=args[1], channel_id=args[2])
+            await _send_history(ctx, f"Channel history for {args[2]}", messages)
+            return
+
+        if scope == "thread" and len(args) >= 4:
+            count = _parse_count(args[4] if len(args) > 4 else None)
+            messages = await app.get_history(
+                n=count,
+                team_aad_group_id=args[1],
+                channel_id=args[2],
+                thread_id=args[3],
+            )
+            await _send_history(ctx, f"Thread history for {args[3]}", messages)
+            return
+
+        await ctx.reply('Invalid command. Say "help" for message history commands.')
+
+    except Exception as e:
+        logger.exception("Failed to get message history")
+        await ctx.reply(f"Failed to get message history: {e}\n\n{_history_error_guidance(e)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(app.start())

--- a/examples/history/src/main.py
+++ b/examples/history/src/main.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
-from microsoft_teams.apps import ActivityContext, App
+from microsoft_teams.apps import ActivityContext, App, ChannelHistorySource, GroupChatHistorySource, MessageHistory
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -78,8 +78,8 @@ def _format_history(title: str, messages: list[Any]) -> str:
     return "\n\n".join(lines)
 
 
-async def _send_history(ctx: ActivityContext[MessageActivity], title: str, messages: list[Any]) -> None:
-    await ctx.reply(_format_history(title, messages))
+async def _send_history(ctx: ActivityContext[MessageActivity], title: str, history: MessageHistory) -> None:
+    await ctx.reply(_format_history(title, history.messages))
 
 
 def _history_error_guidance(error: Exception) -> str:
@@ -112,7 +112,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
             "**Commands:**\n\n"
             "- `history` - current context history with `ctx.get_history(5)`\n\n"
             "- `history ctx <n>` - current context history with a custom count\n\n"
-            "- `history chat <chat-id> [n]` - app-level chat history\n\n"
+            "- `history chat <chat-id> [n]` - app-level group chat history from a `HistorySource`\n\n"
             "- `history channel <team-aad-group-id> <channel-id> [n]` - app-level channel history\n\n"
             "- `history thread <team-aad-group-id> <channel-id> <thread-id> [n]` - app-level channel thread replies"
         )
@@ -130,25 +130,26 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
 
         if scope == "chat" and len(args) >= 2:
             count = _parse_count(args[2] if len(args) > 2 else None)
-            messages = await app.get_history(n=count, chat_id=args[1])
-            await _send_history(ctx, f"Chat history for {args[1]}", messages)
+            history = await app.get_history(n=count, source=GroupChatHistorySource(chat_id=args[1]))
+            await _send_history(ctx, f"Chat history for {args[1]}", history)
             return
 
         if scope == "channel" and len(args) >= 3:
             count = _parse_count(args[3] if len(args) > 3 else None)
-            messages = await app.get_history(n=count, team_aad_group_id=args[1], channel_id=args[2])
-            await _send_history(ctx, f"Channel history for {args[2]}", messages)
+            history = await app.get_history(
+                n=count,
+                source=ChannelHistorySource(team_aad_group_id=args[1], channel_id=args[2]),
+            )
+            await _send_history(ctx, f"Channel history for {args[2]}", history)
             return
 
         if scope == "thread" and len(args) >= 4:
             count = _parse_count(args[4] if len(args) > 4 else None)
-            messages = await app.get_history(
+            history = await app.get_history(
                 n=count,
-                team_aad_group_id=args[1],
-                channel_id=args[2],
-                thread_id=args[3],
+                source=ChannelHistorySource(team_aad_group_id=args[1], channel_id=args[2], thread_id=args[3]),
             )
-            await _send_history(ctx, f"Thread history for {args[3]}", messages)
+            await _send_history(ctx, f"Thread history for {args[3]}", history)
             return
 
         await ctx.reply('Invalid command. Say "help" for message history commands.')

--- a/examples/threading/src/main.py
+++ b/examples/threading/src/main.py
@@ -8,7 +8,7 @@ import logging
 
 from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
-from microsoft_teams.apps import ActivityContext, App, to_threaded_conversation_id
+from microsoft_teams.apps import ActivityContext, App, get_thread_message_id, to_threaded_conversation_id
 
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
@@ -29,8 +29,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
     # When inside a thread, conversation_id contains ;messageid=<rootId>.
     # Extract the root ID for threading; for top-level messages, use activity.id.
-    parts = conversation_id.split(";messageid=")
-    thread_root_id = parts[1] if len(parts) > 1 else message_id
+    thread_root_id = get_thread_message_id(conversation_id) or message_id
 
     # ============================================
     # context.reply() — reactive threaded reply

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -10,6 +10,13 @@ from .app import App
 from .auth import *  # noqa: F403
 from .contexts import *  # noqa: F403
 from .events import *  # noqa: F401, F403
+from .history import (
+    ChannelHistorySource,
+    GroupChatHistorySource,
+    HistorySource,
+    MessageHistory,
+    OneOnOneHistorySource,
+)
 from .http import FastAPIAdapter, HttpServer, HttpServerAdapter
 from .http_stream import HttpStream
 from .options import AppOptions
@@ -26,7 +33,12 @@ __all__: list[str] = [
     "HttpServer",
     "HttpServerAdapter",
     "FastAPIAdapter",
+    "ChannelHistorySource",
+    "GroupChatHistorySource",
+    "HistorySource",
     "HttpStream",
+    "MessageHistory",
+    "OneOnOneHistorySource",
     "ActivityContext",
     "get_base_conversation_id",
     "get_thread_message_id",

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -15,7 +15,7 @@ from .http_stream import HttpStream
 from .options import AppOptions
 from .plugins import *  # noqa: F401, F403
 from .routing import ActivityContext
-from .utils.thread import to_threaded_conversation_id
+from .utils.thread import get_base_conversation_id, get_thread_message_id, to_threaded_conversation_id
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -28,6 +28,8 @@ __all__: list[str] = [
     "FastAPIAdapter",
     "HttpStream",
     "ActivityContext",
+    "get_base_conversation_id",
+    "get_thread_message_id",
     "to_threaded_conversation_id",
 ]
 __all__.extend(auth.__all__)

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -52,7 +52,7 @@ from .events import (
     get_event_type_from_signature,
     is_registered_event,
 )
-from .history import ChatMessage, get_graph_history
+from .history import HistorySource, MessageHistory, get_graph_history
 from .http import FastAPIAdapter, HttpServer
 from .http.adapter import HttpRequest, HttpResponse
 from .options import AppOptions, InternalAppOptions
@@ -620,24 +620,17 @@ class App(ActivityHandlerMixin):
         self,
         *,
         n: int,
-        chat_id: Optional[str] = None,
-        channel_id: Optional[str] = None,
-        thread_id: Optional[str] = None,
-        team_aad_group_id: Optional[str] = None,
+        source: HistorySource,
         tenant_id: Optional[str] = None,
-    ) -> List[ChatMessage]:
+    ) -> MessageHistory:
         """
         Get Teams message history using Microsoft Graph app credentials.
 
-        For chats, pass ``chat_id``. For channels, pass both
-        ``team_aad_group_id`` and ``channel_id``. When ``thread_id`` is supplied,
-        the returned history is the replies for that root message.
+        Pass the ``source`` returned by ``ctx.get_history`` or construct one of
+        the exported ``HistorySource`` model types directly.
         """
         return await get_graph_history(
             self.get_app_graph(tenant_id=tenant_id),
             n,
-            chat_id=chat_id,
-            channel_id=channel_id,
-            thread_id=thread_id,
-            team_aad_group_id=team_aad_group_id,
+            source=source,
         )

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -52,6 +52,7 @@ from .events import (
     get_event_type_from_signature,
     is_registered_event,
 )
+from .history import ChatMessage, get_graph_history
 from .http import FastAPIAdapter, HttpServer
 from .http.adapter import HttpRequest, HttpResponse
 from .options import AppOptions, InternalAppOptions
@@ -614,3 +615,29 @@ class App(ActivityHandlerMixin):
 
         """
         return create_graph_client(lambda: self._get_graph_token(tenant_id), cloud=self.cloud)
+
+    async def get_history(
+        self,
+        *,
+        n: int,
+        chat_id: Optional[str] = None,
+        channel_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        team_aad_group_id: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+    ) -> List[ChatMessage]:
+        """
+        Get Teams message history using Microsoft Graph app credentials.
+
+        For chats, pass ``chat_id``. For channels, pass both
+        ``team_aad_group_id`` and ``channel_id``. When ``thread_id`` is supplied,
+        the returned history is the replies for that root message.
+        """
+        return await get_graph_history(
+            self.get_app_graph(tenant_id=tenant_id),
+            n,
+            chat_id=chat_id,
+            channel_id=channel_id,
+            thread_id=thread_id,
+            team_aad_group_id=team_aad_group_id,
+        )

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -10,6 +10,7 @@ from microsoft_teams.api import CustomBaseModel
 from pydantic import Field
 
 _GRAPH_PAGE_SIZE_LIMIT = 50
+_CHAT_HISTORY_ORDER_BY = ["createdDateTime desc"]
 
 if TYPE_CHECKING:
     from msgraph.generated.models.chat_message import ChatMessage  # type: ignore[reportMissingTypeStubs]
@@ -61,17 +62,17 @@ def _validate_history_count(n: object) -> None:
         raise ValueError("n must be greater than 0")
 
 
-def _get_query_parameters(messages_builder: Any, n: int) -> Any:
+def _get_query_parameters(messages_builder: Any, n: int, *, orderby: list[str] | None = None) -> Any:
     builder_type = cast(type[Any], type(messages_builder))
     for name in ("MessagesRequestBuilderGetQueryParameters", "RepliesRequestBuilderGetQueryParameters"):
         query_parameters_type = getattr(builder_type, name, None)
         if query_parameters_type is not None:
-            return query_parameters_type(top=n)
+            return query_parameters_type(top=n, orderby=orderby)
 
     raise TypeError("messages_builder does not support Graph history query parameters")
 
 
-def _get_request_configuration(messages_builder: Any, n: int) -> Any:
+def _get_request_configuration(messages_builder: Any, n: int, *, orderby: list[str] | None = None) -> Any:
     try:
         from kiota_abstractions.base_request_configuration import RequestConfiguration
     except ImportError as e:
@@ -79,12 +80,18 @@ def _get_request_configuration(messages_builder: Any, n: int) -> Any:
             "Graph functionality not available. Install with 'pip install microsoft-teams-apps[graph]'"
         ) from e
 
-    return RequestConfiguration(query_parameters=_get_query_parameters(messages_builder, n))
+    return RequestConfiguration(query_parameters=_get_query_parameters(messages_builder, n, orderby=orderby))
 
 
 def _get_error_mapping() -> dict[str, Any]:
     ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
     return {"4XX": ODataError, "5XX": ODataError}
+
+
+def _last_n_messages(messages: list[Any], n: int) -> list[Any]:
+    if all(getattr(message, "created_date_time", None) is not None for message in messages):
+        messages = sorted(messages, key=lambda message: message.created_date_time)
+    return messages[-n:]
 
 
 async def get_graph_history(
@@ -109,11 +116,15 @@ async def get_graph_history(
         messages_builder = channel_builder.messages
         if source.thread_id:
             messages_builder = messages_builder.by_chat_message_id(source.thread_id).replies
+        orderby = None
     else:
         messages_builder = graph.chats.by_chat_id(source.chat_id).messages
+        orderby = _CHAT_HISTORY_ORDER_BY
 
     messages: list[ChatMessage] = []
-    response = await messages_builder.get(_get_request_configuration(messages_builder, min(n, _GRAPH_PAGE_SIZE_LIMIT)))
+    collect_all = isinstance(source, ChannelHistorySource) and source.thread_id is not None
+    page_size = _GRAPH_PAGE_SIZE_LIMIT if collect_all else min(n, _GRAPH_PAGE_SIZE_LIMIT)
+    response = await messages_builder.get(_get_request_configuration(messages_builder, page_size, orderby=orderby))
     if response is None or response.value is None:
         return MessageHistory(messages=[], source=source)
 
@@ -126,9 +137,11 @@ async def get_graph_history(
 
     def collect(message: ChatMessage) -> bool:
         messages.append(message)
-        return len(messages) < n
+        return collect_all or len(messages) < n
 
     request_adapter: Any = graph.request_adapter  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     iterator: Any = PageIterator(response, request_adapter, error_mapping=_get_error_mapping())
     await iterator.iterate(collect)
+    if collect_all:
+        messages = _last_n_messages(messages, n)
     return MessageHistory(messages=messages, source=source)

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -3,7 +3,10 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from importlib import import_module
 from typing import TYPE_CHECKING, Any, List, Optional, cast
+
+_GRAPH_PAGE_SIZE_LIMIT = 50
 
 if TYPE_CHECKING:
     from msgraph.generated.models.chat_message import ChatMessage  # type: ignore[reportMissingTypeStubs]
@@ -77,8 +80,42 @@ async def get_graph_history(
     if thread_id:
         messages_builder = messages_builder.by_chat_message_id(thread_id).replies
 
-    response = await messages_builder.get(_get_request_configuration(messages_builder, n))
-    if response is None or response.value is None:
-        return []
+    messages: list[ChatMessage] = []
+    response = await messages_builder.get(_get_request_configuration(messages_builder, min(n, _GRAPH_PAGE_SIZE_LIMIT)))
 
-    return list(response.value)
+    while response is not None:
+        if response.value:
+            messages.extend(response.value[: n - len(messages)])
+
+        if len(messages) >= n:
+            break
+
+        next_link = getattr(response, "odata_next_link", None)
+        if not next_link:
+            break
+
+        response = await _get_next_page(messages_builder, next_link)
+
+    return messages
+
+
+async def _get_next_page(messages_builder: Any, next_link: str) -> Any:
+    try:
+        from kiota_abstractions.method import Method
+        from kiota_abstractions.request_information import RequestInformation
+        from msgraph.generated.models.chat_message_collection_response import (  # type: ignore[reportMissingTypeStubs]
+            ChatMessageCollectionResponse,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "Graph functionality not available. Install with 'pip install microsoft-teams-apps[graph]'"
+        ) from e
+
+    ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
+    request_info = RequestInformation(method=Method.GET)
+    request_info.path_parameters[RequestInformation.RAW_URL_KEY] = next_link
+    return await messages_builder.request_adapter.send_async(
+        request_info,
+        ChatMessageCollectionResponse,
+        {"XXX": ODataError},
+    )

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -117,5 +117,5 @@ async def _get_next_page(messages_builder: Any, next_link: str) -> Any:
     return await messages_builder.request_adapter.send_async(
         request_info,
         ChatMessageCollectionResponse,
-        {"XXX": ODataError},
+        {"4XX": ODataError, "5XX": ODataError},
     )

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -10,13 +10,14 @@ _GRAPH_PAGE_SIZE_LIMIT = 50
 
 if TYPE_CHECKING:
     from msgraph.generated.models.chat_message import ChatMessage  # type: ignore[reportMissingTypeStubs]
-    from msgraph.graph_service_client import GraphServiceClient
 else:
     ChatMessage = Any
 
 
-class _NextPageRequestAdapter(Protocol):
-    async def send_async(self, request_info: Any, parsable_factory: Any, error_map: dict[str, Any]) -> Any: ...
+class _GraphClient(Protocol):
+    request_adapter: Any
+    chats: Any
+    teams: Any
 
 
 def _validate_history_count(n: object) -> None:
@@ -48,7 +49,7 @@ def _get_request_configuration(messages_builder: Any, n: int) -> Any:
 
 
 async def get_graph_history(
-    graph: "GraphServiceClient",
+    graph: _GraphClient,
     n: int,
     *,
     chat_id: Optional[str] = None,
@@ -98,15 +99,12 @@ async def get_graph_history(
         if not next_link:
             break
 
-        response = await _get_next_page(
-            graph.request_adapter,  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
-            next_link,
-        )
+        response = await _get_next_page(graph.request_adapter, next_link)
 
     return messages
 
 
-async def _get_next_page(request_adapter: _NextPageRequestAdapter, next_link: str) -> Any:
+async def _get_next_page(request_adapter: Any, next_link: str) -> Any:
     try:
         from kiota_abstractions.method import Method
         from kiota_abstractions.request_information import RequestInformation

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -43,6 +43,11 @@ def _get_request_configuration(messages_builder: Any, n: int) -> Any:
     return RequestConfiguration(query_parameters=_get_query_parameters(messages_builder, n))
 
 
+def _get_error_mapping() -> dict[str, Any]:
+    ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
+    return {"4XX": ODataError, "5XX": ODataError}
+
+
 async def get_graph_history(
     graph: "GraphServiceClient",
     n: int,
@@ -82,40 +87,21 @@ async def get_graph_history(
 
     messages: list[ChatMessage] = []
     response = await messages_builder.get(_get_request_configuration(messages_builder, min(n, _GRAPH_PAGE_SIZE_LIMIT)))
+    if response is None or response.value is None:
+        return []
 
-    while response is not None:
-        if response.value:
-            messages.extend(response.value[: n - len(messages)])
-
-        if len(messages) >= n:
-            break
-
-        next_link = getattr(response, "odata_next_link", None)
-        if not next_link:
-            break
-
-        response = await _get_next_page(graph, next_link)
-
-    return messages
-
-
-async def _get_next_page(graph: "GraphServiceClient", next_link: str) -> Any:
     try:
-        from kiota_abstractions.method import Method
-        from kiota_abstractions.request_information import RequestInformation
-        from msgraph.generated.models.chat_message_collection_response import (  # type: ignore[reportMissingTypeStubs]
-            ChatMessageCollectionResponse,
-        )
+        from msgraph_core.tasks.page_iterator import PageIterator  # type: ignore[reportMissingTypeStubs]
     except ImportError as e:
         raise ImportError(
             "Graph functionality not available. Install with 'pip install microsoft-teams-apps[graph]'"
         ) from e
 
-    ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
-    request_info = RequestInformation(method=Method.GET)
-    request_info.path_parameters[RequestInformation.RAW_URL_KEY] = next_link
-    return await graph.request_adapter.send_async(  # pyright: ignore[reportUnknownMemberType]
-        request_info,
-        ChatMessageCollectionResponse,
-        {"4XX": ODataError, "5XX": ODataError},
-    )
+    def collect(message: ChatMessage) -> bool:
+        messages.append(message)
+        return len(messages) < n
+
+    request_adapter: Any = graph.request_adapter  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    iterator: Any = PageIterator(response, request_adapter, error_mapping=_get_error_mapping())
+    await iterator.iterate(collect)
+    return messages

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -114,8 +114,7 @@ async def _get_next_page(graph: "GraphServiceClient", next_link: str) -> Any:
     ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
     request_info = RequestInformation(method=Method.GET)
     request_info.path_parameters[RequestInformation.RAW_URL_KEY] = next_link
-    request_adapter: Any = object.__getattribute__(graph, "request_adapter")
-    return await request_adapter.send_async(
+    return await graph.request_adapter.send_async(  # pyright: ignore[reportUnknownMemberType]
         request_info,
         ChatMessageCollectionResponse,
         {"4XX": ODataError, "5XX": ODataError},

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -1,0 +1,84 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import TYPE_CHECKING, Any, List, Optional, cast
+
+if TYPE_CHECKING:
+    from msgraph.generated.models.chat_message import ChatMessage  # type: ignore[reportMissingTypeStubs]
+    from msgraph.graph_service_client import GraphServiceClient
+else:
+    ChatMessage = Any
+
+
+def _validate_history_count(n: object) -> None:
+    if type(n) is not int:
+        raise TypeError("n must be an integer")
+    if n < 1:
+        raise ValueError("n must be greater than 0")
+
+
+def _get_query_parameters(messages_builder: Any, n: int) -> Any:
+    builder_type = cast(type[Any], type(messages_builder))
+    for name in ("MessagesRequestBuilderGetQueryParameters", "RepliesRequestBuilderGetQueryParameters"):
+        query_parameters_type = getattr(builder_type, name, None)
+        if query_parameters_type is not None:
+            return query_parameters_type(top=n)
+
+    raise TypeError("messages_builder does not support Graph history query parameters")
+
+
+def _get_request_configuration(messages_builder: Any, n: int) -> Any:
+    try:
+        from kiota_abstractions.base_request_configuration import RequestConfiguration
+    except ImportError as e:
+        raise ImportError(
+            "Graph functionality not available. Install with 'pip install microsoft-teams-apps[graph]'"
+        ) from e
+
+    return RequestConfiguration(query_parameters=_get_query_parameters(messages_builder, n))
+
+
+async def get_graph_history(
+    graph: "GraphServiceClient",
+    n: int,
+    *,
+    chat_id: Optional[str] = None,
+    channel_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    team_aad_group_id: Optional[str] = None,
+) -> List[ChatMessage]:
+    """
+    Retrieve Teams message history with Microsoft Graph.
+
+    Provide either ``chat_id`` for ``/chats/{chat-id}/messages`` or both
+    ``team_aad_group_id`` and ``channel_id`` for
+    ``/teams/{team-aad-group-id}/channels/{channel-id}/messages``. When
+    ``thread_id`` is supplied, replies for that root message are returned.
+    """
+    _validate_history_count(n)
+
+    has_chat = bool(chat_id)
+    has_channel = bool(team_aad_group_id or channel_id)
+
+    if has_chat == has_channel:
+        raise ValueError("provide either chat_id or both team_aad_group_id and channel_id")
+
+    if has_channel:
+        if not team_aad_group_id or not channel_id:
+            raise ValueError("team_aad_group_id and channel_id are required for channel history")
+        messages_builder = graph.teams.by_team_id(team_aad_group_id).channels.by_channel_id(channel_id).messages
+    else:
+        if not chat_id:
+            raise ValueError("chat_id is required for chat history")
+        messages_builder = graph.chats.by_chat_id(chat_id).messages
+
+    if thread_id:
+        messages_builder = messages_builder.by_chat_message_id(thread_id).replies
+
+    response = await messages_builder.get(_get_request_configuration(messages_builder, n))
+    if response is None or response.value is None:
+        return []
+
+    return list(response.value)

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -4,7 +4,10 @@ Licensed under the MIT License.
 """
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, List, Optional, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
+
+from microsoft_teams.api import CustomBaseModel
+from pydantic import Field
 
 _GRAPH_PAGE_SIZE_LIMIT = 50
 
@@ -13,6 +16,42 @@ if TYPE_CHECKING:
     from msgraph.graph_service_client import GraphServiceClient
 else:
     ChatMessage = Any
+
+
+class OneOnOneHistorySource(CustomBaseModel):
+    """Message history source for a 1:1 chat."""
+
+    type: Literal["oneOnOne"] = "oneOnOne"
+    chat_id: str
+
+
+class GroupChatHistorySource(CustomBaseModel):
+    """Message history source for a group chat."""
+
+    type: Literal["groupChat"] = "groupChat"
+    chat_id: str
+
+
+class ChannelHistorySource(CustomBaseModel):
+    """Message history source for a Teams channel or channel thread."""
+
+    type: Literal["channel"] = "channel"
+    team_aad_group_id: str
+    channel_id: str
+    thread_id: str | None = None
+
+
+HistorySource = Annotated[
+    OneOnOneHistorySource | GroupChatHistorySource | ChannelHistorySource,
+    Field(discriminator="type"),
+]
+
+
+class MessageHistory(CustomBaseModel):
+    """Messages returned from Graph plus the source used to retrieve them."""
+
+    messages: list[ChatMessage]
+    source: HistorySource
 
 
 def _validate_history_count(n: object) -> None:
@@ -52,43 +91,31 @@ async def get_graph_history(
     graph: "GraphServiceClient",
     n: int,
     *,
-    chat_id: Optional[str] = None,
-    channel_id: Optional[str] = None,
-    thread_id: Optional[str] = None,
-    team_aad_group_id: Optional[str] = None,
-) -> List[ChatMessage]:
+    source: HistorySource,
+) -> MessageHistory:
     """
     Retrieve Teams message history with Microsoft Graph.
 
-    Provide either ``chat_id`` for ``/chats/{chat-id}/messages`` or both
-    ``team_aad_group_id`` and ``channel_id`` for
-    ``/teams/{team-aad-group-id}/channels/{channel-id}/messages``. When
-    ``thread_id`` is supplied, replies for that root message are returned.
+    The provided ``source`` selects either ``/chats/{chat-id}/messages`` or
+    ``/teams/{team-aad-group-id}/channels/{channel-id}/messages``. When a
+    channel source includes ``thread_id``, replies for that root message are
+    returned.
     """
     _validate_history_count(n)
 
-    has_chat = bool(chat_id)
-    has_channel = bool(team_aad_group_id or channel_id)
-
-    if has_chat == has_channel:
-        raise ValueError("provide either chat_id or both team_aad_group_id and channel_id")
-
-    if has_channel:
-        if not team_aad_group_id or not channel_id:
-            raise ValueError("team_aad_group_id and channel_id are required for channel history")
-        messages_builder = graph.teams.by_team_id(team_aad_group_id).channels.by_channel_id(channel_id).messages
+    if isinstance(source, ChannelHistorySource):
+        team_builder = graph.teams.by_team_id(source.team_aad_group_id)
+        channel_builder = team_builder.channels.by_channel_id(source.channel_id)
+        messages_builder = channel_builder.messages
+        if source.thread_id:
+            messages_builder = messages_builder.by_chat_message_id(source.thread_id).replies
     else:
-        if not chat_id:
-            raise ValueError("chat_id is required for chat history")
-        messages_builder = graph.chats.by_chat_id(chat_id).messages
-
-    if thread_id:
-        messages_builder = messages_builder.by_chat_message_id(thread_id).replies
+        messages_builder = graph.chats.by_chat_id(source.chat_id).messages
 
     messages: list[ChatMessage] = []
     response = await messages_builder.get(_get_request_configuration(messages_builder, min(n, _GRAPH_PAGE_SIZE_LIMIT)))
     if response is None or response.value is None:
-        return []
+        return MessageHistory(messages=[], source=source)
 
     try:
         from msgraph_core.tasks.page_iterator import PageIterator  # type: ignore[reportMissingTypeStubs]
@@ -104,4 +131,4 @@ async def get_graph_history(
     request_adapter: Any = graph.request_adapter  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     iterator: Any = PageIterator(response, request_adapter, error_mapping=_get_error_mapping())
     await iterator.iterate(collect)
-    return messages
+    return MessageHistory(messages=messages, source=source)

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, List, Optional, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Protocol, cast
 
 _GRAPH_PAGE_SIZE_LIMIT = 50
 
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
     from msgraph.graph_service_client import GraphServiceClient
 else:
     ChatMessage = Any
+
+
+class _NextPageRequestAdapter(Protocol):
+    async def send_async(self, request_info: Any, parsable_factory: Any, error_map: dict[str, Any]) -> Any: ...
 
 
 def _validate_history_count(n: object) -> None:
@@ -94,12 +98,15 @@ async def get_graph_history(
         if not next_link:
             break
 
-        response = await _get_next_page(graph, next_link)
+        response = await _get_next_page(
+            graph.request_adapter,  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType]
+            next_link,
+        )
 
     return messages
 
 
-async def _get_next_page(graph: "GraphServiceClient", next_link: str) -> Any:
+async def _get_next_page(request_adapter: _NextPageRequestAdapter, next_link: str) -> Any:
     try:
         from kiota_abstractions.method import Method
         from kiota_abstractions.request_information import RequestInformation
@@ -114,7 +121,6 @@ async def _get_next_page(graph: "GraphServiceClient", next_link: str) -> Any:
     ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
     request_info = RequestInformation(method=Method.GET)
     request_info.path_parameters[RequestInformation.RAW_URL_KEY] = next_link
-    request_adapter = cast(Any, graph).request_adapter
     return await request_adapter.send_async(
         request_info,
         ChatMessageCollectionResponse,

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -4,20 +4,15 @@ Licensed under the MIT License.
 """
 
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, List, Optional, Protocol, cast
+from typing import TYPE_CHECKING, Any, List, Optional, cast
 
 _GRAPH_PAGE_SIZE_LIMIT = 50
 
 if TYPE_CHECKING:
     from msgraph.generated.models.chat_message import ChatMessage  # type: ignore[reportMissingTypeStubs]
+    from msgraph.graph_service_client import GraphServiceClient
 else:
     ChatMessage = Any
-
-
-class _GraphClient(Protocol):
-    request_adapter: Any
-    chats: Any
-    teams: Any
 
 
 def _validate_history_count(n: object) -> None:
@@ -49,7 +44,7 @@ def _get_request_configuration(messages_builder: Any, n: int) -> Any:
 
 
 async def get_graph_history(
-    graph: _GraphClient,
+    graph: "GraphServiceClient",
     n: int,
     *,
     chat_id: Optional[str] = None,
@@ -99,12 +94,12 @@ async def get_graph_history(
         if not next_link:
             break
 
-        response = await _get_next_page(graph.request_adapter, next_link)
+        response = await _get_next_page(graph, next_link)
 
     return messages
 
 
-async def _get_next_page(request_adapter: Any, next_link: str) -> Any:
+async def _get_next_page(graph: "GraphServiceClient", next_link: str) -> Any:
     try:
         from kiota_abstractions.method import Method
         from kiota_abstractions.request_information import RequestInformation
@@ -119,6 +114,7 @@ async def _get_next_page(request_adapter: Any, next_link: str) -> Any:
     ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
     request_info = RequestInformation(method=Method.GET)
     request_info.path_parameters[RequestInformation.RAW_URL_KEY] = next_link
+    request_adapter: Any = object.__getattribute__(graph, "request_adapter")
     return await request_adapter.send_async(
         request_info,
         ChatMessageCollectionResponse,

--- a/packages/apps/src/microsoft_teams/apps/history.py
+++ b/packages/apps/src/microsoft_teams/apps/history.py
@@ -94,12 +94,12 @@ async def get_graph_history(
         if not next_link:
             break
 
-        response = await _get_next_page(messages_builder, next_link)
+        response = await _get_next_page(graph, next_link)
 
     return messages
 
 
-async def _get_next_page(messages_builder: Any, next_link: str) -> Any:
+async def _get_next_page(graph: "GraphServiceClient", next_link: str) -> Any:
     try:
         from kiota_abstractions.method import Method
         from kiota_abstractions.request_information import RequestInformation
@@ -114,7 +114,8 @@ async def _get_next_page(messages_builder: Any, next_link: str) -> Any:
     ODataError = import_module("msgraph.generated.models.o_data_errors.o_data_error").ODataError
     request_info = RequestInformation(method=Method.GET)
     request_info.path_parameters[RequestInformation.RAW_URL_KEY] = next_link
-    return await messages_builder.request_adapter.send_async(
+    request_adapter = cast(Any, graph).request_adapter
+    return await request_adapter.send_async(
         request_info,
         ChatMessageCollectionResponse,
         {"4XX": ODataError, "5XX": ODataError},

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -43,7 +43,7 @@ from microsoft_teams.common.http.client_token import Token
 
 from ..activity_sender import ActivitySender
 from ..history import ChatMessage, get_graph_history
-from ..utils import create_graph_client
+from ..utils import create_graph_client, get_base_conversation_id, get_thread_message_id
 
 if TYPE_CHECKING:
     from msgraph.graph_service_client import GraphServiceClient
@@ -72,15 +72,6 @@ class SignInOptions:
 
 
 DEFAULT_SIGNIN_OPTIONS = SignInOptions()
-
-
-def _thread_id_from_conversation_id(conversation_id: str) -> Optional[str]:
-    _, separator, thread_id = conversation_id.partition(";messageid=")
-    return thread_id if separator and thread_id else None
-
-
-def _base_conversation_id(conversation_id: str) -> str:
-    return conversation_id.split(";messageid=", 1)[0]
 
 
 class ActivityContext(Generic[T]):
@@ -246,12 +237,12 @@ class ActivityContext(Generic[T]):
             team_aad_group_id = self.activity.team.aad_group_id
         channel_id = self.activity.channel.id if self.activity.channel else None
         conversation_id = self.activity.conversation.id
-        resolved_thread_id = thread_id or self.activity.reply_to_id or _thread_id_from_conversation_id(conversation_id)
+        resolved_thread_id = thread_id or self.activity.reply_to_id or get_thread_message_id(conversation_id)
 
         return await get_graph_history(
             self.app_graph,
             n,
-            chat_id=None if channel_id else _base_conversation_id(conversation_id),
+            chat_id=None if channel_id else get_base_conversation_id(conversation_id),
             channel_id=channel_id,
             thread_id=resolved_thread_id,
             team_aad_group_id=team_aad_group_id,

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -8,7 +8,7 @@ import json
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, Optional, TypeGuard, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, List, Optional, TypeGuard, TypeVar
 
 from microsoft_teams.api import (
     Account,
@@ -42,6 +42,7 @@ from microsoft_teams.common.experimental import ExperimentalWarning
 from microsoft_teams.common.http.client_token import Token
 
 from ..activity_sender import ActivitySender
+from ..history import ChatMessage, get_graph_history
 from ..utils import create_graph_client
 
 if TYPE_CHECKING:
@@ -71,6 +72,15 @@ class SignInOptions:
 
 
 DEFAULT_SIGNIN_OPTIONS = SignInOptions()
+
+
+def _thread_id_from_conversation_id(conversation_id: str) -> Optional[str]:
+    _, separator, thread_id = conversation_id.partition(";messageid=")
+    return thread_id if separator and thread_id else None
+
+
+def _base_conversation_id(conversation_id: str) -> str:
+    return conversation_id.split(";messageid=", 1)[0]
 
 
 class ActivityContext(Generic[T]):
@@ -222,6 +232,30 @@ class ActivityContext(Generic[T]):
         if isinstance(activity, MessageActivityInput):
             activity.prepend_quote(message_id)
         return await self.send(activity)
+
+    async def get_history(self, n: int, *, thread_id: Optional[str] = None) -> List[ChatMessage]:
+        """
+        Get message history for the current Teams conversation using Microsoft Graph.
+
+        In chats, this reads from the current chat. In channels, this reads from the
+        current team/channel and defaults to the current thread when the incoming
+        activity is a thread reply.
+        """
+        team_aad_group_id = None
+        if self.activity.team:
+            team_aad_group_id = self.activity.team.aad_group_id
+        channel_id = self.activity.channel.id if self.activity.channel else None
+        conversation_id = self.activity.conversation.id
+        resolved_thread_id = thread_id or self.activity.reply_to_id or _thread_id_from_conversation_id(conversation_id)
+
+        return await get_graph_history(
+            self.app_graph,
+            n,
+            chat_id=None if channel_id else _base_conversation_id(conversation_id),
+            channel_id=channel_id,
+            thread_id=resolved_thread_id,
+            team_aad_group_id=team_aad_group_id,
+        )
 
     async def next(self) -> None:
         """Call the next middleware in the chain."""

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -8,7 +8,7 @@ import json
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, List, Optional, TypeGuard, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, Optional, TypeGuard, TypeVar
 
 from microsoft_teams.api import (
     Account,
@@ -42,7 +42,13 @@ from microsoft_teams.common.experimental import ExperimentalWarning
 from microsoft_teams.common.http.client_token import Token
 
 from ..activity_sender import ActivitySender
-from ..history import ChatMessage, get_graph_history
+from ..history import (
+    ChannelHistorySource,
+    GroupChatHistorySource,
+    MessageHistory,
+    OneOnOneHistorySource,
+    get_graph_history,
+)
 from ..utils import create_graph_client, get_base_conversation_id, get_thread_message_id
 
 if TYPE_CHECKING:
@@ -224,7 +230,7 @@ class ActivityContext(Generic[T]):
             activity.prepend_quote(message_id)
         return await self.send(activity)
 
-    async def get_history(self, n: int, *, thread_id: Optional[str] = None) -> List[ChatMessage]:
+    async def get_history(self, n: int, *, thread_id: Optional[str] = None) -> MessageHistory:
         """
         Get message history for the current Teams conversation using Microsoft Graph.
 
@@ -239,13 +245,23 @@ class ActivityContext(Generic[T]):
         conversation_id = self.activity.conversation.id
         resolved_thread_id = thread_id or self.activity.reply_to_id or get_thread_message_id(conversation_id)
 
+        if channel_id:
+            if not team_aad_group_id:
+                raise ValueError("team_aad_group_id and channel_id are required for channel history")
+            source = ChannelHistorySource(
+                team_aad_group_id=team_aad_group_id,
+                channel_id=channel_id,
+                thread_id=resolved_thread_id,
+            )
+        elif self.activity.conversation.conversation_type == "personal" or self.activity.conversation.is_group is False:
+            source = OneOnOneHistorySource(chat_id=get_base_conversation_id(conversation_id))
+        else:
+            source = GroupChatHistorySource(chat_id=get_base_conversation_id(conversation_id))
+
         return await get_graph_history(
             self.app_graph,
             n,
-            chat_id=None if channel_id else get_base_conversation_id(conversation_id),
-            channel_id=channel_id,
-            thread_id=resolved_thread_id,
-            team_aad_group_id=team_aad_group_id,
+            source=source,
         )
 
     async def next(self) -> None:

--- a/packages/apps/src/microsoft_teams/apps/utils/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/__init__.py
@@ -6,6 +6,14 @@ Licensed under the MIT License.
 from .activity_utils import extract_tenant_id
 from .graph import create_graph_client
 from .retry import RetryOptions, retry
-from .thread import to_threaded_conversation_id
+from .thread import get_base_conversation_id, get_thread_message_id, to_threaded_conversation_id
 
-__all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions", "to_threaded_conversation_id"]
+__all__ = [
+    "create_graph_client",
+    "extract_tenant_id",
+    "get_base_conversation_id",
+    "get_thread_message_id",
+    "retry",
+    "RetryOptions",
+    "to_threaded_conversation_id",
+]

--- a/packages/apps/src/microsoft_teams/apps/utils/thread.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/thread.py
@@ -3,6 +3,21 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from typing import Optional
+
+_THREAD_MESSAGE_ID_SEPARATOR = ";messageid="
+
+
+def get_base_conversation_id(conversation_id: str) -> str:
+    """Return the conversation ID without the APX thread message suffix."""
+    return conversation_id.split(_THREAD_MESSAGE_ID_SEPARATOR, 1)[0]
+
+
+def get_thread_message_id(conversation_id: str) -> Optional[str]:
+    """Extract the APX thread root message ID from a threaded conversation ID."""
+    _, separator, message_id = conversation_id.partition(_THREAD_MESSAGE_ID_SEPARATOR)
+    return message_id if separator and message_id else None
+
 
 def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
     """Construct a threaded conversation ID by appending `;messageid={message_id}`
@@ -23,5 +38,5 @@ def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
         raise ValueError(f'Invalid message_id "{message_id}": must be a non-zero numeric value')
 
     # Strip any existing ;messageid= suffix (mirrors APX's NormalizeConversationId)
-    base_id = conversation_id.split(";")[0]
+    base_id = get_base_conversation_id(conversation_id)
     return f"{base_id};messageid={message_id}"

--- a/packages/apps/tests/test_history.py
+++ b/packages/apps/tests/test_history.py
@@ -1,0 +1,270 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+# pyright: basic
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from microsoft_teams.api import (
+    Account,
+    ChannelData,
+    ChannelInfo,
+    ConversationAccount,
+    ConversationReference,
+    MessageActivity,
+)
+from microsoft_teams.api.auth.cloud_environment import PUBLIC
+from microsoft_teams.apps import App, AppOptions
+from microsoft_teams.apps.routing.activity_context import ActivityContext
+
+
+@dataclass
+class FakeQueryParameters:
+    top: int | None = None
+
+
+class FakeRepliesBuilder:
+    RepliesRequestBuilderGetQueryParameters = FakeQueryParameters
+
+    def __init__(self, value: list[Any]):
+        self.get = AsyncMock(return_value=SimpleNamespace(value=value))
+
+
+class FakeMessagesBuilder:
+    MessagesRequestBuilderGetQueryParameters = FakeQueryParameters
+
+    def __init__(self, value: list[Any], replies_value: list[Any] | None = None):
+        self.get = AsyncMock(return_value=SimpleNamespace(value=value))
+        self.replies = FakeRepliesBuilder(replies_value or [])
+        self.thread_id: str | None = None
+
+    def by_chat_message_id(self, thread_id: str) -> SimpleNamespace:
+        self.thread_id = thread_id
+        return SimpleNamespace(replies=self.replies)
+
+
+class FakeChatsBuilder:
+    def __init__(self, messages: FakeMessagesBuilder):
+        self.messages = messages
+        self.chat_id: str | None = None
+
+    def by_chat_id(self, chat_id: str) -> SimpleNamespace:
+        self.chat_id = chat_id
+        return SimpleNamespace(messages=self.messages)
+
+
+class FakeChannelsBuilder:
+    def __init__(self, messages: FakeMessagesBuilder):
+        self.messages = messages
+        self.channel_id: str | None = None
+
+    def by_channel_id(self, channel_id: str) -> SimpleNamespace:
+        self.channel_id = channel_id
+        return SimpleNamespace(messages=self.messages)
+
+
+class FakeTeamsBuilder:
+    def __init__(self, channels: FakeChannelsBuilder):
+        self.channels = channels
+        self.team_id: str | None = None
+
+    def by_team_id(self, team_id: str) -> SimpleNamespace:
+        self.team_id = team_id
+        return SimpleNamespace(channels=self.channels)
+
+
+class FakeGraph:
+    def __init__(self):
+        self.chat_messages = FakeMessagesBuilder(["chat-message"], ["chat-reply"])
+        self.channel_messages = FakeMessagesBuilder(["channel-message"], ["channel-reply"])
+        self.chats = FakeChatsBuilder(self.chat_messages)
+        self.channels = FakeChannelsBuilder(self.channel_messages)
+        self.teams = FakeTeamsBuilder(self.channels)
+
+
+@pytest.mark.asyncio
+async def test_app_get_history_reads_chat_messages_with_top() -> None:
+    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+    graph = FakeGraph()
+
+    with patch.object(app, "get_app_graph", return_value=graph):
+        result = await app.get_history(n=3, chat_id="chat-id")
+
+    assert result == ["chat-message"]
+    assert graph.chats.chat_id == "chat-id"
+    config = graph.chat_messages.get.call_args.args[0]
+    assert config.query_parameters.top == 3
+
+
+@pytest.mark.asyncio
+async def test_app_get_history_reads_channel_thread_replies() -> None:
+    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+    graph = FakeGraph()
+
+    with patch.object(app, "get_app_graph", return_value=graph):
+        result = await app.get_history(
+            n=5,
+            team_aad_group_id="team-aad-group-id",
+            channel_id="channel-id",
+            thread_id="root-message-id",
+        )
+
+    assert result == ["channel-reply"]
+    assert graph.teams.team_id == "team-aad-group-id"
+    assert graph.channels.channel_id == "channel-id"
+    assert graph.channel_messages.thread_id == "root-message-id"
+    config = graph.channel_messages.replies.get.call_args.args[0]
+    assert config.query_parameters.top == 5
+
+
+@pytest.mark.asyncio
+async def test_activity_context_get_history_uses_current_channel_thread() -> None:
+    graph = FakeGraph()
+    activity = MessageActivity(
+        id="reply-message-id",
+        text="hello",
+        from_=Account(id="user-id"),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(id="conversation-id", conversation_type="channel"),
+        reply_to_id="root-message-id",
+        channel_data=ChannelData(
+            team={"id": "team-thread-id", "aad_group_id": "team-group-id"},
+            channel=ChannelInfo(id="channel-id"),
+        ),
+    )
+    activity_sender = MagicMock()
+    activity_sender.create_stream = MagicMock(return_value=MagicMock())
+
+    ctx = ActivityContext(
+        activity=activity,
+        app_id="test-app-id",
+        storage=MagicMock(),
+        api=MagicMock(),
+        user_token=None,
+        conversation_ref=ConversationReference(
+            bot=Account(id="bot-id"),
+            conversation=ConversationAccount(id="conversation-id"),
+            channel_id="msteams",
+            service_url="https://service.example",
+        ),
+        is_signed_in=False,
+        connection_name="graph",
+        activity_sender=activity_sender,
+        app_token=MagicMock(),
+        cloud=PUBLIC,
+    )
+    ctx._app_graph = graph
+
+    result = await ctx.get_history(2)
+
+    assert result == ["channel-reply"]
+    assert graph.teams.team_id == "team-group-id"
+    assert graph.channels.channel_id == "channel-id"
+    assert graph.channel_messages.thread_id == "root-message-id"
+
+
+@pytest.mark.asyncio
+async def test_activity_context_get_history_reads_thread_from_conversation_id() -> None:
+    graph = FakeGraph()
+    activity = MessageActivity(
+        id="reply-message-id",
+        text="hello",
+        from_=Account(id="user-id"),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(
+            id="19:channel-id@thread.tacv2;messageid=root-message-id",
+            conversation_type="channel",
+        ),
+        channel_data=ChannelData(
+            team={"id": "team-thread-id", "aad_group_id": "team-group-id"},
+            channel=ChannelInfo(id="channel-id"),
+        ),
+    )
+    activity_sender = MagicMock()
+    activity_sender.create_stream = MagicMock(return_value=MagicMock())
+
+    ctx = ActivityContext(
+        activity=activity,
+        app_id="test-app-id",
+        storage=MagicMock(),
+        api=MagicMock(),
+        user_token=None,
+        conversation_ref=ConversationReference(
+            bot=Account(id="bot-id"),
+            conversation=ConversationAccount(id="19:channel-id@thread.tacv2;messageid=root-message-id"),
+            channel_id="msteams",
+            service_url="https://service.example",
+        ),
+        is_signed_in=False,
+        connection_name="graph",
+        activity_sender=activity_sender,
+        app_token=MagicMock(),
+        cloud=PUBLIC,
+    )
+    ctx._app_graph = graph
+
+    result = await ctx.get_history(2)
+
+    assert result == ["channel-reply"]
+    assert graph.channel_messages.thread_id == "root-message-id"
+
+
+@pytest.mark.asyncio
+async def test_get_history_validates_count() -> None:
+    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+
+    with pytest.raises(ValueError, match="n must be greater than 0"):
+        await app.get_history(n=0, chat_id="chat-id")
+
+
+@pytest.mark.asyncio
+async def test_get_history_requires_complete_channel_target() -> None:
+    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+
+    with pytest.raises(ValueError, match="team_aad_group_id and channel_id are required"):
+        await app.get_history(n=1, channel_id="channel-id")
+
+
+@pytest.mark.asyncio
+async def test_activity_context_channel_history_requires_team_aad_group_id() -> None:
+    activity = MessageActivity(
+        id="reply-message-id",
+        text="hello",
+        from_=Account(id="user-id"),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(id="conversation-id", conversation_type="channel"),
+        channel_data=ChannelData(
+            team={"id": "team-thread-id"},
+            channel=ChannelInfo(id="channel-id"),
+        ),
+    )
+    activity_sender = MagicMock()
+    activity_sender.create_stream = MagicMock(return_value=MagicMock())
+    ctx = ActivityContext(
+        activity=activity,
+        app_id="test-app-id",
+        storage=MagicMock(),
+        api=MagicMock(),
+        user_token=None,
+        conversation_ref=ConversationReference(
+            bot=Account(id="bot-id"),
+            conversation=ConversationAccount(id="conversation-id"),
+            channel_id="msteams",
+            service_url="https://service.example",
+        ),
+        is_signed_in=False,
+        connection_name="graph",
+        activity_sender=activity_sender,
+        app_token=MagicMock(),
+        cloud=PUBLIC,
+    )
+    ctx._app_graph = FakeGraph()
+
+    with pytest.raises(ValueError, match="team_aad_group_id and channel_id are required"):
+        await ctx.get_history(2)

--- a/packages/apps/tests/test_history.py
+++ b/packages/apps/tests/test_history.py
@@ -21,7 +21,15 @@ from microsoft_teams.api import (
 )
 from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.apps import App, AppOptions
+from microsoft_teams.apps.history import (
+    ChannelHistorySource,
+    GroupChatHistorySource,
+    HistorySource,
+    MessageHistory,
+    OneOnOneHistorySource,
+)
 from microsoft_teams.apps.routing.activity_context import ActivityContext
+from pydantic import TypeAdapter
 
 
 @dataclass
@@ -102,9 +110,10 @@ async def test_app_get_history_reads_chat_messages_with_top() -> None:
     graph = FakeGraph()
 
     with patch.object(app, "get_app_graph", return_value=graph):
-        result = await app.get_history(n=3, chat_id="chat-id")
+        result = await app.get_history(n=3, source=OneOnOneHistorySource(chat_id="chat-id"))
 
-    assert result == ["chat-message"]
+    assert result.messages == ["chat-message"]
+    assert result.source == OneOnOneHistorySource(chat_id="chat-id")
     assert graph.chats.chat_id == "chat-id"
     config = graph.chat_messages.get.call_args.args[0]
     assert config.query_parameters.top == 3
@@ -120,9 +129,9 @@ async def test_app_get_history_paginates_when_count_exceeds_graph_page_limit() -
     graph.request_adapter = FakeRequestAdapter([SimpleNamespace(value=list(range(50, 100)), odata_next_link=None)])
 
     with patch.object(app, "get_app_graph", return_value=graph):
-        result = await app.get_history(n=75, chat_id="chat-id")
+        result = await app.get_history(n=75, source=GroupChatHistorySource(chat_id="chat-id"))
 
-    assert result == list(range(75))
+    assert result.messages == list(range(75))
     config = graph.chat_messages.get.call_args.args[0]
     assert config.query_parameters.top == 50
     next_request = graph.request_adapter.send_async.call_args.args[0]
@@ -137,12 +146,19 @@ async def test_app_get_history_reads_channel_thread_replies() -> None:
     with patch.object(app, "get_app_graph", return_value=graph):
         result = await app.get_history(
             n=5,
-            team_aad_group_id="team-aad-group-id",
-            channel_id="channel-id",
-            thread_id="root-message-id",
+            source=ChannelHistorySource(
+                team_aad_group_id="team-aad-group-id",
+                channel_id="channel-id",
+                thread_id="root-message-id",
+            ),
         )
 
-    assert result == ["channel-reply"]
+    assert result.messages == ["channel-reply"]
+    assert result.source == ChannelHistorySource(
+        team_aad_group_id="team-aad-group-id",
+        channel_id="channel-id",
+        thread_id="root-message-id",
+    )
     assert graph.teams.team_id == "team-aad-group-id"
     assert graph.channels.channel_id == "channel-id"
     assert graph.channel_messages.thread_id == "root-message-id"
@@ -190,7 +206,12 @@ async def test_activity_context_get_history_uses_current_channel_thread() -> Non
 
     result = await ctx.get_history(2)
 
-    assert result == ["channel-reply"]
+    assert result.messages == ["channel-reply"]
+    assert result.source == ChannelHistorySource(
+        team_aad_group_id="team-group-id",
+        channel_id="channel-id",
+        thread_id="root-message-id",
+    )
     assert graph.teams.team_id == "team-group-id"
     assert graph.channels.channel_id == "channel-id"
     assert graph.channel_messages.thread_id == "root-message-id"
@@ -238,7 +259,12 @@ async def test_activity_context_get_history_reads_thread_from_conversation_id() 
 
     result = await ctx.get_history(2)
 
-    assert result == ["channel-reply"]
+    assert result.messages == ["channel-reply"]
+    assert result.source == ChannelHistorySource(
+        team_aad_group_id="team-group-id",
+        channel_id="channel-id",
+        thread_id="root-message-id",
+    )
     assert graph.channel_messages.thread_id == "root-message-id"
 
 
@@ -247,15 +273,38 @@ async def test_get_history_validates_count() -> None:
     app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
 
     with pytest.raises(ValueError, match="n must be greater than 0"):
-        await app.get_history(n=0, chat_id="chat-id")
+        await app.get_history(n=0, source=OneOnOneHistorySource(chat_id="chat-id"))
 
 
-@pytest.mark.asyncio
-async def test_get_history_requires_complete_channel_target() -> None:
-    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+def test_history_source_serializes_and_deserializes_with_discriminator() -> None:
+    source = ChannelHistorySource(
+        team_aad_group_id="team-aad-group-id",
+        channel_id="channel-id",
+        thread_id="root-message-id",
+    )
 
-    with pytest.raises(ValueError, match="team_aad_group_id and channel_id are required"):
-        await app.get_history(n=1, channel_id="channel-id")
+    payload = source.model_dump(by_alias=True)
+    restored = TypeAdapter(HistorySource).validate_python(payload)
+
+    assert payload == {
+        "type": "channel",
+        "teamAadGroupId": "team-aad-group-id",
+        "channelId": "channel-id",
+        "threadId": "root-message-id",
+    }
+    assert restored == source
+
+
+def test_message_history_serializes_source() -> None:
+    history = MessageHistory(messages=["message"], source=GroupChatHistorySource(chat_id="chat-id"))
+
+    assert history.model_dump(by_alias=True) == {
+        "messages": ["message"],
+        "source": {
+            "type": "groupChat",
+            "chatId": "chat-id",
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/packages/apps/tests/test_history.py
+++ b/packages/apps/tests/test_history.py
@@ -34,6 +34,12 @@ class FakeRepliesBuilder:
 
     def __init__(self, value: list[Any]):
         self.get = AsyncMock(return_value=SimpleNamespace(value=value))
+        self.request_adapter = FakeRequestAdapter([])
+
+
+class FakeRequestAdapter:
+    def __init__(self, pages: list[Any]):
+        self.send_async = AsyncMock(side_effect=pages)
 
 
 class FakeMessagesBuilder:
@@ -42,6 +48,7 @@ class FakeMessagesBuilder:
     def __init__(self, value: list[Any], replies_value: list[Any] | None = None):
         self.get = AsyncMock(return_value=SimpleNamespace(value=value))
         self.replies = FakeRepliesBuilder(replies_value or [])
+        self.request_adapter = FakeRequestAdapter([])
         self.thread_id: str | None = None
 
     def by_chat_message_id(self, thread_id: str) -> SimpleNamespace:
@@ -100,6 +107,27 @@ async def test_app_get_history_reads_chat_messages_with_top() -> None:
     assert graph.chats.chat_id == "chat-id"
     config = graph.chat_messages.get.call_args.args[0]
     assert config.query_parameters.top == 3
+
+
+@pytest.mark.asyncio
+async def test_app_get_history_paginates_when_count_exceeds_graph_page_limit() -> None:
+    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+    graph = FakeGraph()
+    graph.chat_messages.get = AsyncMock(
+        return_value=SimpleNamespace(value=list(range(50)), odata_next_link="https://graph.example/next")
+    )
+    graph.chat_messages.request_adapter = FakeRequestAdapter(
+        [SimpleNamespace(value=list(range(50, 100)), odata_next_link=None)]
+    )
+
+    with patch.object(app, "get_app_graph", return_value=graph):
+        result = await app.get_history(n=75, chat_id="chat-id")
+
+    assert result == list(range(75))
+    config = graph.chat_messages.get.call_args.args[0]
+    assert config.query_parameters.top == 50
+    next_request = graph.chat_messages.request_adapter.send_async.call_args.args[0]
+    assert next_request.url == "https://graph.example/next"
 
 
 @pytest.mark.asyncio

--- a/packages/apps/tests/test_history.py
+++ b/packages/apps/tests/test_history.py
@@ -88,6 +88,7 @@ class FakeTeamsBuilder:
 
 class FakeGraph:
     def __init__(self):
+        self.request_adapter = FakeRequestAdapter([])
         self.chat_messages = FakeMessagesBuilder(["chat-message"], ["chat-reply"])
         self.channel_messages = FakeMessagesBuilder(["channel-message"], ["channel-reply"])
         self.chats = FakeChatsBuilder(self.chat_messages)
@@ -116,9 +117,7 @@ async def test_app_get_history_paginates_when_count_exceeds_graph_page_limit() -
     graph.chat_messages.get = AsyncMock(
         return_value=SimpleNamespace(value=list(range(50)), odata_next_link="https://graph.example/next")
     )
-    graph.chat_messages.request_adapter = FakeRequestAdapter(
-        [SimpleNamespace(value=list(range(50, 100)), odata_next_link=None)]
-    )
+    graph.request_adapter = FakeRequestAdapter([SimpleNamespace(value=list(range(50, 100)), odata_next_link=None)])
 
     with patch.object(app, "get_app_graph", return_value=graph):
         result = await app.get_history(n=75, chat_id="chat-id")
@@ -126,7 +125,7 @@ async def test_app_get_history_paginates_when_count_exceeds_graph_page_limit() -
     assert result == list(range(75))
     config = graph.chat_messages.get.call_args.args[0]
     assert config.query_parameters.top == 50
-    next_request = graph.chat_messages.request_adapter.send_async.call_args.args[0]
+    next_request = graph.request_adapter.send_async.call_args.args[0]
     assert next_request.url == "https://graph.example/next"
 
 

--- a/packages/apps/tests/test_history.py
+++ b/packages/apps/tests/test_history.py
@@ -6,6 +6,7 @@ Licensed under the MIT License.
 # pyright: basic
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -35,6 +36,7 @@ from pydantic import TypeAdapter
 @dataclass
 class FakeQueryParameters:
     top: int | None = None
+    orderby: list[str] | None = None
 
 
 class FakeRepliesBuilder:
@@ -117,6 +119,7 @@ async def test_app_get_history_reads_chat_messages_with_top() -> None:
     assert graph.chats.chat_id == "chat-id"
     config = graph.chat_messages.get.call_args.args[0]
     assert config.query_parameters.top == 3
+    assert config.query_parameters.orderby == ["createdDateTime desc"]
 
 
 @pytest.mark.asyncio
@@ -134,6 +137,7 @@ async def test_app_get_history_paginates_when_count_exceeds_graph_page_limit() -
     assert result.messages == list(range(75))
     config = graph.chat_messages.get.call_args.args[0]
     assert config.query_parameters.top == 50
+    assert config.query_parameters.orderby == ["createdDateTime desc"]
     next_request = graph.request_adapter.send_async.call_args.args[0]
     assert next_request.url == "https://graph.example/next"
 
@@ -163,7 +167,41 @@ async def test_app_get_history_reads_channel_thread_replies() -> None:
     assert graph.channels.channel_id == "channel-id"
     assert graph.channel_messages.thread_id == "root-message-id"
     config = graph.channel_messages.replies.get.call_args.args[0]
-    assert config.query_parameters.top == 5
+    assert config.query_parameters.top == 50
+    assert config.query_parameters.orderby is None
+
+
+@pytest.mark.asyncio
+async def test_app_get_history_returns_last_channel_thread_replies() -> None:
+    app = App(**AppOptions(client_id="test-id", client_secret="test-secret"))
+    graph = FakeGraph()
+    replies = [
+        SimpleNamespace(id="oldest", created_date_time=datetime(2024, 1, 1, tzinfo=UTC)),
+        SimpleNamespace(id="older", created_date_time=datetime(2024, 1, 2, tzinfo=UTC)),
+        SimpleNamespace(id="newer", created_date_time=datetime(2024, 1, 3, tzinfo=UTC)),
+        SimpleNamespace(id="newest", created_date_time=datetime(2024, 1, 4, tzinfo=UTC)),
+    ]
+    graph.channel_messages.replies.get = AsyncMock(
+        return_value=SimpleNamespace(value=replies[:2], odata_next_link="https://graph.example/replies-next")
+    )
+    graph.request_adapter = FakeRequestAdapter([SimpleNamespace(value=replies[2:], odata_next_link=None)])
+
+    with patch.object(app, "get_app_graph", return_value=graph):
+        result = await app.get_history(
+            n=2,
+            source=ChannelHistorySource(
+                team_aad_group_id="team-aad-group-id",
+                channel_id="channel-id",
+                thread_id="root-message-id",
+            ),
+        )
+
+    assert [message.id for message in result.messages] == ["newer", "newest"]
+    config = graph.channel_messages.replies.get.call_args.args[0]
+    assert config.query_parameters.top == 50
+    assert config.query_parameters.orderby is None
+    next_request = graph.request_adapter.send_async.call_args.args[0]
+    assert next_request.url == "https://graph.example/replies-next"
 
 
 @pytest.mark.asyncio

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import pytest
+from microsoft_teams.apps import get_base_conversation_id, get_thread_message_id
 from microsoft_teams.apps.utils.thread import to_threaded_conversation_id
 
 
@@ -43,3 +44,23 @@ class TestToThreadedConversationId:
     def test_strips_existing_messageid_and_replaces_with_thread_root(self):
         result = to_threaded_conversation_id("19:abc@thread.skype;messageid=111", "222")
         assert result == "19:abc@thread.skype;messageid=222"
+
+
+class TestConversationIdThreadHelpers:
+    def test_get_base_conversation_id_strips_thread_message_id(self):
+        result = get_base_conversation_id("19:abc@thread.skype;messageid=111")
+        assert result == "19:abc@thread.skype"
+
+    def test_get_base_conversation_id_returns_unthreaded_id(self):
+        result = get_base_conversation_id("19:abc@thread.skype")
+        assert result == "19:abc@thread.skype"
+
+    def test_get_thread_message_id_extracts_thread_root(self):
+        result = get_thread_message_id("19:abc@thread.skype;messageid=111")
+        assert result == "111"
+
+    def test_get_thread_message_id_returns_none_for_unthreaded_id(self):
+        assert get_thread_message_id("19:abc@thread.skype") is None
+
+    def test_get_thread_message_id_returns_none_for_empty_thread_root(self):
+        assert get_thread_message_id("19:abc@thread.skype;messageid=") is None

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,9 @@ members = [
     "cards",
     "dialogs",
     "echo",
+    "formatted-messaging",
     "graph",
+    "history",
     "http-adapters",
     "mcp-server",
     "meetings",
@@ -968,6 +970,23 @@ wheels = [
 ]
 
 [[package]]
+name = "formatted-messaging"
+version = "0.1.0"
+source = { virtual = "examples/formatted-messaging" }
+dependencies = [
+    { name = "dotenv" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1181,6 +1200,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/9c/b4cfe330cd4f49cff17fd771154730555fa4123beb7f292cf0098b4e6c20/hatchling-1.29.0.tar.gz", hash = "sha256:793c31816d952cee405b83488ce001c719f325d9cda69f1fc4cd750527640ea6", size = 55656, upload-time = "2026-02-23T19:42:06.539Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl", hash = "sha256:50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0", size = 76356, upload-time = "2026-02-23T19:42:05.197Z" },
+]
+
+[[package]]
+name = "history"
+version = "0.1.0"
+source = { virtual = "examples/history" }
+dependencies = [
+    { name = "dotenv" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+    { name = "microsoft-teams-graph" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
+    { name = "microsoft-teams-graph", editable = "packages/graph" },
 ]
 
 [[package]]
@@ -1816,7 +1854,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "cryptography", specifier = ">=3.4.0" },
     { name = "dependency-injector", specifier = ">=4.48.1" },
     { name = "fastapi", specifier = ">=0.115.13" },
     { name = "microsoft-teams-api", editable = "packages/api" },


### PR DESCRIPTION
## Summary

Adds a Microsoft Graph-backed Teams message history API for context-level and app-level callers, plus a focused example app for manual testing. History now returns both the messages and a serializable source that can be reused for future reads.

## API

### Reactive context API

```python
history = await ctx.get_history(10)
messages = history.messages
source = history.source
```

`ctx.get_history(n)` infers the current scope from the inbound activity and returns `MessageHistory(messages, source)`:

- 1:1 chat / group chat: calls Graph `GET /chats/{chat-id}/messages`
- Team channel: calls Graph `GET /teams/{team-aad-group-id}/channels/{channel-id}/messages`
- Channel thread: detects `reply_to_id` or `;messageid=<root>` and calls `.../messages/{root-message-id}/replies`

For channel history, the SDK requires the Teams activity to include `team.aad_group_id`; this is the Graph team resource ID used by RSC.

### App-level API

```python
history = await app.get_history(n=10, source=source)
```

`app.get_history` intentionally takes a `HistorySource` instead of individual IDs. Callers can pass `history.source` from a previous `ctx.get_history(...)` result or construct one of the exported source models directly:

```python
source = ChannelHistorySource(
    team_aad_group_id=team_aad_group_id,
    channel_id=channel_id,
    thread_id=message_id,
)
history = await app.get_history(n=10, source=source)
```

Available source models:

- `OneOnOneHistorySource(chat_id=...)`
- `GroupChatHistorySource(chat_id=...)`
- `ChannelHistorySource(team_aad_group_id=..., channel_id=..., thread_id=None)`

`HistorySource` is a Pydantic discriminated union, so sources can be persisted with `source.model_dump(by_alias=True)` and restored with `TypeAdapter(HistorySource).validate_python(payload)`.

The helper returns the latest `n` messages for the selected source:

- Chat/group chat requests use Graph `$orderby=createdDateTime desc` with `$top`.
- Channel root messages use Graph's channel ordering, which is by last modified date of the entire reply chain.
- Channel thread replies only support `$top`; the SDK pages through replies and returns the last `n` by `created_date_time` when timestamps are available.

Graph errors propagate unchanged.

## Caveats

- 1:1 chat history depends on service-side support that is expected to be picked up very soon by the service team.

## Example

Adds `examples/history` with commands to test:

- `history` / `history ctx <n>`
- `history chat <chat-id> [n]`
- `history channel <team-aad-group-id> <channel-id> [n]`
- `history thread <team-aad-group-id> <channel-id> <thread-id> [n]`