### PR TITLE
Add App info to ChannelData

### DIFF
--- a/packages/api/src/microsoft_teams/api/models/channel_data/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/__init__.py
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from .app_info import AppInfo
 from .channel_data import ChannelData
 from .channel_info import ChannelInfo
 from .feedback_loop import FeedbackLoop
@@ -13,6 +14,7 @@ from .tenant_info import TenantInfo
 
 __all__ = [
     "ChannelInfo",
+    "AppInfo",
     "NotificationInfo",
     "ChannelDataSettings",
     "TeamInfo",

--- a/packages/api/src/microsoft_teams/api/models/channel_data/app_info.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/app_info.py
@@ -1,0 +1,15 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from ..custom_base_model import CustomBaseModel
+
+
+class AppInfo(CustomBaseModel):
+    """
+    Describes an app
+    """
+
+    id: str
+    "Unique identifier representing an app"

--- a/packages/api/src/microsoft_teams/api/models/channel_data/app_info.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/app_info.py
@@ -3,6 +3,8 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from typing import Optional
+
 from ..custom_base_model import CustomBaseModel
 
 
@@ -13,3 +15,6 @@ class AppInfo(CustomBaseModel):
 
     id: str
     "Unique identifier representing an app"
+
+    version: Optional[str] = None
+    "The version of the app"

--- a/packages/api/src/microsoft_teams/api/models/channel_data/channel_data.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/channel_data.py
@@ -9,6 +9,7 @@ from pydantic import model_validator
 
 from ..custom_base_model import CustomBaseModel
 from ..meetings import MeetingInfo
+from .app_info import AppInfo
 from .channel_info import ChannelInfo
 from .feedback_loop import FeedbackLoop
 from .notification_info import NotificationInfo
@@ -24,6 +25,9 @@ class ChannelData(CustomBaseModel):
 
     channel: Optional[ChannelInfo] = None
     "Information about the channel in which the message was sent."
+
+    app: Optional[AppInfo] = None
+    "Information about the app that sent the message."
 
     event_type: Optional[str] = None
     "Type of event."


### PR DESCRIPTION
This pull request adds support for representing app information in the Microsoft Teams channel data models. The main changes introduce a new `AppInfo` model and integrate it into the `ChannelData` model, allowing the API to capture details about the app that sent a message.
**New model addition:**

* Added a new `AppInfo` model in `app_info.py` to describe an app, including its unique identifier and version.
* Updated `ChannelData` to include an optional `app` field of type `AppInfo`, representing information about the app that sent the message.