### PR TITLE
Default agentic_app_blueprint_id to app client id in get_agentic_identity

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -341,16 +341,21 @@ class App(ActivityHandlerMixin):
         tenant_id: Optional[str] = None,
         agentic_app_blueprint_id: Optional[str] = None,
     ) -> AgenticIdentity:
-        """Get an Agent ID identity for API calls."""
+        """Get an Agent ID identity for API calls.
+
+        When ``agentic_app_blueprint_id`` is omitted, it defaults to the app's own
+        client/app id (``self.id``).
+        """
         resolved_tenant_id = tenant_id or (self.credentials.tenant_id if self.credentials else None)
         if resolved_tenant_id is None:
             raise ValueError("tenant_id is required to get an agentic identity")
 
+        resolved_blueprint_id = agentic_app_blueprint_id or self.id
         return AgenticIdentity(
             agentic_app_id=agentic_app_id,
             agentic_user_id=agentic_user_id,
             tenant_id=resolved_tenant_id,
-            agentic_app_blueprint_id=agentic_app_blueprint_id,
+            agentic_app_blueprint_id=resolved_blueprint_id,
         )
 
     @overload

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -834,6 +834,34 @@ class TestApp:
         }
         assert result.id == "sent-activity-id"
 
+    def test_get_agentic_identity_preserves_explicit_blueprint_id(self, mock_storage) -> None:
+        """An explicitly provided agentic_app_blueprint_id should be preserved."""
+        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        identity = app.get_agentic_identity(
+            "agentic-app-id",
+            "agentic-user-id",
+            tenant_id="tenant-id",
+            agentic_app_blueprint_id="explicit-blueprint-id",
+        )
+
+        assert identity.agentic_app_blueprint_id == "explicit-blueprint-id"
+
+    def test_get_agentic_identity_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
+        """When agentic_app_blueprint_id is omitted, it should default to the app's client id."""
+        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        identity = app.get_agentic_identity(
+            "agentic-app-id",
+            "agentic-user-id",
+            tenant_id="tenant-id",
+        )
+
+        assert identity.agentic_app_blueprint_id == app.id
+        assert identity.agentic_app_blueprint_id == "test-client-id"
+
 
 class TestAppInitialize:
     """Test cases for App.initialize() method."""


### PR DESCRIPTION
## Summary

`App.get_agentic_identity(...)` previously passed `agentic_app_blueprint_id` straight through, which meant it could be `None` if the caller didn't provide it. This change makes it default to the app's own client/app id (`self.id`) when omitted, mirroring the existing `resolved_tenant_id` style for readability.

## Behavior change

- **Before:** `agentic_app_blueprint_id=None` when the caller didn't pass one.
- **After:** `agentic_app_blueprint_id` falls back to `self.id` (the app's `client_id`) when omitted. An explicitly provided value is still preserved.

## Tests

Added two unit tests in `packages/apps/tests/test_app.py`:
- explicitly provided `agentic_app_blueprint_id` is preserved
- omitting it falls back to the app's `client_id`

All checks green: `ruff format`, `ruff check`, `pyright` (0 errors), and `pytest packages` (692 passed).

## Note

This stacks on the Agent 365 feature branch (#464) and targets `feature_agent365_support` as its base — not `main`.