### PR TITLE
fix(apps): specify specific string for 'Content stream is not allowed'

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -410,7 +410,7 @@ class HttpStream(StreamerProtocol):
                     self._canceled = True
                     logger.warning("The streaming was stopped by the user.")
                     raise StreamCancelledError(message) from e
-                elif "not allowed" in normalized:
+                elif "not allowed" in normalized and "completed streamed message" not in normalized:
                     logger.warning("The streaming API isn't allowed for the user or bot.")
                     raise StreamNotAllowedError(message) from e
                 else:

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -355,9 +355,6 @@ class TestHttpStream:
         with pytest.raises(expected) as exc_info:
             await stream._send(TypingActivityInput(text="hi"))
 
-        # Assert the exact error type, not a subclass: StreamNotAllowedError subclasses
-        # TerminalStreamError, so pytest.raises(TerminalStreamError) alone would pass even
-        # when the wrong error is raised for the "already completed" message.
         assert type(exc_info.value) is expected
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -352,8 +352,13 @@ class TestHttpStream:
         mock_api_client.conversations.activities().create = mock_send_403
         stream = HttpStream(mock_api_client, conversation_reference)
 
-        with pytest.raises(expected):
+        with pytest.raises(expected) as exc_info:
             await stream._send(TypingActivityInput(text="hi"))
+
+        # Assert the exact error type, not a subclass: StreamNotAllowedError subclasses
+        # TerminalStreamError, so pytest.raises(TerminalStreamError) alone would pass even
+        # when the wrong error is raised for the "already completed" message.
+        assert type(exc_info.value) is expected
 
     @pytest.mark.asyncio
     async def test_send_403_with_empty_body_raises_stream_error(self, mock_api_client, conversation_reference):


### PR DESCRIPTION
## Problem

Our streaming error conditions checks strings for keywords - but two of the errors share "not allowed". The one we want to catch is 

- `Content stream is not allowed` — the streaming feature is disabled for the user/bot → **`StreamNotAllowedError`**

but it also caught:
- `Content stream is not allowed on an already completed streamed message` — the stream is already finalized → **terminal**, should be `TerminalStreamError`. 

This latter error isn't possible given our current implementation, so we don't need to specially handle this case 

