### PR TITLE
feat(api): flatten client method chains to reduce call hops

### DIFF
--- a/examples/message-extensions/src/main.py
+++ b/examples/message-extensions/src/main.py
@@ -129,7 +129,7 @@ async def handle_message_ext_submit(ctx: ActivityContext[MessageExtensionSubmitA
 @app.on_message_ext_open
 async def handle_message_ext_open(ctx: ActivityContext[MessageExtensionFetchTaskInvokeActivity]):
     conversation_id = ctx.activity.conversation.id
-    members = await ctx.api.conversations.members(conversation_id).get_all()
+    members = await ctx.api.conversations.get_members(conversation_id)
     card = create_conversation_members_card(members)
 
     card_info = CardTaskModuleTaskInfo(

--- a/examples/proactive-messaging/src/main.py
+++ b/examples/proactive-messaging/src/main.py
@@ -95,7 +95,7 @@ async def send_and_update_proactive_message(app: App, conversation_id: str) -> N
 
     # Now update the same message proactively using the ConversationClient
     updated = MessageActivityInput(text="Status: Complete ✅ (updated proactively without a running server)")
-    await app.api.conversations.activities(conversation_id).update(activity_id, updated)
+    await app.api.conversations.update_activity(conversation_id, activity_id, updated)
     logger.info(f"✓ Message updated successfully! Activity ID: {activity_id}")
 
 

--- a/examples/reactions/src/main.py
+++ b/examples/reactions/src/main.py
@@ -41,7 +41,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     if text.startswith("react "):
         reaction_type = text[6:].strip()
 
-        await ctx.api.reactions.add(
+        await ctx.api.conversations.add_reaction(
             conversation_id=conversation_id,
             activity_id=activity_id,
             reaction_type=reaction_type,
@@ -57,14 +57,14 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     if text.startswith("unreact "):
         reaction_type = text[8:].strip()
 
-        await ctx.api.reactions.add(
+        await ctx.api.conversations.add_reaction(
             conversation_id=conversation_id,
             activity_id=activity_id,
             reaction_type=reaction_type,
         )
         await ctx.reply(f"✅ Added {reaction_type} reaction, removing in 2s...")
         await asyncio.sleep(2)
-        await ctx.api.reactions.delete(
+        await ctx.api.conversations.delete_reaction(
             conversation_id=conversation_id,
             activity_id=activity_id,
             reaction_type=reaction_type,

--- a/examples/targeted-messages/src/main.py
+++ b/examples/targeted-messages/src/main.py
@@ -72,7 +72,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
                     )
                     updated_message.id = message_id
 
-                    await ctx.api.conversations.activities(conversation_id).update_targeted(message_id, updated_message)
+                    await ctx.api.conversations.update_targeted_activity(conversation_id, message_id, updated_message)
                     logger.info("[UPDATE] Updated targeted message")
                 except Exception as err:
                     logger.error(f"[UPDATE] Error: {err}")
@@ -97,7 +97,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             async def delete_after_delay():
                 await asyncio.sleep(3)
                 try:
-                    await ctx.api.conversations.activities(conversation_id).delete_targeted(message_id)
+                    await ctx.api.conversations.delete_targeted_activity(conversation_id, message_id)
                     logger.info("[DELETE] Deleted targeted message")
                 except Exception as err:
                     logger.error(f"[DELETE] Error: {err}")

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -9,10 +9,11 @@ from typing import TYPE_CHECKING, Optional, Union
 
 from microsoft_teams.common import Client as HttpClient
 from microsoft_teams.common import ClientOptions
+from typing_extensions import deprecated
 
 from .api_client_settings import ApiClientSettings
 from .base_client import BaseClient
-from .bot import BotClient
+from .bot import BotClient  # pyright: ignore[reportDeprecated]
 from .conversation import ConversationClient
 from .meeting import MeetingClient
 from .reaction import ReactionClient
@@ -45,7 +46,9 @@ class ApiClient(BaseClient):
         self.service_url = service_url.rstrip("/")
 
         # Initialize all client types
-        self.bots = BotClient(self._http, self._api_client_settings, cloud=cloud)
+        self._bots = BotClient(  # pyright: ignore[reportDeprecated]
+            self._http, self._api_client_settings, cloud=cloud
+        )
         self.users = UserClient(self._http, self._api_client_settings)
         self.conversations = ConversationClient(self.service_url, self._http, self._api_client_settings)
         self.teams = TeamClient(self.service_url, self._http, self._api_client_settings)
@@ -53,6 +56,16 @@ class ApiClient(BaseClient):
         self._reactions: Optional[ReactionClient] = None
 
     @property
+    @deprecated("The bot client is no longer used and will be removed in a future release.")
+    def bots(self):
+        """Get the bot client."""
+        return self._bots
+
+    @property
+    @deprecated(
+        "Use `conversations.add_reaction(...)` and `conversations.delete_reaction(...)` instead. "
+        "This will be removed in a future release."
+    )
     def reactions(self) -> ReactionClient:
         """Get the reactions client (preview). Lazily instantiated to avoid warnings for non-users."""
         if self._reactions is None:
@@ -67,7 +80,7 @@ class ApiClient(BaseClient):
     @http.setter
     def http(self, value: HttpClient) -> None:
         """Set the HTTP client instance and propagate to all sub-clients."""
-        self.bots.http = value
+        self._bots.http = value
         self.conversations.http = value
         self.users.http = value
         self.teams.http = value

--- a/packages/api/src/microsoft_teams/api/clients/bot/__init__.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/__init__.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from .client import BotClient
+from .client import BotClient  # pyright: ignore[reportDeprecated]
 from .params import GetBotSignInResourceParams, GetBotSignInUrlParams
 from .sign_in_client import BotSignInClient
 from .token_client import BotTokenClient

--- a/packages/api/src/microsoft_teams/api/clients/bot/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Union
 
 from microsoft_teams.common.http import Client, ClientOptions
+from typing_extensions import deprecated
 
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from ...auth.cloud_environment import CloudEnvironment
 
 
+@deprecated("The bot client is deprecated and will be removed in a future release.")
 class BotClient(BaseClient):
     """Client for managing bot operations."""
 

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -50,6 +50,7 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
 
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.post(
             f"{self.service_url}/v3/conversations/{conversation_id}/activities",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -73,6 +74,7 @@ class ConversationActivityClient(BaseClient):
         Returns:
             The updated activity
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.put(
             f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -92,6 +94,7 @@ class ConversationActivityClient(BaseClient):
         Returns:
             The created reply activity
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         activity_json = activity.model_dump(by_alias=True, exclude_none=True)
         activity_json["replyToId"] = activity_id
         response = await self.http.post(
@@ -109,6 +112,7 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         await self.http.delete(f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}")
 
     async def get_members(self, conversation_id: str, activity_id: str) -> List[TeamsChannelAccount]:
@@ -122,6 +126,7 @@ class ConversationActivityClient(BaseClient):
         Returns:
             List of TeamsChannelAccount objects representing the activity members
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.get(
             f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}/members"
         )
@@ -145,6 +150,7 @@ class ConversationActivityClient(BaseClient):
         Returns:
             The created activity
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.post(
             f"{self.service_url}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -169,6 +175,7 @@ class ConversationActivityClient(BaseClient):
         Returns:
             The updated activity
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.put(
             f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -189,6 +196,7 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         await self.http.delete(
             f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true"
         )

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -6,10 +6,13 @@ Licensed under the MIT License.
 from typing import Optional, Union
 
 from microsoft_teams.common.http import Client, ClientOptions
+from typing_extensions import deprecated
 
 from ...models import ConversationResource
+from ...models.message import MessageReactionType
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
+from ..reaction import ReactionClient
 from .activity import ActivityParams, ConversationActivityClient
 from .member import ConversationMemberClient
 from .params import CreateConversationParams
@@ -88,6 +91,7 @@ class ConversationClient(BaseClient):
 
         self._activities_client = ConversationActivityClient(self.service_url, self.http, self._api_client_settings)
         self._members_client = ConversationMemberClient(self.service_url, self.http, self._api_client_settings)
+        self._reactions_client = ReactionClient(self.service_url, self.http, self._api_client_settings)
 
     @property
     def http(self) -> Client:
@@ -100,6 +104,7 @@ class ConversationClient(BaseClient):
         self._http = value
         self._activities_client.http = value
         self._members_client.http = value
+        self._reactions_client.http = value
 
     @property
     def activities_client(self) -> ConversationActivityClient:
@@ -111,6 +116,11 @@ class ConversationClient(BaseClient):
         """Get the members client."""
         return self._members_client
 
+    @deprecated(
+        "Use the flattened activity methods on `ConversationClient` instead "
+        "(e.g. `conversations.create_activity(conversation_id, ...)`). "
+        "This grouped accessor will be removed in a future release."
+    )
     def activities(self, conversation_id: str) -> ActivityOperations:
         """Get activity operations for a conversation.
 
@@ -122,6 +132,11 @@ class ConversationClient(BaseClient):
         """
         return ActivityOperations(self, conversation_id)
 
+    @deprecated(
+        "Use the flattened member methods on `ConversationClient` instead "
+        "(e.g. `conversations.get_members(conversation_id)`). "
+        "This grouped accessor will be removed in a future release."
+    )
     def members(self, conversation_id: str) -> MemberOperations:
         """Get member operations for a conversation.
 
@@ -132,6 +147,63 @@ class ConversationClient(BaseClient):
             An operations object for managing members in the conversation.
         """
         return MemberOperations(self, conversation_id)
+
+    async def create_activity(self, conversation_id: str, activity: ActivityParams):
+        """Create an activity in a conversation."""
+        return await self._activities_client.create(conversation_id, activity)
+
+    async def update_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+        """Update an activity in a conversation."""
+        return await self._activities_client.update(conversation_id, activity_id, activity)
+
+    async def reply_to_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+        """Reply to an activity in a conversation."""
+        return await self._activities_client.reply(conversation_id, activity_id, activity)
+
+    async def delete_activity(self, conversation_id: str, activity_id: str):
+        """Delete an activity in a conversation."""
+        return await self._activities_client.delete(conversation_id, activity_id)
+
+    async def get_activity_members(self, conversation_id: str, activity_id: str):
+        """Get the members of an activity in a conversation."""
+        return await self._activities_client.get_members(conversation_id, activity_id)
+
+    async def create_targeted_activity(self, conversation_id: str, activity: ActivityParams):
+        """Create a targeted activity in a conversation."""
+        return await self._activities_client.create_targeted(conversation_id, activity)
+
+    async def update_targeted_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+        """Update a targeted activity in a conversation."""
+        return await self._activities_client.update_targeted(conversation_id, activity_id, activity)
+
+    async def delete_targeted_activity(self, conversation_id: str, activity_id: str):
+        """Delete a targeted activity in a conversation."""
+        return await self._activities_client.delete_targeted(conversation_id, activity_id)
+
+    async def get_members(self, conversation_id: str):
+        """Get the members of a conversation."""
+        return await self._members_client.get(conversation_id)
+
+    async def get_member_by_id(self, conversation_id: str, member_id: str):
+        """Get a member of a conversation by id."""
+        return await self._members_client.get_by_id(conversation_id, member_id)
+
+    async def get_paged_members(
+        self,
+        conversation_id: str,
+        page_size: Optional[int] = None,
+        continuation_token: Optional[str] = None,
+    ):
+        """Get paged members of a conversation."""
+        return await self._members_client.get_paged(conversation_id, page_size, continuation_token)
+
+    async def add_reaction(self, conversation_id: str, activity_id: str, reaction_type: MessageReactionType) -> None:
+        """Add a reaction to an activity in a conversation."""
+        return await self._reactions_client.add(conversation_id, activity_id, reaction_type)
+
+    async def delete_reaction(self, conversation_id: str, activity_id: str, reaction_type: MessageReactionType) -> None:
+        """Delete a reaction from an activity in a conversation."""
+        return await self._reactions_client.delete(conversation_id, activity_id, reaction_type)
 
     async def create(self, params: CreateConversationParams) -> ConversationResource:
         """Create a new conversation.

--- a/packages/api/src/microsoft_teams/api/clients/conversation/member.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/member.py
@@ -45,6 +45,7 @@ class ConversationMemberClient(BaseClient):
         Returns:
             List of TeamsChannelAccount objects representing the conversation members
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.get(f"{self.service_url}/v3/conversations/{conversation_id}/members")
         return [TeamsChannelAccount.model_validate(member) for member in response.json()]
 
@@ -66,6 +67,7 @@ class ConversationMemberClient(BaseClient):
             PagedMembersResult containing the members and an optional continuation token
             for fetching subsequent pages.
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         url = f"{self.service_url}/v3/conversations/{conversation_id}/pagedMembers"
         response = await self.http.get(url, params={"pageSize": page_size, "continuationToken": continuation_token})
         return PagedMembersResult.model_validate(response.json())
@@ -81,5 +83,6 @@ class ConversationMemberClient(BaseClient):
         Returns:
             TeamsChannelAccount object representing the conversation member
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.get(f"{self.service_url}/v3/conversations/{conversation_id}/members/{member_id}")
         return TeamsChannelAccount.model_validate(response.json())

--- a/packages/api/src/microsoft_teams/api/clients/reaction/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/reaction/client.py
@@ -48,6 +48,7 @@ class ReactionClient(BaseClient):
             activity_id: The id of the activity to react to.
             reaction_type: The reaction type (for example: "like", "heart", "laugh", etc.).
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         url = (
             f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}/reactions/{reaction_type}"
         )
@@ -67,6 +68,7 @@ class ReactionClient(BaseClient):
             activity_id: The id of the activity the reaction is on.
             reaction_type: The reaction type to remove (for example: "like", "heart", "laugh", etc.).
         """
+        # TODO: Will be deprecated alongside accessor in ConversationClient
         url = (
             f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}/reactions/{reaction_type}"
         )

--- a/packages/api/src/microsoft_teams/api/clients/user/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/user/client.py
@@ -3,12 +3,21 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Optional, Union
+from typing import Dict, List, Optional, Union
 
 from microsoft_teams.common.http import Client, ClientOptions
+from typing_extensions import deprecated
 
+from ...models import TokenResponse, TokenStatus
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
+from .params import (
+    ExchangeUserTokenParams,
+    GetUserAADTokenParams,
+    GetUserTokenParams,
+    GetUserTokenStatusParams,
+    SignOutUserParams,
+)
 from .token_client import UserTokenClient
 
 
@@ -28,7 +37,7 @@ class UserClient(BaseClient):
             api_client_settings: Optional API client settings.
         """
         super().__init__(options, api_client_settings)
-        self.token = UserTokenClient(self.http, self._api_client_settings)
+        self._token = UserTokenClient(self.http, self._api_client_settings)
 
     @property
     def http(self) -> Client:
@@ -39,4 +48,33 @@ class UserClient(BaseClient):
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
         self._http = value
-        self.token.http = value
+        self._token.http = value
+
+    @property
+    @deprecated(
+        "Use the flattened methods on `UserClient` instead (e.g. `users.get_token(...)`). "
+        "This grouped accessor will be removed in a future release."
+    )
+    def token(self) -> UserTokenClient:
+        """Get the user token client."""
+        return self._token
+
+    async def get_token(self, params: GetUserTokenParams) -> TokenResponse:
+        """Get a user token for the given connection."""
+        return await self._token.get(params)
+
+    async def get_aad_tokens(self, params: GetUserAADTokenParams) -> Dict[str, TokenResponse]:
+        """Get AAD tokens for the given connection and resource urls."""
+        return await self._token.get_aad(params)
+
+    async def get_token_status(self, params: GetUserTokenStatusParams) -> List[TokenStatus]:
+        """Get the token status for a user."""
+        return await self._token.get_status(params)
+
+    async def sign_out(self, params: SignOutUserParams) -> None:
+        """Sign a user out of the given connection."""
+        return await self._token.sign_out(params)
+
+    async def exchange_token(self, params: ExchangeUserTokenParams) -> TokenResponse:
+        """Exchange a user token for the given connection."""
+        return await self._token.exchange(params)

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -4,6 +4,8 @@ Licensed under the MIT License.
 """
 # pyright: basic
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from microsoft_teams.api.clients import ApiClient, ReactionClient
 from microsoft_teams.common.http import Client, ClientOptions
@@ -38,7 +40,7 @@ class TestApiClientReactionsProperty:
         client.http = new_http
 
         assert client._http is new_http
-        assert client.bots.http is new_http
+        assert client._bots.http is new_http
         assert client.conversations.http is new_http
         assert client.users.http is new_http
         assert client.teams.http is new_http
@@ -66,3 +68,33 @@ class TestApiClientReactionsProperty:
 
         assert client._reactions.http is new_http
         assert client._http is new_http
+
+
+@pytest.mark.unit
+class TestApiClientDeprecatedAccessors:
+    """The bots and reactions accessors are deprecated but still supported."""
+
+    def test_reactions_accessor_warns(self, mock_http_client):
+        client = ApiClient("https://mock.service.url", mock_http_client)
+        with pytest.warns(DeprecationWarning):
+            reactions = client.reactions
+        assert isinstance(reactions, ReactionClient)
+
+    def test_bots_accessor_warns(self, mock_http_client):
+        client = ApiClient("https://mock.service.url", mock_http_client)
+        with pytest.warns(DeprecationWarning):
+            bots = client.bots
+        assert bots.sign_in is not None
+
+    @pytest.mark.asyncio
+    async def test_deprecated_reactions_add_still_routes(self, mock_http_client):
+        client = ApiClient("https://mock.service.url", mock_http_client)
+        with pytest.warns(DeprecationWarning):
+            reactions = client.reactions
+
+        with patch.object(reactions.http, "put", new_callable=AsyncMock) as mock_put:
+            await reactions.add("conv-1", "act-1", "like")
+
+        mock_put.assert_called_once_with(
+            "https://mock.service.url/v3/conversations/conv-1/activities/act-1/reactions/like"
+        )

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -413,6 +413,7 @@ class TestConversationClientHttpClientSharing:
 
         assert client.activities_client.http == mock_http_client
         assert client.members_client.http == mock_http_client
+        assert client._reactions_client.http == mock_http_client
 
     def test_http_client_update_propagates(self, mock_http_client):
         """Test that updating HTTP client propagates to sub-clients."""
@@ -428,6 +429,7 @@ class TestConversationClientHttpClientSharing:
 
         assert client.activities_client.http == new_http_client
         assert client.members_client.http == new_http_client
+        assert client._reactions_client.http == new_http_client
 
 
 @pytest.mark.unit
@@ -471,3 +473,156 @@ class TestTargetedActivityOperations:
 
         # Should not raise an exception
         await activities.delete_targeted(activity_id)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestConversationClientFlattened:
+    """Unit tests for the flattened ConversationClient methods (conversations.create_activity, etc.)."""
+
+    async def test_create_activity(self, request_capture, mock_activity):
+        """create_activity should POST an activity."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        result = await client.create_activity("conv-1", mock_activity)
+
+        assert result is not None
+        assert result.id is not None
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "POST"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities"
+
+    async def test_update_activity(self, request_capture, mock_activity):
+        """update_activity should PUT an activity."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        result = await client.update_activity("conv-1", "act-1", mock_activity)
+
+        assert result is not None
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "PUT"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
+
+    async def test_reply_to_activity(self, request_capture, mock_activity):
+        """reply_to_activity should POST a reply with replyToId set."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        result = await client.reply_to_activity("conv-1", "act-1", mock_activity)
+
+        assert result is not None
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "POST"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
+        payload = json.loads(last_request.content)
+        assert payload["replyToId"] == "act-1"
+
+    async def test_delete_activity(self, request_capture):
+        """delete_activity should DELETE an activity."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        await client.delete_activity("conv-1", "act-1")
+
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "DELETE"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
+
+    async def test_get_activity_members(self, request_capture):
+        """get_activity_members should GET the activity members."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        result = await client.get_activity_members("conv-1", "act-1")
+
+        assert isinstance(result, list)
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "GET"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1/members"
+
+    async def test_get_members(self, request_capture):
+        """get_members should GET all conversation members."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        result = await client.get_members("conv-1")
+
+        assert isinstance(result, list)
+        assert result[0].id == "mock_member_id"
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "GET"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/members"
+
+    async def test_get_member_by_id(self, request_capture):
+        """get_member_by_id should GET a single conversation member."""
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        result = await client.get_member_by_id("conv-1", "member-1")
+
+        assert result.id == "mock_member_id"
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "GET"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/members/member-1"
+
+    async def test_get_paged_members(self, mock_http_client):
+        """get_paged_members should return a PagedMembersResult."""
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        result = await client.get_paged_members("conv-1")
+
+        assert isinstance(result, PagedMembersResult)
+        assert result.members[0].id == "mock_member_id"
+        assert result.continuation_token == "mock_continuation_token"
+
+    async def test_create_targeted_activity(self, mock_http_client, mock_activity):
+        """create_targeted_activity should return a SentActivity."""
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        result = await client.create_targeted_activity("conv-1", mock_activity)
+
+        assert result is not None
+
+    async def test_update_targeted_activity(self, mock_http_client, mock_activity):
+        """update_targeted_activity should return a SentActivity."""
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        result = await client.update_targeted_activity("conv-1", "act-1", mock_activity)
+
+        assert result is not None
+
+    async def test_delete_targeted_activity(self, mock_http_client):
+        """delete_targeted_activity should not raise."""
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        await client.delete_targeted_activity("conv-1", "act-1")
+
+    async def test_add_reaction(self, mock_http_client):
+        """add_reaction should PUT to the reactions endpoint."""
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        with patch.object(mock_http_client, "put", new_callable=AsyncMock) as mock_put:
+            await client.add_reaction("conv-1", "act-1", "like")
+
+        expected_url = "https://test.service.url/v3/conversations/conv-1/activities/act-1/reactions/like"
+        mock_put.assert_called_once_with(expected_url)
+
+    async def test_delete_reaction(self, mock_http_client):
+        """delete_reaction should DELETE from the reactions endpoint."""
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        with patch.object(mock_http_client, "delete", new_callable=AsyncMock) as mock_delete:
+            await client.delete_reaction("conv-1", "act-1", "like")
+
+        expected_url = "https://test.service.url/v3/conversations/conv-1/activities/act-1/reactions/like"
+        mock_delete.assert_called_once_with(expected_url)
+
+
+@pytest.mark.unit
+class TestConversationClientDeprecatedAccessors:
+    """The grouped activities()/members() accessors are deprecated but still supported."""
+
+    def test_activities_accessor_warns(self, mock_http_client):
+        client = ConversationClient("https://test.service.url", mock_http_client)
+        with pytest.warns(DeprecationWarning):
+            client.activities("conv-1")
+
+    def test_members_accessor_warns(self, mock_http_client):
+        client = ConversationClient("https://test.service.url", mock_http_client)
+        with pytest.warns(DeprecationWarning):
+            client.members("conv-1")

--- a/packages/api/tests/unit/test_user_client.py
+++ b/packages/api/tests/unit/test_user_client.py
@@ -251,8 +251,8 @@ class TestUserClientFlattened:
 
         response = await client.get_aad_tokens(params)
 
-        assert "https://graph.microsoft.com" in response
-        assert "https://api.botframework.com" in response
+        assert "https://graph.microsoft.com" in response.keys()
+        assert "https://api.botframework.com" in response.keys()
 
     @pytest.mark.asyncio
     async def test_get_token_status(self, mock_http_client):

--- a/packages/api/tests/unit/test_user_client.py
+++ b/packages/api/tests/unit/test_user_client.py
@@ -50,8 +50,8 @@ class TestUserClient:
 
         response = await client.token.get_aad(params)
 
-        assert "https://graph.microsoft.com" in response
-        assert "https://api.botframework.com" in response
+        assert response.get("https://graph.microsoft.com") is not None
+        assert response.get("https://api.botframework.com") is not None
 
     @pytest.mark.asyncio
     async def test_user_token_get_status(self, mock_http_client):
@@ -160,7 +160,7 @@ class TestUserClientRegionalEndpoints:
 
         response = await client.token.get_aad(params)
 
-        assert "https://graph.microsoft.com" in response
+        assert response.get("https://graph.microsoft.com") is not None
 
     @pytest.mark.asyncio
     async def test_user_token_get_status_with_regional_endpoint(self, mock_http_client):
@@ -251,8 +251,8 @@ class TestUserClientFlattened:
 
         response = await client.get_aad_tokens(params)
 
-        assert "https://graph.microsoft.com" in response.keys()
-        assert "https://api.botframework.com" in response.keys()
+        assert response.get("https://graph.microsoft.com") is not None
+        assert response.get("https://api.botframework.com") is not None
 
     @pytest.mark.asyncio
     async def test_get_token_status(self, mock_http_client):

--- a/packages/api/tests/unit/test_user_client.py
+++ b/packages/api/tests/unit/test_user_client.py
@@ -216,3 +216,97 @@ class TestUserClientRegionalEndpoints:
         assert response.token is not None
         assert response.token == "mock_exchanged_token_123"
         assert response.connection_name == "test_connection"
+
+
+@pytest.mark.unit
+class TestUserClientFlattened:
+    """Unit tests for the flattened UserClient methods (users.get_token, etc.)."""
+
+    @pytest.mark.asyncio
+    async def test_get_token(self, mock_http_client):
+        client = UserClient(mock_http_client)
+
+        params = GetUserTokenParams(
+            user_id="test_user_id",
+            connection_name="test_connection",
+            channel_id="test_channel_id",
+            code="auth_code_123",
+        )
+
+        response = await client.get_token(params)
+
+        assert response.token == "mock_access_token_123"
+        assert response.connection_name == "test_connection"
+
+    @pytest.mark.asyncio
+    async def test_get_aad_tokens(self, mock_http_client):
+        client = UserClient(mock_http_client)
+
+        params = GetUserAADTokenParams(
+            user_id="test_user_id",
+            connection_name="test_connection",
+            resource_urls=["https://graph.microsoft.com", "https://api.botframework.com"],
+            channel_id="test_channel_id",
+        )
+
+        response = await client.get_aad_tokens(params)
+
+        assert "https://graph.microsoft.com" in response
+        assert "https://api.botframework.com" in response
+
+    @pytest.mark.asyncio
+    async def test_get_token_status(self, mock_http_client):
+        client = UserClient(mock_http_client)
+
+        params = GetUserTokenStatusParams(
+            user_id="test_user_id",
+            channel_id="test_channel_id",
+            include_filter="*",
+        )
+
+        response = await client.get_token_status(params)
+
+        assert len(response) > 0
+        assert response[0].connection_name == "test_connection"
+        assert response[0].has_token is True
+
+    @pytest.mark.asyncio
+    async def test_sign_out(self, mock_http_client):
+        client = UserClient(mock_http_client)
+
+        params = SignOutUserParams(
+            user_id="test_user_id",
+            connection_name="test_connection",
+            channel_id="test_channel_id",
+        )
+
+        result = await client.sign_out(params)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_exchange_token(self, mock_http_client):
+        client = UserClient(mock_http_client)
+
+        params = ExchangeUserTokenParams(
+            user_id="test_user_id",
+            connection_name="test_connection",
+            channel_id="test_channel_id",
+            exchange_request=TokenExchangeRequest(
+                uri="https://test.resource.com",
+                token="exchange_token_123",
+            ),
+        )
+
+        response = await client.exchange_token(params)
+
+        assert response.token == "mock_exchanged_token_123"
+        assert response.connection_name == "test_connection"
+
+    def test_deprecated_token_accessor_warns(self, mock_http_client):
+        """The deprecated `token` accessor still works but emits a DeprecationWarning."""
+        client = UserClient(mock_http_client)
+
+        with pytest.warns(DeprecationWarning):
+            token_client = client.token
+
+        assert token_client.http == mock_http_client

--- a/packages/apps/src/microsoft_teams/apps/activity_sender.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_sender.py
@@ -64,20 +64,20 @@ class ActivitySender:
         activity.conversation = ref.conversation
 
         is_update = hasattr(activity, "id") and activity.id
-        activities = api.conversations.activities(ref.conversation.id)
+        conversation_id = ref.conversation.id
 
         if is_update:
             activity_id = cast(str, activity.id)
             if is_targeted:
-                res = await activities.update_targeted(activity_id, activity)
+                res = await api.conversations.update_targeted_activity(conversation_id, activity_id, activity)
             else:
-                res = await activities.update(activity_id, activity)
+                res = await api.conversations.update_activity(conversation_id, activity_id, activity)
             return SentActivity.merge(activity, res)
 
         if is_targeted:
-            res = await activities.create_targeted(activity)
+            res = await api.conversations.create_targeted_activity(conversation_id, activity)
         else:
-            res = await activities.create(activity)
+            res = await api.conversations.create_activity(conversation_id, activity)
         return SentActivity.merge(activity, res)
 
     def create_stream(self, ref: ConversationReference) -> StreamerProtocol:

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -49,7 +49,7 @@ class OauthHandlers:
                 )
 
             try:
-                token = await api.users.token.exchange(
+                token = await api.users.exchange_token(
                     ExchangeUserTokenParams(
                         connection_name=activity.value.connection_name,
                         user_id=activity.from_.id,
@@ -166,7 +166,7 @@ class OauthHandlers:
             )
 
             try:
-                token = await api.users.token.get(
+                token = await api.users.get_token(
                     GetUserTokenParams(
                         connection_name=self.default_connection_name,
                         user_id=activity.from_.id,

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -101,7 +101,7 @@ class ActivityProcessor:
         is_signed_in = False
         user_token: Optional[str] = None
         try:
-            user_token_res = await api_client.users.token.get(
+            user_token_res = await api_client.users.get_token(
                 GetUserTokenParams(
                     channel_id=activity.channel_id,
                     user_id=activity.from_.id,

--- a/packages/apps/src/microsoft_teams/apps/contexts/function_context.py
+++ b/packages/apps/src/microsoft_teams/apps/contexts/function_context.py
@@ -102,9 +102,7 @@ class FunctionContext(ClientContext, Generic[T]):
         # Validate that both the bot and user are members of the conversation.
         if self._resolved_conversation_id:
             try:
-                member = await self.api.conversations.members_client.get_by_id(
-                    self._resolved_conversation_id, self.user_id
-                )
+                member = await self.api.conversations.get_member_by_id(self._resolved_conversation_id, self.user_id)
                 if not member:
                     logger.warning(
                         f"User {self.user_id} is not a member of conversation {self._resolved_conversation_id}"

--- a/packages/apps/src/microsoft_teams/apps/http_stream.py
+++ b/packages/apps/src/microsoft_teams/apps/http_stream.py
@@ -382,9 +382,9 @@ class HttpStream(StreamerProtocol):
 
         try:
             if to_send.id and not any(e.type == "streaminfo" for e in (to_send.entities or [])):
-                res = await self._client.conversations.activities(self._ref.conversation.id).update(to_send.id, to_send)
+                res = await self._client.conversations.update_activity(self._ref.conversation.id, to_send.id, to_send)
             else:
-                res = await self._client.conversations.activities(self._ref.conversation.id).create(to_send)
+                res = await self._client.conversations.create_activity(self._ref.conversation.id, to_send)
 
             return SentActivity.merge(to_send, res)
         except HTTPStatusError as e:

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -316,7 +316,7 @@ class ActivityContext(Generic[T]):
                 user_id=self.activity.from_.id,
                 connection_name=connection_name,
             )
-            res = await self.api.users.token.get(token_params)
+            res = await self.api.users.get_token(token_params)
             return res.token
         except Exception:
             # Token not available, continue with OAuth flow
@@ -348,7 +348,7 @@ class ActivityContext(Generic[T]):
 
         # Get sign-in resource
         resource_params = GetBotSignInResourceParams(state=state)
-        resource = await self.api.bots.sign_in.get_resource(resource_params)
+        resource = await self.api._bots.sign_in.get_resource(resource_params)  # pyright: ignore[reportPrivateUsage]
 
         payload = MessageActivityInput(recipient=self.activity.from_).add_attachments(
             card_attachment(
@@ -387,7 +387,7 @@ class ActivityContext(Generic[T]):
                 user_id=self.activity.from_.id,
                 connection_name=self.connection_name,
             )
-            await self.api.users.token.sign_out(sign_out_params)
+            await self.api.users.sign_out(sign_out_params)
             self.logger.debug(f"User {self.activity.from_.id} signed out successfully.")
         except Exception as e:
             self.logger.error(f"Failed to sign out user: {e}")

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -494,12 +494,12 @@ class TestActivityContextSignIn:
 
         token_response = MagicMock()
         token_response.token = "existing-token-value"
-        ctx.api.users.token.get = AsyncMock(return_value=token_response)
+        ctx.api.users.get_token = AsyncMock(return_value=token_response)
 
         result = await ctx.sign_in()
 
         assert result == "existing-token-value"
-        ctx.api.users.token.get.assert_called_once()
+        ctx.api.users.get_token.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sign_in_sends_oauth_card_when_no_existing_token(self) -> None:
@@ -510,13 +510,13 @@ class TestActivityContextSignIn:
         mock_activity.conversation.is_group = False
 
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
-        ctx.api.users.token.get = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
 
         resource_response = MagicMock()
         resource_response.token_exchange_resource = MagicMock()
         resource_response.token_post_resource = MagicMock()
         resource_response.sign_in_link = "https://login.example.com"
-        ctx.api.bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
 
         token_state = MagicMock()
         token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
@@ -534,7 +534,7 @@ class TestActivityContextSignIn:
             result = await ctx.sign_in()
 
         assert result is None
-        ctx.api.bots.sign_in.get_resource.assert_called_once()
+        ctx.api._bots.sign_in.get_resource.assert_called_once()
         assert mock_sender.send.called
 
     @pytest.mark.asyncio
@@ -547,7 +547,7 @@ class TestActivityContextSignIn:
         mock_activity.conversation.tenant_id = "tenant-001"
 
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
-        ctx.api.users.token.get = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
 
         one_on_one = MagicMock()
         one_on_one.id = "1on1-conv-id"
@@ -557,7 +557,7 @@ class TestActivityContextSignIn:
         resource_response.token_exchange_resource = MagicMock()
         resource_response.token_post_resource = MagicMock()
         resource_response.sign_in_link = "https://login.example.com"
-        ctx.api.bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
 
         token_state = MagicMock()
         token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
@@ -591,13 +591,13 @@ class TestActivityContextSignIn:
         mock_activity.conversation.is_group = False
 
         ctx, _ = _create_activity_context(activity=mock_activity)
-        ctx.api.users.token.get = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
 
         resource_response = MagicMock()
         resource_response.token_exchange_resource = MagicMock()
         resource_response.token_post_resource = MagicMock()
         resource_response.sign_in_link = "https://login.example.com"
-        ctx.api.bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
 
         custom_options = SignInOptions(
             oauth_card_text="Custom prompt",
@@ -621,7 +621,7 @@ class TestActivityContextSignIn:
             result = await ctx.sign_in(options=custom_options)
 
         assert result is None
-        token_get_params = ctx.api.users.token.get.call_args[0][0]
+        token_get_params = ctx.api.users.get_token.call_args[0][0]
         assert token_get_params.connection_name == "custom-connection"
 
 
@@ -636,7 +636,7 @@ class TestActivityContextSignOut:
         mock_activity.from_.id = "user-success"
 
         ctx, _ = _create_activity_context(activity=mock_activity)
-        ctx.api.users.token.sign_out = AsyncMock(return_value=None)
+        ctx.api.users.sign_out = AsyncMock(return_value=None)
 
         with patch.object(ctx.logger, "debug") as mock_log_debug:
             await ctx.sign_out()
@@ -652,7 +652,7 @@ class TestActivityContextSignOut:
         mock_activity.from_.id = "user-003"
 
         ctx, _ = _create_activity_context(activity=mock_activity)
-        ctx.api.users.token.sign_out = AsyncMock(side_effect=Exception("API failure"))
+        ctx.api.users.sign_out = AsyncMock(side_effect=Exception("API failure"))
 
         with patch.object(ctx.logger, "error") as mock_log_error:
             # Should not raise

--- a/packages/apps/tests/test_activity_sender.py
+++ b/packages/apps/tests/test_activity_sender.py
@@ -52,50 +52,43 @@ class TestActivitySender:
 
     @pytest.mark.asyncio
     async def test_send_new_message_calls_create(self, sender, conversation_ref):
-        """Test that new messages (no id) use the create method."""
+        """Test that new messages (no id) use the create_activity method."""
         activity = MessageActivityInput(text="Hello")
-
-        mock_activities = MagicMock()
-        mock_activities.create = AsyncMock(return_value=self._create_sent_activity(activity))
 
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.create_activity = AsyncMock(return_value=self._create_sent_activity(activity))
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, conversation_ref)
 
-            mock_activities.create.assert_called_once_with(activity)
+            mock_api.conversations.create_activity.assert_called_once_with("conv-456", activity)
 
     @pytest.mark.asyncio
     async def test_send_existing_message_calls_update(self, sender, conversation_ref):
-        """Test that messages with an id use the update method."""
+        """Test that messages with an id use the update_activity method."""
         activity = MessageActivityInput(text="Updated message")
         activity.id = "existing-msg-id"
 
-        mock_activities = MagicMock()
-        mock_activities.update = AsyncMock(return_value=self._create_sent_activity(activity, "existing-msg-id"))
-
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.update_activity = AsyncMock(
+                return_value=self._create_sent_activity(activity, "existing-msg-id")
+            )
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, conversation_ref)
 
-            mock_activities.update.assert_called_once_with("existing-msg-id", activity)
+            mock_api.conversations.update_activity.assert_called_once_with("conv-456", "existing-msg-id", activity)
 
     @pytest.mark.asyncio
     async def test_send_sets_from_and_conversation(self, sender, conversation_ref):
         """Test that send merges activity with conversation reference."""
         activity = MessageActivityInput(text="Hello")
 
-        mock_activities = MagicMock()
-        mock_activities.create = AsyncMock(return_value=self._create_sent_activity(activity))
-
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.create_activity = AsyncMock(return_value=self._create_sent_activity(activity))
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, conversation_ref)
@@ -105,81 +98,75 @@ class TestActivitySender:
 
     @pytest.mark.asyncio
     async def test_send_targeted_message_calls_create_targeted(self, sender, group_conversation_ref):
-        """Test that targeted messages use the create_targeted method."""
+        """Test that targeted messages use the create_targeted_activity method."""
         recipient = Account(id="user-123", name="Test User", role="user")
         activity = MessageActivityInput(text="Hello").with_recipient(recipient, is_targeted=True)
 
-        mock_activities = MagicMock()
-        mock_activities.create_targeted = AsyncMock(return_value=self._create_sent_activity(activity))
-
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.create_targeted_activity = AsyncMock(
+                return_value=self._create_sent_activity(activity)
+            )
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, group_conversation_ref)
 
-            mock_activities.create_targeted.assert_called_once_with(activity)
-            mock_activities.create.assert_not_called()
+            mock_api.conversations.create_targeted_activity.assert_called_once_with("conv-789", activity)
+            mock_api.conversations.create_activity.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_non_targeted_message_does_not_call_create_targeted(self, sender, conversation_ref):
-        """Test that non-targeted messages use the regular create method."""
+        """Test that non-targeted messages use the regular create_activity method."""
         activity = MessageActivityInput(text="Hello")
-
-        mock_activities = MagicMock()
-        mock_activities.create = AsyncMock(return_value=self._create_sent_activity(activity))
 
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.create_activity = AsyncMock(return_value=self._create_sent_activity(activity))
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, conversation_ref)
 
-            mock_activities.create.assert_called_once_with(activity)
-            mock_activities.create_targeted.assert_not_called()
+            mock_api.conversations.create_activity.assert_called_once_with("conv-456", activity)
+            mock_api.conversations.create_targeted_activity.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_targeted_message_calls_update_targeted(self, sender, group_conversation_ref):
-        """Test that targeted message updates use the update_targeted method."""
+        """Test that targeted message updates use the update_targeted_activity method."""
         activity = MessageActivityInput(text="Updated targeted message")
         activity.recipient = Account(id="user-123", name="Test User", role="user", is_targeted=True)
         activity.id = "existing-msg-id"
 
-        mock_activities = MagicMock()
-        mock_activities.update_targeted = AsyncMock(
-            return_value=self._create_sent_activity(activity, "existing-msg-id")
-        )
-
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.update_targeted_activity = AsyncMock(
+                return_value=self._create_sent_activity(activity, "existing-msg-id")
+            )
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, group_conversation_ref)
 
-            mock_activities.update_targeted.assert_called_once_with("existing-msg-id", activity)
-            mock_activities.update.assert_not_called()
+            mock_api.conversations.update_targeted_activity.assert_called_once_with(
+                "conv-789", "existing-msg-id", activity
+            )
+            mock_api.conversations.update_activity.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_non_targeted_message_calls_update(self, sender, conversation_ref):
-        """Test that non-targeted message updates use the regular update method."""
+        """Test that non-targeted message updates use the regular update_activity method."""
         activity = MessageActivityInput(text="Updated message")
         activity.id = "existing-msg-id"
 
-        mock_activities = MagicMock()
-        mock_activities.update = AsyncMock(return_value=self._create_sent_activity(activity, "existing-msg-id"))
-
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.update_activity = AsyncMock(
+                return_value=self._create_sent_activity(activity, "existing-msg-id")
+            )
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, conversation_ref)
 
-            mock_activities.update.assert_called_once_with("existing-msg-id", activity)
-            mock_activities.update_targeted.assert_not_called()
+            mock_api.conversations.update_activity.assert_called_once_with("conv-456", "existing-msg-id", activity)
+            mock_api.conversations.update_targeted_activity.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_targeted_in_personal_chat_raises(self, sender, conversation_ref):
@@ -198,14 +185,13 @@ class TestActivitySender:
             Account(id="user-1", name="User"), is_targeted=True
         )
 
-        mock_activities = MagicMock()
-        mock_activities.create_targeted = AsyncMock(return_value=self._create_sent_activity(activity))
-
         with patch("microsoft_teams.apps.activity_sender.ApiClient") as mock_api_client:
             mock_api = MagicMock()
-            mock_api.conversations.activities.return_value = mock_activities
+            mock_api.conversations.create_targeted_activity = AsyncMock(
+                return_value=self._create_sent_activity(activity)
+            )
             mock_api_client.return_value = mock_api
 
             await sender.send(activity, group_conversation_ref)
 
-            mock_activities.create_targeted.assert_called_once()
+            mock_api.conversations.create_targeted_activity.assert_called_once()

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -55,8 +55,8 @@ class TestOauthHandlers:
         context = MagicMock(spec=ActivityContext)
         context.logger = MagicMock()
         context.api = MagicMock()
-        context.api.users.token.exchange = AsyncMock()
-        context.api.users.token.get = AsyncMock()
+        context.api.users.exchange_token = AsyncMock()
+        context.api.users.get_token = AsyncMock()
         context.next = AsyncMock()
         return context
 
@@ -113,13 +113,13 @@ class TestOauthHandlers:
     ):
         """Test successful token exchange."""
         mock_context.activity = token_exchange_activity
-        mock_context.api.users.token.exchange.return_value = mock_token_response
+        mock_context.api.users.exchange_token.return_value = mock_token_response
 
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
         # Verify API call
-        mock_context.api.users.token.exchange.assert_called_once()
-        call_args = mock_context.api.users.token.exchange.call_args[0][0]
+        mock_context.api.users.exchange_token.assert_called_once()
+        call_args = mock_context.api.users.exchange_token.call_args[0][0]
         assert isinstance(call_args, ExchangeUserTokenParams)
         assert call_args.connection_name == "test-connection"
         assert call_args.user_id == "user-123"
@@ -144,12 +144,12 @@ class TestOauthHandlers:
         """Test token exchange with different connection name."""
         token_exchange_activity.value.connection_name = "different-connection"
         mock_context.activity = token_exchange_activity
-        mock_context.api.users.token.exchange.return_value = mock_token_response
+        mock_context.api.users.exchange_token.return_value = mock_token_response
 
         await oauth_handlers.sign_in_token_exchange(mock_context)
 
         # Exchange still succeeds despite connection name mismatch
-        mock_context.api.users.token.exchange.assert_called_once()
+        mock_context.api.users.exchange_token.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sign_in_token_exchange_http_error_404(self, oauth_handlers, mock_context, token_exchange_activity):
@@ -162,7 +162,7 @@ class TestOauthHandlers:
         mock_response.status_code = 404
         http_error = HTTPStatusError("Not found", request=mock_request, response=mock_response)
 
-        mock_context.api.users.token.exchange.side_effect = http_error
+        mock_context.api.users.exchange_token.side_effect = http_error
 
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
@@ -186,7 +186,7 @@ class TestOauthHandlers:
         mock_response.status_code = 500
         http_error = HTTPStatusError("Server error", request=mock_request, response=mock_response)
 
-        mock_context.api.users.token.exchange.side_effect = http_error
+        mock_context.api.users.exchange_token.side_effect = http_error
 
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
@@ -206,7 +206,7 @@ class TestOauthHandlers:
         """Test token exchange with generic exception."""
         mock_context.activity = token_exchange_activity
         generic_error = ValueError("Generic error")
-        mock_context.api.users.token.exchange.side_effect = generic_error
+        mock_context.api.users.exchange_token.side_effect = generic_error
 
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
@@ -226,13 +226,13 @@ class TestOauthHandlers:
     ):
         """Test successful state verification."""
         mock_context.activity = verify_state_activity
-        mock_context.api.users.token.get.return_value = mock_token_response
+        mock_context.api.users.get_token.return_value = mock_token_response
 
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 
         # Verify API call
-        mock_context.api.users.token.get.assert_called_once()
-        call_args = mock_context.api.users.token.get.call_args[0][0]
+        mock_context.api.users.get_token.assert_called_once()
+        call_args = mock_context.api.users.get_token.call_args[0][0]
         assert isinstance(call_args, GetUserTokenParams)
         assert call_args.connection_name == "test-connection"
         assert call_args.user_id == "user-123"
@@ -259,7 +259,7 @@ class TestOauthHandlers:
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 
         # Verify no API call
-        mock_context.api.users.token.get.assert_not_called()
+        mock_context.api.users.get_token.assert_not_called()
 
         # Verify 404 response
         assert isinstance(result, InvokeResponse) and result.body is None
@@ -279,7 +279,7 @@ class TestOauthHandlers:
         mock_response.status_code = 500
         http_error = HTTPStatusError("Server error", request=mock_request, response=mock_response)
 
-        mock_context.api.users.token.get.side_effect = http_error
+        mock_context.api.users.get_token.side_effect = http_error
 
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 
@@ -303,7 +303,7 @@ class TestOauthHandlers:
         mock_response.status_code = 404
         http_error = HTTPStatusError("Not found", request=mock_request, response=mock_response)
 
-        mock_context.api.users.token.get.side_effect = http_error
+        mock_context.api.users.get_token.side_effect = http_error
 
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 
@@ -316,7 +316,7 @@ class TestOauthHandlers:
         """Test state verification with generic exception."""
         mock_context.activity = verify_state_activity
         generic_error = ValueError("Generic error")
-        mock_context.api.users.token.get.side_effect = generic_error
+        mock_context.api.users.get_token.side_effect = generic_error
 
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -289,11 +289,11 @@ class TestActivityProcessor:
         mock_token.service_url = "https://service.url"
         mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
 
-        # Patch ApiClient so users.token.get returns a successful response
+        # Patch ApiClient so users.get_token returns a successful response
         token_response = MagicMock()
         token_response.token = "user-jwt-token"
         mock_api_client = MagicMock()
-        mock_api_client.users.token.get = AsyncMock(return_value=token_response)
+        mock_api_client.users.get_token = AsyncMock(return_value=token_response)
 
         activity_processor.router.select_handlers = MagicMock(return_value=[])
         activity_processor.event_manager = MagicMock()
@@ -303,7 +303,7 @@ class TestActivityProcessor:
         with patch("microsoft_teams.apps.app_process.ApiClient", return_value=mock_api_client):
             await activity_processor.process_activity([], mock_activity_event)
 
-        mock_api_client.users.token.get.assert_called_once()
+        mock_api_client.users.get_token.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_process_activity_raises_when_event_manager_missing(self, activity_processor):

--- a/packages/apps/tests/test_function_context.py
+++ b/packages/apps/tests/test_function_context.py
@@ -25,7 +25,7 @@ class TestFunctionContextSend:
         api.service_url = "https://test.service.url"
         mock_conversations = MagicMock()
         mock_conversations.create = AsyncMock(return_value=MagicMock(id="new-conv"))
-        mock_conversations.members_client.get_by_id = AsyncMock(return_value=True)
+        mock_conversations.get_member_by_id = AsyncMock(return_value=True)
 
         api.conversations = mock_conversations
         return api

--- a/packages/apps/tests/test_http_stream.py
+++ b/packages/apps/tests/test_http_stream.py
@@ -39,20 +39,18 @@ class TestHttpStream:
     def mock_api_client(self):
         client = MagicMock(spec=ApiClient)
 
-        mock_activities = MagicMock()
         mock_conversations = MagicMock()
-        mock_conversations.activities.return_value = mock_activities
         client.conversations = mock_conversations
 
         client.send_call_count = 0
         client.sent_activities = []
 
-        async def mock_send(activity):
+        async def mock_send(conversation_id, activity):
             client.send_call_count += 1
             client.sent_activities.append(activity)
             return SentActivity(id=f"activity-{client.send_call_count}", activity_params=activity)
 
-        client.conversations.activities().create = mock_send
+        client.conversations.create_activity = mock_send
 
         return client
 
@@ -113,14 +111,14 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_send_with_timeout(activity):
+            async def mock_send_with_timeout(conversation_id, activity):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:
                     raise TimeoutError("Operation timed out")
                 return SentActivity(id=f"success-after-timeout-{call_count}", activity_params=activity)
 
-            mock_api_client.conversations.activities().create = mock_send_with_timeout
+            mock_api_client.conversations.create_activity = mock_send_with_timeout
             stream = HttpStream(mock_api_client, conversation_reference)
 
             stream.emit("Test message with timeout")
@@ -140,12 +138,12 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_send_all_timeout(activity):
+            async def mock_send_all_timeout(conversation_id, activity):
                 nonlocal call_count
                 call_count += 1
                 raise TimeoutError("All operations timed out")
 
-            mock_api_client.conversations.activities().create = mock_send_all_timeout
+            mock_api_client.conversations.create_activity = mock_send_all_timeout
             stream = HttpStream(mock_api_client, conversation_reference)
 
             stream.emit("Test message with all timeouts")
@@ -206,7 +204,7 @@ class TestHttpStream:
         loop = asyncio.get_running_loop()
         patcher, scheduled = patch_loop_call_later(loop)
 
-        async def mock_send(activity):
+        async def mock_send(conversation_id, activity):
             nonlocal concurrent_entries, max_concurrent_entries
             async with lock:
                 concurrent_entries += 1
@@ -216,7 +214,7 @@ class TestHttpStream:
                 concurrent_entries -= 1
             return activity
 
-        mock_api_client.conversations.activities().create = mock_send
+        mock_api_client.conversations.create_activity = mock_send
 
         with patcher:
             stream = HttpStream(mock_api_client, conversation_reference)
@@ -236,14 +234,14 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_send_403(activity):
+            async def mock_send_403(conversation_id, activity):
                 raise HTTPStatusError(
                     "Forbidden",
                     request=Request("POST", "https://example.com"),
                     response=Response(403, json={"error": {"message": "Content stream was canceled by user"}}),
                 )
 
-            mock_api_client.conversations.activities().create = mock_send_403
+            mock_api_client.conversations.create_activity = mock_send_403
             stream = HttpStream(mock_api_client, conversation_reference)
 
             stream.emit("Test message")
@@ -258,14 +256,14 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_send_403(activity):
+            async def mock_send_403(conversation_id, activity):
                 raise HTTPStatusError(
                     "Forbidden",
                     request=Request("POST", "https://example.com"),
                     response=Response(403, json={"error": {"message": "Content stream was canceled by user"}}),
                 )
 
-            mock_api_client.conversations.activities().create = mock_send_403
+            mock_api_client.conversations.create_activity = mock_send_403
             stream = HttpStream(mock_api_client, conversation_reference)
 
             stream.emit("First message")
@@ -295,7 +293,7 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_send_then_403(activity):
+            async def mock_send_then_403(conversation_id, activity):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:
@@ -306,7 +304,7 @@ class TestHttpStream:
                     response=Response(403, json={"error": {"message": "Content stream was canceled by user"}}),
                 )
 
-            mock_api_client.conversations.activities().create = mock_send_then_403
+            mock_api_client.conversations.create_activity = mock_send_then_403
             stream = HttpStream(mock_api_client, conversation_reference)
 
             # First emit succeeds
@@ -342,14 +340,14 @@ class TestHttpStream:
     )
     @pytest.mark.asyncio
     async def test_send_maps_403_message_to_error(self, mock_api_client, conversation_reference, message, expected):
-        async def mock_send_403(activity):
+        async def mock_send_403(conversation_id, activity):
             raise HTTPStatusError(
                 "Forbidden",
                 request=Request("POST", "https://example.com"),
                 response=Response(403, json={"error": {"message": message}}),
             )
 
-        mock_api_client.conversations.activities().create = mock_send_403
+        mock_api_client.conversations.create_activity = mock_send_403
         stream = HttpStream(mock_api_client, conversation_reference)
 
         with pytest.raises(expected) as exc_info:
@@ -361,14 +359,14 @@ class TestHttpStream:
     async def test_send_403_with_empty_body_raises_stream_error(self, mock_api_client, conversation_reference):
         """A 403 with an empty/non-JSON body is treated as an unknown stream error instead of crashing."""
 
-        async def mock_send_403(activity):
+        async def mock_send_403(conversation_id, activity):
             raise HTTPStatusError(
                 "Forbidden",
                 request=Request("POST", "https://example.com"),
                 response=Response(403),
             )
 
-        mock_api_client.conversations.activities().create = mock_send_403
+        mock_api_client.conversations.create_activity = mock_send_403
         stream = HttpStream(mock_api_client, conversation_reference)
 
         with pytest.raises(TerminalStreamError):
@@ -386,7 +384,7 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_create(activity):
+            async def mock_create(conversation_id, activity):
                 nonlocal create_calls
                 create_calls += 1
                 if create_calls == 2:
@@ -401,7 +399,7 @@ class TestHttpStream:
                     )
                 return SentActivity(id="stream-1", activity_params=activity)
 
-            async def mock_update(activity_id, activity):
+            async def mock_update(conversation_id, activity_id, activity):
                 updates.append(
                     {
                         "id": activity_id,
@@ -414,8 +412,8 @@ class TestHttpStream:
                 )
                 return SentActivity(id=activity_id, activity_params=activity)
 
-            mock_api_client.conversations.activities().create = mock_create
-            mock_api_client.conversations.activities().update = mock_update
+            mock_api_client.conversations.create_activity = mock_create
+            mock_api_client.conversations.update_activity = mock_update
             stream = HttpStream(mock_api_client, conversation_reference)
 
             stream.emit("Final answer")
@@ -445,7 +443,7 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
         with patcher:
 
-            async def mock_create(activity):
+            async def mock_create(conversation_id, activity):
                 nonlocal create_calls
                 create_calls += 1
                 if create_calls == 2:
@@ -459,7 +457,7 @@ class TestHttpStream:
                     )
                 return SentActivity(id="stream-1", activity_params=activity)
 
-            async def mock_update(activity_id, activity):
+            async def mock_update(conversation_id, activity_id, activity):
                 updates.append(
                     {
                         "id": activity_id,
@@ -471,8 +469,8 @@ class TestHttpStream:
                 )
                 return SentActivity(id=activity_id, activity_params=activity)
 
-            mock_api_client.conversations.activities().create = mock_create
-            mock_api_client.conversations.activities().update = mock_update
+            mock_api_client.conversations.create_activity = mock_create
+            mock_api_client.conversations.update_activity = mock_update
             stream = HttpStream(mock_api_client, conversation_reference)
 
             # First chunk streams fine (create #1 -> id assigned).
@@ -511,9 +509,10 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
 
         update_call_count = 0
-        original_create = mock_api_client.conversations.activities().create
+        original_create = mock_api_client.conversations.create_activity
 
-        async def mock_send(activity):
+        async def mock_send(*args):
+            activity = args[-1]
             nonlocal update_call_count
             if (
                 hasattr(activity, "id")
@@ -522,10 +521,10 @@ class TestHttpStream:
             ):
                 update_call_count += 1
                 return SentActivity(id=activity.id, activity_params=activity)
-            return await original_create(activity)
+            return await original_create(*args)
 
-        mock_api_client.conversations.activities().create = mock_send
-        mock_api_client.conversations.activities().update = mock_send
+        mock_api_client.conversations.create_activity = mock_send
+        mock_api_client.conversations.update_activity = mock_send
 
         with patcher:
             stream = HttpStream(mock_api_client, conversation_reference)
@@ -561,9 +560,10 @@ class TestHttpStream:
         patcher, scheduled = patch_loop_call_later(loop)
 
         update_call_count = 0
-        original_create = mock_api_client.conversations.activities().create
+        original_create = mock_api_client.conversations.create_activity
 
-        async def mock_send(activity):
+        async def mock_send(*args):
+            activity = args[-1]
             nonlocal update_call_count
             if (
                 hasattr(activity, "id")
@@ -572,10 +572,10 @@ class TestHttpStream:
             ):
                 update_call_count += 1
                 return SentActivity(id=activity.id, activity_params=activity)
-            return await original_create(activity)
+            return await original_create(*args)
 
-        mock_api_client.conversations.activities().create = mock_send
-        mock_api_client.conversations.activities().update = mock_send
+        mock_api_client.conversations.create_activity = mock_send
+        mock_api_client.conversations.update_activity = mock_send
 
         with patcher:
             stream = HttpStream(mock_api_client, conversation_reference)


### PR DESCRIPTION
Port of microsoft/teams.ts#634. Promotes grouped sub-client methods onto their parent clients so common calls drop from 3 hops to 2. Additive and backward compatible: the existing chained accessors remain as deprecated aliases.