### PR TITLE
Remove typed extras from message activity input

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/message/message.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message.py
@@ -48,9 +48,6 @@ class _MessageBase(CustomBaseModel):
     text: Optional[str] = None
     """The text content of the message."""
 
-    summary: Optional[str] = None
-    """The text to display if the channel cannot render cards."""
-
     text_format: Optional[TextFormat] = None
     """Format of text fields. Default: markdown. Possible values: 'markdown', 'plain', 'xml', 'extendedmarkdown'."""
 
@@ -63,18 +60,21 @@ class _MessageBase(CustomBaseModel):
     suggested_actions: Optional[SuggestedActions] = None
     """The suggested actions for the activity."""
 
-    delivery_mode: Optional[DeliveryMode] = None
-    """A delivery hint to signal to the recipient alternate delivery paths for the activity."""
-
-    value: Optional[Any] = None
-    """A value that is associated with the activity."""
-
 
 class MessageActivity(_MessageBase, ActivityBase):
     """Output model for received message activities with required fields and read-only properties."""
 
     text: str = ""  # pyright: ignore [reportGeneralTypeIssues, reportIncompatibleVariableOverride]
     """The text content of the message."""
+
+    summary: Optional[str] = None
+    """The text to display if the channel cannot render cards."""
+
+    delivery_mode: Optional[DeliveryMode] = None
+    """A delivery hint to signal to the recipient alternate delivery paths for the activity."""
+
+    value: Optional[Any] = None
+    """A value that is associated with the activity."""
 
     def get_quoted_messages(self) -> list[QuotedReplyEntity]:
         """
@@ -154,19 +154,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
         self.text = text
         return self
 
-    def with_summary(self, summary: str) -> Self:
-        """
-        Set the text to display if the channel cannot render cards.
-
-        Args:
-            summary: Summary text
-
-        Returns:
-            Self for method chaining
-        """
-        self.summary = summary
-        return self
-
     def with_text_format(self, text_format: TextFormat) -> Self:
         """
         Set the format of text fields.
@@ -204,19 +191,6 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
             Self for method chaining
         """
         self.suggested_actions = suggested_actions
-        return self
-
-    def with_delivery_mode(self, delivery_mode: DeliveryMode) -> Self:
-        """
-        Set the delivery mode for the activity.
-
-        Args:
-            delivery_mode: Delivery mode (normal, notification)
-
-        Returns:
-            Self for method chaining
-        """
-        self.delivery_mode = delivery_mode
         return self
 
     def add_text(self, text: str) -> Self:

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 # pyright: basic
 
 from datetime import datetime
-from typing import cast
+from typing import Any, cast
 
 from microsoft_teams.api.activities import ActivityTypeAdapter
 from microsoft_teams.api.activities.message import (
@@ -393,14 +393,29 @@ class TestMessageActivity:
         card = AdaptiveCard()
         activity.add_card(card)
 
-        # Set properties
-        activity.delivery_mode = "notification"
-
         # Verify final state
         assert activity.text and activity.text.find("Meeting with <at>Alice</at> and <at>Bob</at> scheduled.") >= 0
         assert activity.entities and len(activity.entities) == 2  # Two mentions
         assert activity.attachments and len(activity.attachments) == 1
-        assert activity.delivery_mode == "notification"
+
+    def test_message_activity_input_removed_fields_serialize_as_extras(self):
+        """Test removed input fields can still be provided as serializable extras"""
+        extras: dict[str, Any] = {
+            "summary": "Fallback text",
+            "value": {"custom": "data"},
+            "deliveryMode": "notification",
+        }
+        activity = MessageActivityInput(text="Hello", **extras)
+
+        assert "summary" not in MessageActivityInput.model_fields
+        assert "value" not in MessageActivityInput.model_fields
+        assert "delivery_mode" not in MessageActivityInput.model_fields
+
+        data = activity.model_dump(by_alias=True, exclude_none=True)
+
+        assert data["summary"] == "Fallback text"
+        assert data["value"] == {"custom": "data"}
+        assert data["deliveryMode"] == "notification"
 
     def test_is_recipient_mentioned_no_entities_received(self):
         """Test MessageActivity.is_recipient_mentioned when no entities exist"""
@@ -651,9 +666,7 @@ class TestMessageUpdateActivity:
 
     def test_message_update_with_attachments_from_json(self):
         """Test that inbound messageUpdate with attachments parses them as Attachment objects."""
-        payload = self._make_message_update_payload(
-            attachments=[{"contentType": "text/html", "content": "hey\n\n"}]
-        )
+        payload = self._make_message_update_payload(attachments=[{"contentType": "text/html", "content": "hey\n\n"}])
 
         activity = ActivityTypeAdapter.validate_python(payload)
 


### PR DESCRIPTION
## Summary
- Remove `summary`, `value`, and `delivery_mode` from `MessageActivityInput`'s typed field surface
- Keep those fields typed on received `MessageActivity`
- Add coverage showing `MessageActivityInput` still accepts constructor extras and serializes `summary`, `value`, and `deliveryMode` correctly

## Validation
- `uv run poe check`
- `uv run pyright`
- `uv run pytest packages -q`
- `uv run pytest packages/api/tests/unit/test_message_activities.py -q`