### PR TITLE
fix(apps): add opt-out for per-activity user token lookup

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -140,6 +140,7 @@ class App(ActivityHandlerMixin):
             self.options.api_client_settings,
             self.activity_sender,
             self.cloud,
+            fetch_user_token=self.options.fetch_user_token,
         )
         self.event_manager = EventManager(self._events)
         self.activity_processor.event_manager = self.event_manager

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -51,6 +51,7 @@ class ActivityProcessor:
         api_client_settings: Optional[ApiClientSettings],
         activity_sender: ActivitySender,
         cloud: CloudEnvironment = PUBLIC,
+        fetch_user_token: bool = True,
     ) -> None:
         self.router = router
         self.id = id
@@ -61,6 +62,7 @@ class ActivityProcessor:
         self.api_client_settings = api_client_settings
         self.activity_sender = activity_sender
         self.cloud = cloud
+        self.fetch_user_token = fetch_user_token
 
         # This will be set after the EventManager is initialized due to
         # a circular dependency
@@ -97,24 +99,27 @@ class ActivityProcessor:
             self.api_client_settings,
         )
 
-        # Check if user is signed in
+        # Check if user is signed in.
+        # Skipped unless configured (see App fetch_user_token / OAuth auto-detection) to avoid
+        # a wasted user-token request on every activity when the app never reads ctx.user_graph.
         is_signed_in = False
         user_token: Optional[str] = None
-        try:
-            user_token_res = await api_client.users.get_token(
-                GetUserTokenParams(
-                    channel_id=activity.channel_id,
-                    user_id=activity.from_.id,
-                    connection_name=self.default_connection_name,
+        if self.fetch_user_token:
+            try:
+                user_token_res = await api_client.users.get_token(
+                    GetUserTokenParams(
+                        channel_id=activity.channel_id,
+                        user_id=activity.from_.id,
+                        connection_name=self.default_connection_name,
+                    )
                 )
-            )
 
-            user_token = user_token_res.token
-            is_signed_in = True
-        except Exception:
-            # User token not available
-            logger.debug("No user token available")
-            pass
+                user_token = user_token_res.token
+                is_signed_in = True
+            except Exception:
+                # User token not available
+                logger.debug("No user token available")
+                pass
 
         tenant_id = extract_tenant_id(activity)
 

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -100,8 +100,9 @@ class AppOptions(TypedDict, total=False):
     """The OAuth connection name to use for authentication. Defaults to 'graph'."""
 
     fetch_user_token: Optional[bool]
-    """Whether to eagerly fetch the user's OAuth token on every inbound activity to
-    populate ``ctx.is_signed_in`` / ``ctx.user_token`` / ``ctx.user_graph``.
+    """Whether to eagerly look up the user's OAuth token on every inbound activity.
+    The token is used to compute ``ctx.is_signed_in`` and ``ctx.user_token``, and to authenticate
+    ``ctx.user_graph`` (which is always constructed regardless of this setting).
     When left unset, this is auto-detected: enabled only when an OAuth connection is
     explicitly configured via ``default_connection_name``, so apps that never use user OAuth
     do not pay for a wasted token request on every turn.
@@ -139,8 +140,9 @@ class InternalAppOptions:
     default_connection_name: str = "graph"
     """The OAuth connection name to use for authentication."""
     fetch_user_token: bool = False
-    """When True, eagerly fetches the user's OAuth token on every inbound activity to
-    populate ``ctx.is_signed_in`` / ``ctx.user_token`` / ``ctx.user_graph``.
+    """When True, eagerly looks up the user's OAuth token on every inbound activity.
+    The token is used to compute ``ctx.is_signed_in`` and ``ctx.user_token``, and to authenticate
+    ``ctx.user_graph`` (which is always constructed regardless of this setting).
     Resolved by ``from_typeddict``: auto-enabled when an OAuth connection is explicitly configured,
     unless overridden by an explicit ``fetch_user_token`` in ``AppOptions``."""
     plugins: List[PluginBase] = field(default_factory=lambda: [])

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -99,6 +99,14 @@ class AppOptions(TypedDict, total=False):
     default_connection_name: Optional[str]
     """The OAuth connection name to use for authentication. Defaults to 'graph'."""
 
+    fetch_user_token: Optional[bool]
+    """Whether to eagerly fetch the user's OAuth token on every inbound activity to
+    populate ``ctx.is_signed_in`` / ``ctx.user_token`` / ``ctx.user_graph``.
+    When left unset, this is auto-detected: enabled only when an OAuth connection is
+    explicitly configured via ``default_connection_name``, so apps that never use user OAuth
+    do not pay for a wasted token request on every turn.
+    Set explicitly to ``True`` or ``False`` to override the auto-detection."""
+
     # API Client Settings
     api_client_settings: Optional[ApiClientSettings]
     """API client settings used for overriding."""
@@ -130,6 +138,11 @@ class InternalAppOptions:
     """Whether to accept incoming requests without JWT validation."""
     default_connection_name: str = "graph"
     """The OAuth connection name to use for authentication."""
+    fetch_user_token: bool = False
+    """When True, eagerly fetches the user's OAuth token on every inbound activity to
+    populate ``ctx.is_signed_in`` / ``ctx.user_token`` / ``ctx.user_graph``.
+    Resolved by ``from_typeddict``: auto-enabled when an OAuth connection is explicitly configured,
+    unless overridden by an explicit ``fetch_user_token`` in ``AppOptions``."""
     plugins: List[PluginBase] = field(default_factory=lambda: [])
     api_client_settings: Optional[ApiClientSettings] = None
     """API client settings used for overriding."""
@@ -197,6 +210,15 @@ class InternalAppOptions:
                     _parse_bool_env_var(DANGEROUSLY_ALLOW_UNAUTHENTICATED_REQUESTS_ENV_VAR) or False
                 )
         kwargs["dangerously_allow_unauthenticated_requests"] = dangerously_allow_unauthenticated_requests
+
+        # Resolve whether to eagerly fetch the user's OAuth token on every inbound activity
+        # (used only to populate ctx.is_signed_in / ctx.user_token / ctx.user_graph).
+        # An explicit fetch_user_token wins; otherwise auto-detect based on whether an OAuth
+        # connection was explicitly configured, so apps that never use user OAuth don't pay
+        # for a wasted token request on every turn.
+        if options.get("fetch_user_token") is None:
+            kwargs["fetch_user_token"] = options.get("default_connection_name") is not None
+
         return cls(**kwargs)
 
 

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -953,3 +953,33 @@ class TestMergeAppOptions:
         assert result["dangerously_allow_unauthenticated_requests"] is False
         assert result["skip_auth"] is False
         assert result["default_connection_name"] == "graph"
+
+
+class TestFetchUserTokenResolution:
+    """Auto-detection and explicit override of fetch_user_token via InternalAppOptions."""
+
+    def test_disabled_by_default_when_no_oauth_configured(self):
+        from microsoft_teams.apps.options import AppOptions, InternalAppOptions
+
+        options = InternalAppOptions.from_typeddict(AppOptions())
+        assert options.fetch_user_token is False
+
+    def test_auto_enabled_when_connection_name_configured(self):
+        from microsoft_teams.apps.options import AppOptions, InternalAppOptions
+
+        options = InternalAppOptions.from_typeddict(AppOptions(default_connection_name="my-connection"))
+        assert options.fetch_user_token is True
+
+    def test_explicit_true_overrides_auto_detection(self):
+        from microsoft_teams.apps.options import AppOptions, InternalAppOptions
+
+        options = InternalAppOptions.from_typeddict(AppOptions(fetch_user_token=True))
+        assert options.fetch_user_token is True
+
+    def test_explicit_false_overrides_auto_detection(self):
+        from microsoft_teams.apps.options import AppOptions, InternalAppOptions
+
+        options = InternalAppOptions.from_typeddict(
+            AppOptions(default_connection_name="my-connection", fetch_user_token=False)
+        )
+        assert options.fetch_user_token is False

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -306,6 +306,41 @@ class TestActivityProcessor:
         mock_api_client.users.get_token.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_build_context_skips_token_fetch_when_disabled(self, activity_processor):
+        """When fetch_user_token is False, the user-token API is not called."""
+        from unittest.mock import patch
+
+        activity_processor.fetch_user_token = False
+
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-no-token",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        mock_api_client = MagicMock()
+        mock_api_client.users.get_token = AsyncMock()
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        with patch("microsoft_teams.apps.app_process.ApiClient", return_value=mock_api_client):
+            await activity_processor.process_activity([], mock_activity_event)
+
+        mock_api_client.users.get_token.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_process_activity_raises_when_event_manager_missing(self, activity_processor):
         """process_activity raises ValueError if event_manager was never initialized."""
         core_activity = CoreActivity(


### PR DESCRIPTION
## Problem

Fixes #506

Every inbound activity triggers an eager Bot Framework `GetToken` call, even when the app never uses `ctx.user_graph` / `ctx.is_signed_in`. For apps with no OAuth connection this adds ~93ms of latency per turn and emits OTel ERROR spans (404s from the token service).

## Change (non-breaking)

Adds a `fetch_user_token` option to `AppOptions` that gates the eager token lookup.

- **Auto-detect default:** when unset, the lookup is skipped unless OAuth is explicitly configured (i.e. `default_connection_name` was provided by the user). Apps with no OAuth connection stop paying the cost with no config change.
- **Explicit override:** pass `fetch_user_token=True` to force the lookup, or `False` to always skip it.

OAuth-configured apps are unchanged.

## Edge case

Apps that rely on the default `"graph"` connection *without* explicitly passing `default_connection_name`, and read `ctx.is_signed_in` / `ctx.user_graph`, will now see the fetch skipped. They must set `fetch_user_token=True`.

## Verification

- `ruff` + `pyright` clean; all apps tests pass (added `TestFetchUserTokenResolution` + a process-level test).
- In-process transport check (no network): default app = **0** GetToken calls, OAuth app = **1** (unchanged), explicit opt-out = **0**.

The breaking full-laziness change (fetch on first access of `user_graph`, deprecate `is_signed_in`/`user_token`) is deferred to 2.1.