### PR TITLE
docs(samples): add Tab Web README with npm CFS proxy note

### DIFF
--- a/examples/tab/Web/README.md
+++ b/examples/tab/Web/README.md
@@ -1,0 +1,14 @@
+# Tab Web frontend
+
+The React/Vite frontend for the Tab example. The Python bot serves the built assets.
+
+## Build
+
+```bash
+npm install
+npm run build
+```
+
+> **Microsoft-managed devices:** direct access to `registry.npmjs.org` is blocked, so `npm install` may fail. Your machine should already default to the Central Feed Services (CFS) proxy; if not, follow the setup instructions at [aka.ms/CFS](https://aka.ms/CFS). External contributors are unaffected.
+
+> This sample depends on `@microsoft/teams.*` packages. On a managed device, a newly published version may be held in CFS for ~7 days before it can be installed, so `npm install` can fail to resolve a just-released version until the quarantine clears.

--- a/examples/tab/Web/README.md
+++ b/examples/tab/Web/README.md
@@ -11,4 +11,4 @@ npm run build
 
 > **Microsoft-managed devices:** direct access to `registry.npmjs.org` is blocked, so `npm install` may fail. Your machine should already default to the Central Feed Services (CFS) proxy; if not, follow the setup instructions at [aka.ms/CFS](https://aka.ms/CFS). External contributors are unaffected.
 
-> This sample depends on `@microsoft/teams.*` packages. On a managed device, a newly published version may be held in CFS for ~7 days before it can be installed, so `npm install` can fail to resolve a just-released version until the quarantine clears.
+> This sample depends on `@microsoft/teams.*` packages. On a managed device, a newly published version may be held in CFS for a short quarantine period before it can be installed, so `npm install` can fail to resolve a just-released version until the quarantine clears.


### PR DESCRIPTION
## What

Adds `examples/tab/Web/README.md` (the Tab example Web frontend had no README), documenting the build and the npm CFS note.

## Why

The Tab Web frontend uses `npm install`, which is blocked on Microsoft-managed devices. The Python SDK release build is unaffected (PyPI) — this is a dev-time sample note.

## Notes

- Links to [aka.ms/CFS](https://aka.ms/CFS); external contributors unaffected.
- No internal feed URL committed.
