### PR TITLE
Support resetting response streams

### DIFF
--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -4,7 +4,7 @@ A test application that demonstrates streaming functionality.
 
 - Send any message for the normal single-stream demo with suggested actions.
 - Send `simple-card` to send a minimal Adaptive Card outside the streaming flow.
-- Send `multi-stream` to test emitting an Adaptive Card as part of the first stream final message, finalizing with `close(reset=True)`, and then reusing `ctx.stream` for another streamed response.
+- Send `multi-stream` to test emitting an Adaptive Card as part of the first stream final message, finalizing with `close()`, and then reusing `ctx.stream` for another streamed response.
 
 ## Running
 

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -3,6 +3,7 @@
 A test application that demonstrates streaming functionality.
 
 - Send any message for the normal single-stream demo with suggested actions.
+- Send `simple-card` to send a minimal Adaptive Card outside the streaming flow.
 - Send `multi-stream` to test finalizing the current stream with `close(reset=True)`, sending a normal message, and then reusing `ctx.stream` for another streamed response.
 
 ## Running

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -4,7 +4,7 @@ A test application that demonstrates streaming functionality.
 
 - Send any message for the normal single-stream demo with suggested actions.
 - Send `simple-card` to send a minimal Adaptive Card outside the streaming flow.
-- Send `multi-stream` to test finalizing the current stream with `close(reset=True)`, sending an Adaptive Card, and then reusing `ctx.stream` for another streamed response.
+- Send `multi-stream` to test emitting an Adaptive Card as part of the first stream final message, finalizing with `close(reset=True)`, and then reusing `ctx.stream` for another streamed response.
 
 ## Running
 

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -2,6 +2,9 @@
 
 A test application that demonstrates streaming functionality.
 
+- Send any message for the normal single-stream demo with suggested actions.
+- Send `multi-stream` to test finalizing the current stream with `close(reset=True)`, sending a normal message, and then reusing `ctx.stream` for another streamed response.
+
 ## Running
 
 ```bash

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -4,7 +4,7 @@ A test application that demonstrates streaming functionality.
 
 - Send any message for the normal single-stream demo with suggested actions.
 - Send `simple-card` to send a minimal Adaptive Card outside the streaming flow.
-- Send `multi-stream` to test finalizing the current stream with `close(reset=True)`, sending a normal message, and then reusing `ctx.stream` for another streamed response.
+- Send `multi-stream` to test finalizing the current stream with `close(reset=True)`, sending an Adaptive Card, and then reusing `ctx.stream` for another streamed response.
 
 ## Running
 

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -31,10 +31,50 @@ STREAM_MESSAGES = [
     "✨ Stream test complete!",
 ]
 
+FIRST_STREAM_MESSAGES = [
+    "[stream 1] Starting the first streamed response. ",
+    "[stream 1] This is using the default ctx.stream instance. ",
+    "[stream 1] Next the handler will close with reset=True.",
+]
+
+SECOND_STREAM_MESSAGES = [
+    "[stream 2] Reusing ctx.stream after close(reset=True). ",
+    "[stream 2] This should render after the non-stream checkpoint message. ",
+    "[stream 2] The app processor will close this stream when the handler returns.",
+]
+
+
+def should_run_multi_stream(text: str | None) -> bool:
+    normalized = (text or "").lower().replace("-", " ")
+    return "multi stream" in normalized
+
 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Stream messages to the user on any message activity."""
+
+    if should_run_multi_stream(ctx.activity.text):
+        ctx.stream.update("Starting stream 1...")
+        await asyncio.sleep(1)
+
+        for message in FIRST_STREAM_MESSAGES:
+            await asyncio.sleep(0.5)
+            ctx.stream.emit(message)
+
+        await ctx.stream.close(reset=True)
+        await asyncio.sleep(1)
+
+        sent_message = await ctx.send("NON-STREAM MESSAGE BETWEEN STREAMS")
+        logger.info("Sent checkpoint message: %s", sent_message.id)
+        await asyncio.sleep(2)
+
+        ctx.stream.update("Starting stream 2...")
+        await asyncio.sleep(1)
+
+        for message in SECOND_STREAM_MESSAGES:
+            await asyncio.sleep(0.5)
+            ctx.stream.emit(message)
+        return
 
     ctx.stream.update("Stream starting...")
     await asyncio.sleep(1)

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -97,12 +97,13 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             await asyncio.sleep(0.5)
             ctx.stream.emit(message)
 
-        await ctx.stream.close(reset=True)
-        await asyncio.sleep(1)
-
-        card_message = MessageActivityInput(text="Adaptive Card between streams.").add_card(create_simple_card())
-        sent_message = await ctx.send(card_message)
-        logger.info("Sent checkpoint adaptive card: %s", sent_message.id)
+        card_message = MessageActivityInput(text="Adaptive Card emitted as part of stream 1.").add_card(
+            create_simple_card()
+        )
+        ctx.stream.emit(card_message)
+        sent_message = await ctx.stream.close(reset=True)
+        if sent_message:
+            logger.info("Sent stream 1 final message with adaptive card: %s", sent_message.id)
         await asyncio.sleep(2)
 
         ctx.stream.update("Starting stream 2...")

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -9,7 +9,7 @@ from random import random
 
 from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
 from microsoft_teams.apps import ActivityContext, App
-from microsoft_teams.cards import AdaptiveCard
+from microsoft_teams.cards import AdaptiveCard, TextBlock
 
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
@@ -56,25 +56,12 @@ def should_send_simple_card(text: str | None) -> bool:
 
 
 def create_simple_card() -> AdaptiveCard:
-    return AdaptiveCard.model_validate(
-        {
-            "type": "AdaptiveCard",
-            "version": "1.4",
-            "body": [
-                {
-                    "type": "TextBlock",
-                    "text": "Simple Adaptive Card",
-                    "weight": "Bolder",
-                    "size": "Large",
-                    "wrap": True,
-                },
-                {
-                    "type": "TextBlock",
-                    "text": "If you can see this card, basic Adaptive Card delivery is working.",
-                    "wrap": True,
-                },
-            ],
-        }
+    return AdaptiveCard(
+        version="1.4",
+        body=[
+            TextBlock(text="Simple Adaptive Card", weight="Bolder", size="Large", wrap=True),
+            TextBlock(text="If you can see this card, basic Adaptive Card delivery is working.", wrap=True),
+        ],
     )
 
 

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -100,8 +100,9 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
         await ctx.stream.close(reset=True)
         await asyncio.sleep(1)
 
-        sent_message = await ctx.send("NON-STREAM MESSAGE BETWEEN STREAMS")
-        logger.info("Sent checkpoint message: %s", sent_message.id)
+        card_message = MessageActivityInput(text="Adaptive Card between streams.").add_card(create_simple_card())
+        sent_message = await ctx.send(card_message)
+        logger.info("Sent checkpoint adaptive card: %s", sent_message.id)
         await asyncio.sleep(2)
 
         ctx.stream.update("Starting stream 2...")

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -35,11 +35,11 @@ STREAM_MESSAGES = [
 FIRST_STREAM_MESSAGES = [
     "[stream 1] Starting the first streamed response. ",
     "[stream 1] This is using the default ctx.stream instance. ",
-    "[stream 1] Next the handler will close with reset=True.",
+    "[stream 1] Next the handler will close the current streamed message.",
 ]
 
 SECOND_STREAM_MESSAGES = [
-    "[stream 2] Reusing ctx.stream after close(reset=True). ",
+    "[stream 2] Reusing ctx.stream after emit reopens the closed stream. ",
     "[stream 2] This should render after the non-stream checkpoint message. ",
     "[stream 2] The app processor will close this stream when the handler returns.",
 ]
@@ -101,7 +101,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             create_simple_card()
         )
         ctx.stream.emit(card_message)
-        sent_message = await ctx.stream.close(reset=True)
+        sent_message = await ctx.stream.close()
         if sent_message:
             logger.info("Sent stream 1 final message with adaptive card: %s", sent_message.id)
         await asyncio.sleep(2)

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -40,7 +40,7 @@ FIRST_STREAM_MESSAGES = [
 
 SECOND_STREAM_MESSAGES = [
     "[stream 2] Reusing ctx.stream after emit reopens the closed stream. ",
-    "[stream 2] This should render after the non-stream checkpoint message. ",
+    "[stream 2] This should render after stream 1's final Adaptive Card message. ",
     "[stream 2] The app processor will close this stream when the handler returns.",
 ]
 

--- a/examples/stream/src/main.py
+++ b/examples/stream/src/main.py
@@ -9,6 +9,7 @@ from random import random
 
 from microsoft_teams.api import CardAction, CardActionType, MessageActivity, MessageActivityInput, SuggestedActions
 from microsoft_teams.apps import ActivityContext, App
+from microsoft_teams.cards import AdaptiveCard
 
 # Surface SDK INFO/WARNING logs (including the anonymous-mode startup warning
 # emitted when CLIENT_ID / CLIENT_SECRET / TENANT_ID are not configured).
@@ -49,9 +50,44 @@ def should_run_multi_stream(text: str | None) -> bool:
     return "multi stream" in normalized
 
 
+def should_send_simple_card(text: str | None) -> bool:
+    normalized = (text or "").lower().replace("-", " ")
+    return "simple card" in normalized
+
+
+def create_simple_card() -> AdaptiveCard:
+    return AdaptiveCard.model_validate(
+        {
+            "type": "AdaptiveCard",
+            "version": "1.4",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "text": "Simple Adaptive Card",
+                    "weight": "Bolder",
+                    "size": "Large",
+                    "wrap": True,
+                },
+                {
+                    "type": "TextBlock",
+                    "text": "If you can see this card, basic Adaptive Card delivery is working.",
+                    "wrap": True,
+                },
+            ],
+        }
+    )
+
+
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Stream messages to the user on any message activity."""
+
+    if should_send_simple_card(ctx.activity.text):
+        sent_card = await ctx.send(
+            MessageActivityInput(text="Sending a simple Adaptive Card.").add_card(create_simple_card())
+        )
+        logger.info("Sent simple adaptive card: %s", sent_card.id)
+        return
 
     if should_run_multi_stream(ctx.activity.text):
         ctx.stream.update("Starting stream 1...")

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -83,7 +83,7 @@ class HttpStream(StreamerProtocol):
 
     @property
     def closed(self) -> bool:
-        """Whether the final stream message has been sent."""
+        """Whether the current streamed message has been finalized."""
         return self._result is not None
 
     @property
@@ -112,6 +112,10 @@ class HttpStream(StreamerProtocol):
 
         if self._canceled:
             raise StreamCancelledError("Stream has been cancelled.")
+
+        if self._result is not None:
+            logger.debug("starting a new streamed message after close")
+            self._result = None
 
         if isinstance(activity, str):
             activity = MessageActivityInput(text=activity, type="message")
@@ -162,25 +166,17 @@ class HttpStream(StreamerProtocol):
         except asyncio.TimeoutError:
             return False
 
-    async def close(self, reset: bool = False) -> Optional[SentActivity]:
+    async def close(self) -> Optional[SentActivity]:
         """
         Finalize the current streamed message.
 
-        By default, closing is terminal and idempotent: subsequent calls return
-        the same final activity. When reset is True, the current streamed
-        message is finalized and the stream is reset so the same instance can
-        be used for another streamed message.
-
-        Args:
-            reset: Whether to reset the stream after finalizing the current
-                streamed message.
+        Closing is idempotent until the next emit or update. Emitting or
+        updating after close starts a new streamed message using the same
+        stream instance.
         """
         if self._result is not None:
             logger.debug("stream already closed with result")
-            result = self._result
-            if reset:
-                self._result = None
-            return result
+            return self._result
 
         if self._canceled:
             logger.debug("stream was cancelled, nothing to close")
@@ -219,8 +215,7 @@ class HttpStream(StreamerProtocol):
 
         # Reset per-message state; keep event handlers and cancellation state.
         self._reset_state()
-        if not reset:
-            self._result = res
+        self._result = res
         logger.debug("stream closed with result: %s", res)
 
         return res

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -118,7 +118,7 @@ class HttpStream(StreamerProtocol):
         if self._canceled:
             raise StreamCancelledError("Stream has been cancelled.")
 
-        if self._result is not None:
+        if self.closed:
             logger.debug("starting a new streamed message after close")
             self._reset_stream_for_next_stream()
 
@@ -179,8 +179,9 @@ class HttpStream(StreamerProtocol):
         updating after close starts a new streamed message using the same
         stream instance.
         """
-        if self._result is not None:
+        if self.closed:
             logger.debug("stream already closed with result")
+            assert self._result is not None
             return self._result
 
         if self._canceled:

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -100,7 +100,7 @@ class HttpStream(StreamerProtocol):
         self._events.on("chunk", handler)
 
     def on_close(self, handler: Callable[[SentActivity], Awaitable[None]]):
-        self._events.once("close", handler)
+        self._events.on("close", handler)
 
     def emit(self, activity: Union[MessageActivityInput, TypingActivityInput, str]) -> None:
         """
@@ -162,11 +162,25 @@ class HttpStream(StreamerProtocol):
         except asyncio.TimeoutError:
             return False
 
-    async def close(self) -> Optional[SentActivity]:
-        # wait for lock to be free
+    async def close(self, reset: bool = False) -> Optional[SentActivity]:
+        """
+        Finalize the current streamed message.
+
+        By default, closing is terminal and idempotent: subsequent calls return
+        the same final activity. When reset is True, the current streamed
+        message is finalized and the stream is reset so the same instance can
+        be used for another streamed message.
+
+        Args:
+            reset: Whether to reset the stream after finalizing the current
+                streamed message.
+        """
         if self._result is not None:
             logger.debug("stream already closed with result")
-            return self._result
+            result = self._result
+            if reset:
+                self._result = None
+            return result
 
         if self._canceled:
             logger.debug("stream was cancelled, nothing to close")
@@ -203,9 +217,10 @@ class HttpStream(StreamerProtocol):
         # Emit close event
         self._events.emit("close", res)
 
-        # Reset state
+        # Reset per-message state; keep event handlers and cancellation state.
         self._reset_state()
-        self._result = res
+        if not reset:
+            self._result = res
         logger.debug("stream closed with result: %s", res)
 
         return res

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -62,16 +62,21 @@ class HttpStream(StreamerProtocol):
         self._state_changed = asyncio.Event()
 
         self._canceled = False
-        self._reset_state()
+        self._reset_current_stream()
 
-    def _reset_state(self) -> None:
-        """Reset the stream state to initial values."""
+    def _reset_current_stream(self) -> None:
+        """Reset per-message state for the current stream cycle."""
         self._index = 1
         self._id: Optional[str] = None
         self._text: str = ""
         self._channel_data: ChannelData = ChannelData()
         self._final_activity: Optional[MessageActivityInput] = None
         self._queue: deque[Union[MessageActivityInput, TypingActivityInput, str]] = deque()
+
+    def _reset_stream_for_next_stream(self) -> None:
+        """Prepare the stream instance to start a new stream cycle."""
+        self._reset_current_stream()
+        self._result = None
 
     @property
     def canceled(self) -> bool:
@@ -115,7 +120,7 @@ class HttpStream(StreamerProtocol):
 
         if self._result is not None:
             logger.debug("starting a new streamed message after close")
-            self._result = None
+            self._reset_stream_for_next_stream()
 
         if isinstance(activity, str):
             activity = MessageActivityInput(text=activity, type="message")
@@ -214,7 +219,7 @@ class HttpStream(StreamerProtocol):
         self._events.emit("close", res)
 
         # Reset per-message state; keep event handlers and cancellation state.
-        self._reset_state()
+        self._reset_current_stream()
         self._result = res
         logger.debug("stream closed with result: %s", res)
 

--- a/packages/apps/src/microsoft_teams/apps/plugins/streamer.py
+++ b/packages/apps/src/microsoft_teams/apps/plugins/streamer.py
@@ -87,17 +87,12 @@ class StreamerProtocol(Protocol):
         """
         ...
 
-    async def close(self, reset: bool = False) -> Optional[SentActivity]:
+    async def close(self) -> Optional[SentActivity]:
         """
         Finalize the current streamed message.
 
-        By default, closing is terminal and idempotent: subsequent calls return
-        the same final activity. When reset is True, the current streamed
-        message is finalized and the stream is reset so the same instance can
-        be used for another streamed message.
-
-        Args:
-            reset: Whether to reset the stream after finalizing the current
-                streamed message.
+        Closing is idempotent until the next emit or update. Emitting or
+        updating after close starts a new streamed message using the same
+        stream instance.
         """
         ...

--- a/packages/apps/src/microsoft_teams/apps/plugins/streamer.py
+++ b/packages/apps/src/microsoft_teams/apps/plugins/streamer.py
@@ -30,7 +30,7 @@ class StreamerProtocol(Protocol):
 
     @property
     def closed(self) -> bool:
-        """Whether the final stream message has been sent."""
+        """Whether the current streamed message has been finalized."""
         ...
 
     @property

--- a/packages/apps/src/microsoft_teams/apps/plugins/streamer.py
+++ b/packages/apps/src/microsoft_teams/apps/plugins/streamer.py
@@ -59,10 +59,10 @@ class StreamerProtocol(Protocol):
 
     def on_close(self, handler: Callable[[SentActivity], Awaitable[None]]) -> None:
         """
-        Register a handler for close events.
+        Register a handler for stream close events.
 
         Args:
-            handler: Async function that will be called when the stream closes
+            handler: Async function that will be called each time the stream closes
         """
         ...
 
@@ -87,8 +87,17 @@ class StreamerProtocol(Protocol):
         """
         ...
 
-    async def close(self) -> Optional[SentActivity]:
+    async def close(self, reset: bool = False) -> Optional[SentActivity]:
         """
-        Close the stream.
+        Finalize the current streamed message.
+
+        By default, closing is terminal and idempotent: subsequent calls return
+        the same final activity. When reset is True, the current streamed
+        message is finalized and the stream is reset so the same instance can
+        be used for another streamed message.
+
+        Args:
+            reset: Whether to reset the stream after finalizing the current
+                streamed message.
         """
         ...

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -646,7 +646,7 @@ class TestHttpStream:
             await self._run_scheduled_flushes(scheduled)
 
             first_result = await stream.close()
-            await close_event.wait()
+            await asyncio.wait_for(close_event.wait(), timeout=1)
             close_event.clear()
             assert first_result is not None
             assert stream.closed is True
@@ -661,7 +661,7 @@ class TestHttpStream:
             await self._run_scheduled_flushes(scheduled)
 
             second_result = await stream.close()
-            await close_event.wait()
+            await asyncio.wait_for(close_event.wait(), timeout=1)
             assert second_result is not None
             assert stream.closed is True
 

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -455,7 +455,7 @@ class TestHttpStream:
         assert mock_api_client.sent_activities[0].text == "Response text"
 
     @pytest.mark.asyncio
-    async def test_close_reset_reuses_stream_for_next_message(
+    async def test_emit_after_close_reopens_stream_for_next_message(
         self, mock_api_client, conversation_reference, patch_loop_call_later
     ):
         loop = asyncio.get_running_loop()
@@ -475,17 +475,21 @@ class TestHttpStream:
             await asyncio.sleep(0)
             await self._run_scheduled_flushes(scheduled)
 
-            first_result = await stream.close(reset=True)
+            first_result = await stream.close()
             await close_event.wait()
             close_event.clear()
             assert first_result is not None
-            assert stream.closed is False
-            assert stream.sequence == 1
+            assert stream.closed is True
+
+            repeated_result = await stream.close()
+            assert repeated_result is first_result
+            assert stream.closed is True
 
             stream.emit("Second streamed message")
+            assert stream.closed is False
             await asyncio.sleep(0)
             await self._run_scheduled_flushes(scheduled)
-            second_result = await stream.close()
+
             second_result = await stream.close()
             await close_event.wait()
             assert second_result is not None

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -453,3 +453,45 @@ class TestHttpStream:
         assert result is not None
         assert mock_api_client.send_call_count == 1
         assert mock_api_client.sent_activities[0].text == "Response text"
+
+    @pytest.mark.asyncio
+    async def test_close_reset_reuses_stream_for_next_message(
+        self, mock_api_client, conversation_reference, patch_loop_call_later
+    ):
+        loop = asyncio.get_running_loop()
+        patcher, scheduled = patch_loop_call_later(loop)
+        close_results: list[SentActivity] = []
+        close_event = asyncio.Event()
+
+        async def handle_close(activity: SentActivity) -> None:
+            close_results.append(activity)
+            close_event.set()
+
+        with patcher:
+            stream = HttpStream(mock_api_client, conversation_reference)
+            stream.on_close(handle_close)
+
+            stream.emit("First streamed message")
+            await asyncio.sleep(0)
+            await self._run_scheduled_flushes(scheduled)
+
+            first_result = await stream.close(reset=True)
+            await close_event.wait()
+            close_event.clear()
+            assert first_result is not None
+            assert stream.closed is False
+            assert stream.sequence == 1
+
+            stream.emit("Second streamed message")
+            await asyncio.sleep(0)
+            await self._run_scheduled_flushes(scheduled)
+            second_result = await stream.close()
+            second_result = await stream.close()
+            await close_event.wait()
+            assert second_result is not None
+            assert stream.closed is True
+
+            assert first_result.id != second_result.id
+            assert first_result.activity_params.text == "First streamed message"
+            assert second_result.activity_params.text == "Second streamed message"
+            assert [result.id for result in close_results] == [first_result.id, second_result.id]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ members = [
     "cards",
     "dialogs",
     "echo",
+    "formatted-messaging",
     "graph",
     "http-adapters",
     "mcp-server",
@@ -968,6 +969,23 @@ wheels = [
 ]
 
 [[package]]
+name = "formatted-messaging"
+version = "0.1.0"
+source = { virtual = "examples/formatted-messaging" }
+dependencies = [
+    { name = "dotenv" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1816,7 +1834,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "cryptography", specifier = ">=3.4.0" },
     { name = "dependency-injector", specifier = ">=4.48.1" },
     { name = "fastapi", specifier = ">=0.115.13" },
     { name = "microsoft-teams-api", editable = "packages/api" },


### PR DESCRIPTION
## Summary

- make `HttpStream` reusable after close: a later `emit()` or `update()` starts a new streamed message cycle on the same stream instance
- keep repeated `close()` calls idempotent until another emit/update occurs
- update the stream example with a `multi-stream` flow that emits an Adaptive Card in the first stream final message, closes, then reuses `ctx.stream` for a second streamed segment
- add coverage for close idempotency followed by emit-driven stream reopening
- refresh `uv.lock` to include the missing `formatted-messaging` workspace member and dependency metadata

## Context

This addresses the scenario in #489 where a handler needs to:

1. stream part of a response,
2. include a normal message or card in the flow,
3. continue with another streamed response.

Before this change, the only way to do that was to close `ctx.stream` and then reach into the private `ctx._activity_sender.create_stream(...)` API to create another stream.

## Motivation

This is useful for conversational AI and tool-using bot flows where a response is not always one uninterrupted text stream.

For example, a bot may need to stream an explanation while it reasons or searches, include a structured checkpoint message, approval prompt, or card, and then continue streaming the final answer after that intermediate interaction.

Without a public lifecycle API, developers either have to avoid streaming for these richer flows or access private SDK internals to create a fresh stream. Reopening the stream on the next emit gives them a supported way to split one handler's response into multiple sequential streamed messages while keeping the SDK's one-stream-object model.

## Alternatives considered

### `ctx.new_stream()`

We first considered adding a public `ctx.new_stream()` method that would create and return another stream object.

That solves the private API issue, but it makes the model feel like a handler can manage multiple stream objects at once. In practice, Teams appears to behave more reliably when there is only one active stream at a time. Multiple stream objects also complicate ownership, finalization, event handler registration, and retry behavior.

### Context-managed multiple streams

We also considered having `ActivityContext` track all streams created during a handler and close them all at the end.

That keeps cleanup centralized, but it still encourages multiple open streams during one handler. It also makes ordering less explicit: a stream could remain active while a normal message or a second stream is sent, which is exactly the behavior that seemed risky.

### `close(reset=True)`

We also tried an explicit `close(reset=True)` option. It worked, but it made the API more awkward and introduced a flag for what is conceptually the next stream cycle.

The approach in this PR keeps `close()` simple: it finalizes the current streamed message. Repeated `close()` calls remain idempotent. If the caller later emits or updates, the stream starts a new cycle automatically.

## Example

The stream example now includes a `multi-stream` path:


https://github.com/user-attachments/assets/91021174-fd9d-43c4-acb0-e38348ef6d12



```python
ctx.stream.emit("[stream 1] Starting the first streamed response.")
ctx.stream.emit(MessageActivityInput(text="...").add_card(card))
await ctx.stream.close()

ctx.stream.emit("[stream 2] Reusing ctx.stream after close().")
```

This demonstrates the intended lifecycle: one streamed message is finalized, and the same `ctx.stream` instance is reused for the next streamed message when the handler emits again.

Addresses #489