### PR TITLE
Send OAuth/SSO sign-in cards natively in group chats & channels (targeted); drop 1:1 fallback

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -59,6 +59,8 @@ class OauthHandlers:
                         ),
                     )
                 )
+                ctx.is_signed_in = True
+                ctx.user_token = token.token
                 self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
                 return None
             except Exception as e:
@@ -174,6 +176,8 @@ class OauthHandlers:
                         code=activity.value.state,
                     )
                 )
+                ctx.is_signed_in = True
+                ctx.user_token = token.token
                 self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
                 logger.debug(
                     f"Sign-in state verified for user {activity.from_.id} in conversation {activity.conversation.id}"

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -18,7 +18,6 @@ from microsoft_teams.api import (
     CardAction,
     CardActionType,
     ConversationReference,
-    CreateConversationParams,
     GetBotSignInResourceParams,
     GetUserTokenParams,
     JsonWebToken,
@@ -329,20 +328,6 @@ class ActivityContext(Generic[T]):
             ms_app_id=self.app_id,
         )
 
-        # Check if this is a group conversation
-        # if it's a group conversation, then we create a 1:1 conversation with the user
-        # and send the OAuth card there since group oauth currently isn't released.
-        conversation_id = self.conversation_ref.conversation.id
-        if self.activity.conversation.is_group:
-            one_on_one_conversation = await self.api.conversations.create(
-                CreateConversationParams(
-                    tenant_id=self.activity.conversation.tenant_id,
-                    members=[self.activity.from_],
-                )
-            )
-            conversation_id = one_on_one_conversation.id
-            await self.send(MessageActivityInput(text=oauth_card_text))
-
         # Encode state
         state = base64.b64encode(json.dumps(token_exchange_state.model_dump()).encode()).decode()
 
@@ -350,13 +335,25 @@ class ActivityContext(Generic[T]):
         resource_params = GetBotSignInResourceParams(state=state)
         resource = await self.api._bots.sign_in.get_resource(resource_params)  # pyright: ignore[reportPrivateUsage]
 
-        payload = MessageActivityInput(recipient=self.activity.from_).add_attachments(
+        # In group conversations (group chats and channels) the OAuth card is sent as a
+        # targeted message so it is visible only to the requesting user rather than the
+        # whole conversation. Channels cannot perform the silent SSO token exchange, so
+        # the token exchange resource is omitted there to render the sign-in button
+        # (OAuth card flow) instead of attempting an exchange that would fail.
+        is_group = self.activity.conversation.is_group is True
+        is_channel = self.activity.conversation.conversation_type == "channel"
+
+        recipient = self.activity.from_.model_copy()
+        if is_group:
+            recipient.is_targeted = True
+
+        payload = MessageActivityInput(recipient=recipient).add_attachments(
             card_attachment(
                 attachment=OAuthCardAttachment(
                     content=OAuthCard(
                         text=oauth_card_text,
                         connection_name=connection_name,
-                        token_exchange_resource=resource.token_exchange_resource,
+                        token_exchange_resource=None if is_channel else resource.token_exchange_resource,
                         token_post_resource=resource.token_post_resource,
                         buttons=[
                             CardAction(
@@ -370,7 +367,6 @@ class ActivityContext(Generic[T]):
             )
         )
 
-        self.conversation_ref.conversation.id = conversation_id
         await self.send(payload, self.conversation_ref)
 
         return None

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -536,22 +536,24 @@ class TestActivityContextSignIn:
         assert result is None
         ctx.api._bots.sign_in.get_resource.assert_called_once()
         assert mock_sender.send.called
+        # 1:1 (personal) sign-in cards are never targeted.
+        sent_payload = mock_sender.send.call_args.args[0]
+        assert sent_payload.recipient is not None
+        assert sent_payload.recipient.is_targeted is not True
 
     @pytest.mark.asyncio
-    async def test_sign_in_creates_one_on_one_conversation_for_group_chat(self) -> None:
-        """For group conversations, sign_in creates a 1:1 conversation before sending the OAuth card."""
+    async def test_sign_in_group_chat_sends_targeted_card(self) -> None:
+        """In a group chat, sign_in sends the OAuth card as a targeted message directly in
+        the conversation (no 1:1 fallback) and keeps the token exchange resource for SSO."""
         mock_activity = MagicMock()
         mock_activity.channel_id = "msteams"
         mock_activity.from_ = Account(id="user-001")
         mock_activity.conversation.is_group = True
-        mock_activity.conversation.tenant_id = "tenant-001"
+        mock_activity.conversation.conversation_type = "groupChat"
 
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
         ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
-
-        one_on_one = MagicMock()
-        one_on_one.id = "1on1-conv-id"
-        ctx.api.conversations.create = AsyncMock(return_value=one_on_one)
+        ctx.api.conversations.create = AsyncMock()
 
         resource_response = MagicMock()
         resource_response.token_exchange_resource = MagicMock()
@@ -566,19 +568,68 @@ class TestActivityContextSignIn:
                 "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
                 return_value=token_state,
             ),
-            patch("microsoft_teams.apps.routing.activity_context.CreateConversationParams"),
             patch("microsoft_teams.apps.routing.activity_context.card_attachment"),
             patch("microsoft_teams.apps.routing.activity_context.OAuthCardAttachment"),
-            patch("microsoft_teams.apps.routing.activity_context.OAuthCard"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCard") as mock_oauth_card,
             patch("microsoft_teams.apps.routing.activity_context.CardAction"),
             patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
         ):
             result = await ctx.sign_in()
 
         assert result is None
-        ctx.api.conversations.create.assert_called_once()
-        # one greeting message before the OAuth card, plus the OAuth card itself
-        assert mock_sender.send.call_count >= 2
+        # No 1:1 fallback conversation is created.
+        ctx.api.conversations.create.assert_not_called()
+        # A single OAuth card is sent, targeted to the requesting user.
+        assert mock_sender.send.call_count == 1
+        sent_payload = mock_sender.send.call_args.args[0]
+        assert sent_payload.recipient is not None
+        assert sent_payload.recipient.is_targeted is True
+        # SSO token exchange remains available in group chats.
+        assert mock_oauth_card.call_args.kwargs["token_exchange_resource"] is resource_response.token_exchange_resource
+
+    @pytest.mark.asyncio
+    async def test_sign_in_channel_targets_and_omits_token_exchange(self) -> None:
+        """In a channel, sign_in sends a targeted OAuth card and omits the token exchange
+        resource (channels can't do silent SSO) so Teams renders the sign-in button."""
+        mock_activity = MagicMock()
+        mock_activity.channel_id = "msteams"
+        mock_activity.from_ = Account(id="user-001")
+        mock_activity.conversation.is_group = True
+        mock_activity.conversation.conversation_type = "channel"
+
+        ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.conversations.create = AsyncMock()
+
+        resource_response = MagicMock()
+        resource_response.token_exchange_resource = MagicMock()
+        resource_response.token_post_resource = MagicMock()
+        resource_response.sign_in_link = "https://login.example.com"
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.card_attachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCardAttachment"),
+            patch("microsoft_teams.apps.routing.activity_context.OAuthCard") as mock_oauth_card,
+            patch("microsoft_teams.apps.routing.activity_context.CardAction"),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+        ):
+            result = await ctx.sign_in()
+
+        assert result is None
+        ctx.api.conversations.create.assert_not_called()
+        assert mock_sender.send.call_count == 1
+        sent_payload = mock_sender.send.call_args.args[0]
+        assert sent_payload.recipient is not None
+        assert sent_payload.recipient.is_targeted is True
+        # SSO isn't possible in channels, so the token exchange resource is omitted.
+        assert mock_oauth_card.call_args.kwargs["token_exchange_resource"] is None
 
     @pytest.mark.asyncio
     async def test_sign_in_uses_signin_options_connection_name_override(self) -> None:

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -131,6 +131,11 @@ class TestOauthHandlers:
             "sign_in", SignInEvent(activity_ctx=mock_context, token_response=mock_token_response)
         )
 
+        # Verify the context is marked signed-in with the exchanged token so
+        # "sign_in" event handlers can immediately use ctx.user_token / ctx.user_graph.
+        assert mock_context.is_signed_in is True
+        assert mock_context.user_token == "access-token"
+
         # Verify response
         assert result is None
 
@@ -243,6 +248,11 @@ class TestOauthHandlers:
         oauth_handlers.event_emitter.emit.assert_called_once_with(
             "sign_in", SignInEvent(activity_ctx=mock_context, token_response=mock_token_response)
         )
+
+        # Verify the context is marked signed-in with the verified token so
+        # "sign_in" event handlers can immediately use ctx.user_token / ctx.user_graph.
+        assert mock_context.is_signed_in is True
+        assert mock_context.user_token == "access-token"
 
         # Verify response
         assert result is None


### PR DESCRIPTION
## Summary

Updates `ActivityContext.sign_in()` to deliver the OAuth/SSO sign-in card **directly in the conversation** (as a targeted, requester-only message) instead of falling back to a 1:1 chat. Also fixes the `sign_in` event context so Graph calls work immediately after sign-in.

## Motivation

The old flow assumed group OAuth "isn't released" and, for any group conversation, created a 1:1 with the user and sent the OAuth card there. The platform now supports:

- **SSO** (silent token exchange) in **1:1** and **group chats**
- **OAuth card** in **1:1**, **group chats**, and **channels**
- SSO is **not** possible in **channels** (platform limitation)

The 1:1 fallback is no longer needed and produced a poor UX (sign-in happening in a different chat). In channels the old code also attempted a silent exchange that always failed with `resourcematchfailed`.

## Changes

**`activity_context.py` — `sign_in()`**
- Removed the 1:1 fallback (`conversations.create`) for group conversations.
- **Group chats & channels:** the OAuth card is now sent as a **targeted message** (`recipient.is_targeted = True`) — visible only to the requesting user.
- **Channels:** omit `token_exchange_resource` from the `OAuthCard` so Teams renders the sign-in **button** (OAuth flow) instead of attempting the silent SSO exchange that isn't supported in channel scope (fixes `resourcematchfailed`).
- Removed the now-dead `conversation_id` redirect (`self.conversation_ref.conversation.id = ...`) and the unused `CreateConversationParams` import.

**`app_oauth.py` — sign-in event context fix**
- Stamp `ctx.is_signed_in = True` / `ctx.user_token = token.token` before emitting the `sign_in` event (both `tokenExchange` and `verifyState` paths). Previously `ctx.user_graph` / `ctx.user_token` raised "User must be signed in" inside a `sign_in` handler because the context predated the token — it only worked on the next turn.

**Tests**
- `test_activity_context.py`: group chat sends a targeted card (no 1:1, keeps token exchange); channel targets + omits token exchange; personal is never targeted.
- `test_app_oauth.py`: context is marked signed-in with the token after exchange/verify.

## Behavior

| Scope | Before | After |
|---|---|---|
| 1:1 (personal) | OAuth card in chat | unchanged |
| Group chat | 1:1 fallback (card DM'd) | **targeted** card in the group chat; SSO exchange **or** OAuth card |
| Channel | 1:1 fallback; SSO attempt → `resourcematchfailed` | **targeted** OAuth card (sign-in button) in the channel; no failed exchange |

## Testing

- Manually verified in a live tenant across every supported scope: 1:1 (OAuth + SSO), group chat (OAuth + SSO), channel (OAuth). Bot logs confirmed `tokenExchange` in personal + groupChat and `verifyState` in personal + groupChat + channel, with zero `resourcematchfailed`.
- `ruff`, `pyright`, and `pytest packages/apps` all pass.

## Notes

- SSO (silent token exchange) remains unsupported in channel scope; channels use the OAuth card flow.
- Targeted delivery uses the existing `create_targeted_activity` path; targeting is never applied in 1:1 (the sender rejects it there).
