### PR TITLE
Add OpenTelemetry HTTP middleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Repository Agent Guidance
+
+- Activity inputs are pydantic models. Access known fields directly (for example, `activity.type`) instead of using defensive `getattr` calls.

--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -28,3 +28,113 @@ uv run --project examples/agent365 python src/proactive.py \
   <agentic-app-id> \
   <agentic-user-id>
 ```
+
+## Observability
+
+The Teams SDK emits OpenTelemetry-compatible spans and metrics, but it does not configure exporters or the OpenTelemetry SDK for you. Configure tracing, metrics, resources, and exporters in your application host.
+
+Install exporter packages in your app or example environment only:
+
+```bash
+uv add --project examples/agent365 opentelemetry-sdk opentelemetry-exporter-otlp
+```
+
+Then configure OpenTelemetry before starting the app. The public telemetry constants expose the canonical source names used by the SDK:
+
+- API/lower layer tracer and meter: `Microsoft.Teams.Api`
+- Apps/orchestration tracer and meter: `Microsoft.Teams.Apps`
+
+```python
+import os
+
+from microsoft_teams.api import TEAMS_API_METER_NAME, TEAMS_API_TRACER_NAME
+from microsoft_teams.apps import (
+    TEAMS_BOT_APPLICATION_METER_NAME,
+    TEAMS_BOT_APPLICATION_TRACER_NAME,
+)
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def configure_observability() -> None:
+    resource = Resource.create(
+        {
+            "service.name": os.getenv("OTEL_SERVICE_NAME", "agent365-example"),
+        }
+    )
+
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(tracer_provider)
+
+    metric_reader = PeriodicExportingMetricReader(OTLPMetricExporter())
+    metrics.set_meter_provider(MeterProvider(resource=resource, metric_readers=[metric_reader]))
+
+    # Register the canonical SDK source names with the configured providers.
+    for tracer_name in (TEAMS_API_TRACER_NAME, TEAMS_BOT_APPLICATION_TRACER_NAME):
+        trace.get_tracer(tracer_name)
+    for meter_name in (TEAMS_API_METER_NAME, TEAMS_BOT_APPLICATION_METER_NAME):
+        metrics.get_meter(meter_name)
+```
+
+Set exporter configuration through OpenTelemetry environment variables, for example:
+
+```bash
+export OTEL_SERVICE_NAME=agent365-example
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+```
+
+### Agent365 baggage
+
+Inbound activities automatically populate the Agent365 baggage values that are present on the activity. Use `with_teams_baggage(...)` to add host-specific values that the SDK cannot infer, such as the service name and invoke-agent server address:
+
+```python
+import os
+
+from microsoft_teams.api import MessageActivity
+from microsoft_teams.apps import ActivityContext, TeamsBaggageBuilder, with_teams_baggage
+
+
+def add_host_baggage(builder: TeamsBaggageBuilder) -> None:
+    builder.operation_source(os.getenv("OTEL_SERVICE_NAME", "agent365-example"))
+    builder.invoke_agent_server(
+        os.getenv("AGENT365_SERVER_ADDRESS", "localhost"),
+        int(os.getenv("PORT", "3978")),
+    )
+
+    # Only set client.address when your hosting layer provides a trusted caller address.
+    client_address = os.getenv("CALLER_CLIENT_ADDRESS")
+    if client_address:
+        builder.set("client.address", client_address)
+
+
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    with with_teams_baggage(ctx, add_host_baggage):
+        await ctx.reply("Hello from Agent365 with scoped baggage.")
+```
+
+For work that is not tied to an inbound activity, use `TeamsBaggageBuilder` directly:
+
+```python
+import os
+
+from microsoft_teams.apps import TeamsBaggageBuilder
+
+with (
+    TeamsBaggageBuilder()
+    .operation_source(os.getenv("OTEL_SERVICE_NAME", "agent365-example"))
+    .invoke_agent_server(
+        os.getenv("AGENT365_SERVER_ADDRESS", "localhost"),
+        int(os.getenv("PORT", "3978")),
+    )
+    .build()
+):
+    # Run proactive work here.
+    ...
+```

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 requires-python = ">=3.11,<4.0"
 dependencies = [
+    "opentelemetry-api>=1.41.0",
     "pydantic>=2.0.0",
     "microsoft-teams-common",
     "microsoft-teams-cards",

--- a/packages/api/src/microsoft_teams/api/__init__.py
+++ b/packages/api/src/microsoft_teams/api/__init__.py
@@ -5,10 +5,11 @@ Licensed under the MIT License.
 
 import logging
 
-from . import activities, auth, clients, models
+from . import activities, auth, clients, diagnostics, models
 from .activities import *  # noqa: F403
 from .auth import *  # noqa: F403
 from .clients import *  # noqa: F403
+from .diagnostics import *  # noqa: F403
 from .models import *  # noqa: F403
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -18,4 +19,5 @@ __all__: list[str] = []
 __all__.extend(activities.__all__)
 __all__.extend(auth.__all__)
 __all__.extend(clients.__all__)
+__all__.extend(diagnostics.__all__)
 __all__.extend(models.__all__)

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -5,13 +5,17 @@ Licensed under the MIT License.
 
 from __future__ import annotations
 
+import inspect
 from typing import Literal, Optional, TypeAlias, Union
 
 from microsoft_teams.common import Client as HttpClient
 from microsoft_teams.common import ClientOptions, Token
+from microsoft_teams.common.http.client_token import StringLike
 from typing_extensions import deprecated
 
 from ..auth.cloud_environment import PUBLIC, CloudEnvironment
+from ..diagnostics._constants import API_ATTRIBUTE_NAMES, API_AUTH_FLOWS, API_SPAN_NAMES
+from ..diagnostics._helpers import get_tracer, record_exception
 from ..models import AgenticIdentity
 from ._auth_provider import AuthProvider
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
@@ -149,7 +153,24 @@ class ApiClient(BaseClient):
         if auth_provider is None:
             return None
 
-        return lambda: auth_provider.token(agentic_identity=agentic_identity)
+        async def resolve_auth_provider_token() -> str | StringLike | None:
+            with get_tracer().start_as_current_span(
+                API_SPAN_NAMES.auth_outbound,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                flow = API_AUTH_FLOWS.agentic if agentic_identity is not None else API_AUTH_FLOWS.app_only
+                span.set_attribute(API_ATTRIBUTE_NAMES.auth_flow, flow)
+                try:
+                    token = auth_provider.token(agentic_identity=agentic_identity)
+                    if inspect.isawaitable(token):
+                        return await token
+                    return token
+                except Exception as exception:
+                    record_exception(span, exception)
+                    raise
+
+        return resolve_auth_provider_token
 
     @property
     def http(self) -> HttpClient:

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -71,7 +71,12 @@ class ApiClient(BaseClient):
             self._http, self._api_client_settings, cloud=self._cloud
         )
         self.users = UserClient(self._http, self._api_client_settings, cloud=self._cloud)
-        self.conversations = ConversationClient(self.service_url, self._http, self._api_client_settings)
+        self.conversations = ConversationClient(
+            self.service_url,
+            self._http,
+            self._api_client_settings,
+            scope_factory=self._scope_conversations,
+        )
         self.teams = TeamClient(self.service_url, self._http, self._api_client_settings)
         self.meetings = MeetingClient(self.service_url, self._http, self._api_client_settings)
         self._reactions: Optional[ReactionClient] = None
@@ -134,6 +139,13 @@ class ApiClient(BaseClient):
     def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
         """Alias for from_agentic_identity."""
         return self.from_agentic_identity(agentic_identity)
+
+    def _scope_conversations(
+        self,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+    ) -> ConversationClient:
+        return self.clone(service_url=service_url, agentic_identity=agentic_identity).conversations
 
     def _get_scoped_http(self, agentic_identity: AgenticIdentity | None) -> HttpClient:
         if self._auth_provider is None:

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -11,11 +11,13 @@ from typing import Literal, Optional, TypeAlias, Union
 from microsoft_teams.common import Client as HttpClient
 from microsoft_teams.common import ClientOptions, Token
 from microsoft_teams.common.http.client_token import StringLike
+from opentelemetry.trace import SpanKind
 from typing_extensions import deprecated
 
 from ..auth.cloud_environment import PUBLIC, CloudEnvironment
 from ..diagnostics._constants import API_ATTRIBUTE_NAMES, API_AUTH_FLOWS, API_SPAN_NAMES
 from ..diagnostics._helpers import get_tracer, record_exception
+from ..diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ..models import AgenticIdentity
 from ._auth_provider import AuthProvider
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
@@ -156,6 +158,7 @@ class ApiClient(BaseClient):
         async def resolve_auth_provider_token() -> str | StringLike | None:
             with get_tracer().start_as_current_span(
                 API_SPAN_NAMES.auth_outbound,
+                kind=SpanKind.CLIENT,
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
@@ -182,6 +185,7 @@ class ApiClient(BaseClient):
         """Set the HTTP client instance and propagate to all sub-clients."""
         self._http = value
         self._apply_auth_provider_token()
+        ensure_outbound_telemetry_middleware(self._http)
         self._bots.http = self._http
         self.conversations.http = self._http
         self.users.http = self._http

--- a/packages/api/src/microsoft_teams/api/clients/base_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/base_client.py
@@ -46,8 +46,9 @@ class BaseClient:
         ensure_outbound_telemetry_middleware(value)
         self._http = value
 
-    def _get_service_url(self) -> str:
+    def _get_service_url(self, service_url: str | None = None) -> str:
         current_service_url = cast(str | None, getattr(self, "service_url", None))
-        if current_service_url is None:
+        resolved_service_url = service_url or current_service_url
+        if resolved_service_url is None:
             raise ValueError("service_url is required")
-        return current_service_url.rstrip("/")
+        return resolved_service_url.rstrip("/")

--- a/packages/api/src/microsoft_teams/api/clients/base_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/base_client.py
@@ -7,6 +7,7 @@ from typing import Optional, Union, cast
 
 from microsoft_teams.common import Client, ClientOptions
 
+from ..diagnostics._outbound import ensure_outbound_telemetry_middleware
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
 
 
@@ -32,6 +33,7 @@ class BaseClient:
             self._http = Client(options)
 
         self._api_client_settings = merge_api_client_settings(api_client_settings)
+        ensure_outbound_telemetry_middleware(self._http)
 
     @property
     def http(self) -> Client:
@@ -41,6 +43,7 @@ class BaseClient:
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
 
     def _get_service_url(self) -> str:

--- a/packages/api/src/microsoft_teams/api/clients/bot/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/client.py
@@ -11,6 +11,7 @@ from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
 from ...auth.cloud_environment import PUBLIC, CloudEnvironment
+from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ..api_client_settings import ApiClientSettings, merge_api_client_settings
 from ..base_client import BaseClient
 from .sign_in_client import BotSignInClient
@@ -48,6 +49,7 @@ class BotClient(BaseClient):
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
         self.token.http = value
         self.sign_in.http = value

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -3,9 +3,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from contextlib import contextmanager
-from typing import Iterator, List, Optional
+from typing import List, Optional, cast
 
+import httpx
 from microsoft_teams.common.experimental import experimental
 from microsoft_teams.common.http import Client
 from opentelemetry.trace import Span
@@ -14,9 +14,8 @@ from ...activities import ActivityParams, SentActivity
 from ...diagnostics._constants import (
     API_ATTRIBUTE_NAMES,
     API_OUTBOUND_OPERATIONS,
-    API_SPAN_NAMES,
 )
-from ...diagnostics._helpers import get_tracer, record_exception, record_outbound_call, record_outbound_error
+from ...diagnostics._outbound import ApiOutboundResponseHook, ApiOutboundTelemetryMetadata
 from ...models import TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -63,19 +62,23 @@ class ConversationActivityClient(BaseClient):
         """
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        with self._trace_activity_operation(API_OUTBOUND_OPERATIONS.create, conversation_id, activity=activity) as span:
-            response = await self.http.post(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities",
-                json=activity.model_dump(by_alias=True, exclude_none=True),
-            )
+        response = await self.http.post(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities",
+            json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.create,
+                conversation_id,
+                activity=activity,
+                on_response=_set_response_activity_id,
+            ),
+        )
 
-            # Note: Typing activities (non-streaming) always produce empty responses.
-            # Note: For streaming activities, the first response includes the stream id.
-            # Note: Subsequent responses for streaming activities are empty (both typing and message type).
-            response_body = response.json()
-            id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
-            self._set_activity_id(span, response_body.get("id"))
-            return SentActivity(id=id, activity_params=activity)
+        # Note: Typing activities (non-streaming) always produce empty responses.
+        # Note: For streaming activities, the first response includes the stream id.
+        # Note: Subsequent responses for streaming activities are empty (both typing and message type).
+        response_body = response.json()
+        id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
+        return SentActivity(id=id, activity_params=activity)
 
     async def update(
         self,
@@ -95,16 +98,19 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        with self._trace_activity_operation(
-            API_OUTBOUND_OPERATIONS.update, conversation_id, activity=activity, activity_id=activity_id
-        ) as span:
-            response = await self.http.put(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
-                json=activity.model_dump(by_alias=True, exclude_none=True),
-            )
-            id = response.json()["id"]
-            self._set_activity_id(span, id)
-            return SentActivity(id=id, activity_params=activity)
+        response = await self.http.put(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.update,
+                conversation_id,
+                activity=activity,
+                activity_id=activity_id,
+                on_response=_set_response_activity_id,
+            ),
+        )
+        id = response.json()["id"]
+        return SentActivity(id=id, activity_params=activity)
 
     async def reply(
         self,
@@ -124,18 +130,21 @@ class ConversationActivityClient(BaseClient):
             The created reply activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        with self._trace_activity_operation(
-            API_OUTBOUND_OPERATIONS.reply, conversation_id, activity=activity, activity_id=activity_id
-        ) as span:
-            activity_json = activity.model_dump(by_alias=True, exclude_none=True)
-            activity_json["replyToId"] = activity_id
-            response = await self.http.post(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
-                json=activity_json,
-            )
-            id = response.json()["id"]
-            self._set_activity_id(span, id)
-            return SentActivity(id=id, activity_params=activity)
+        activity_json = activity.model_dump(by_alias=True, exclude_none=True)
+        activity_json["replyToId"] = activity_id
+        response = await self.http.post(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            json=activity_json,
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.reply,
+                conversation_id,
+                activity=activity,
+                activity_id=activity_id,
+                on_response=_set_response_activity_id,
+            ),
+        )
+        id = response.json()["id"]
+        return SentActivity(id=id, activity_params=activity)
 
     async def delete(
         self,
@@ -149,10 +158,14 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
-        with self._trace_activity_operation(API_OUTBOUND_OPERATIONS.delete, conversation_id, activity_id=activity_id):
-            await self.http.delete(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
-            )
+        await self.http.delete(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.delete,
+                conversation_id,
+                activity_id=activity_id,
+            ),
+        )
 
     async def get_members(
         self,
@@ -198,17 +211,19 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        with self._trace_activity_operation(
-            API_OUTBOUND_OPERATIONS.create_targeted, conversation_id, activity=activity
-        ) as span:
-            response = await self.http.post(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
-                json=activity.model_dump(by_alias=True, exclude_none=True),
-            )
-            response_body = response.json()
-            id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
-            self._set_activity_id(span, response_body.get("id"))
-            return SentActivity(id=id, activity_params=activity)
+        response = await self.http.post(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
+            json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.create_targeted,
+                conversation_id,
+                activity=activity,
+                on_response=_set_response_activity_id,
+            ),
+        )
+        response_body = response.json()
+        id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
+        return SentActivity(id=id, activity_params=activity)
 
     @experimental("ExperimentalTeamsTargeted")
     async def update_targeted(
@@ -233,16 +248,19 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        with self._trace_activity_operation(
-            API_OUTBOUND_OPERATIONS.update_targeted, conversation_id, activity=activity, activity_id=activity_id
-        ) as span:
-            response = await self.http.put(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
-                json=activity.model_dump(by_alias=True, exclude_none=True),
-            )
-            id = response.json()["id"]
-            self._set_activity_id(span, id)
-            return SentActivity(id=id, activity_params=activity)
+        response = await self.http.put(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+            json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.update_targeted,
+                conversation_id,
+                activity=activity,
+                activity_id=activity_id,
+                on_response=_set_response_activity_id,
+            ),
+        )
+        id = response.json()["id"]
+        return SentActivity(id=id, activity_params=activity)
 
     @experimental("ExperimentalTeamsTargeted")
     async def delete_targeted(
@@ -262,41 +280,45 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        with self._trace_activity_operation(
-            API_OUTBOUND_OPERATIONS.delete_targeted, conversation_id, activity_id=activity_id
-        ):
-            await self.http.delete(
-                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true"
-            )
+        await self.http.delete(
+            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.delete_targeted,
+                conversation_id,
+                activity_id=activity_id,
+            ),
+        )
 
-    @contextmanager
-    def _trace_activity_operation(
+    def _create_activity_telemetry_metadata(
         self,
         operation: str,
         conversation_id: str,
         *,
         activity: ActivityParams | None = None,
         activity_id: str | None = None,
-    ) -> Iterator[Span]:
-        record_outbound_call(operation)
-        with get_tracer().start_as_current_span(
-            API_SPAN_NAMES.conversation_client,
-            record_exception=False,
-            set_status_on_exception=False,
-        ) as span:
-            span.set_attribute(API_ATTRIBUTE_NAMES.operation, operation)
-            span.set_attribute(API_ATTRIBUTE_NAMES.service_url, self._get_service_url())
-            span.set_attribute(API_ATTRIBUTE_NAMES.conversation_id, conversation_id)
-            if activity is not None:
-                span.set_attribute(API_ATTRIBUTE_NAMES.activity_type, str(activity.type))
-            self._set_activity_id(span, activity_id)
-            try:
-                yield span
-            except Exception as exception:
-                record_exception(span, exception)
-                record_outbound_error(operation)
-                raise
+        on_response: ApiOutboundResponseHook | None = None,
+    ) -> ApiOutboundTelemetryMetadata:
+        attributes = {
+            API_ATTRIBUTE_NAMES.operation: operation,
+            API_ATTRIBUTE_NAMES.service_url: self._get_service_url(),
+            API_ATTRIBUTE_NAMES.conversation_id: conversation_id,
+        }
+        if activity is not None:
+            attributes[API_ATTRIBUTE_NAMES.activity_type] = str(activity.type)
+        if activity_id is not None:
+            attributes[API_ATTRIBUTE_NAMES.activity_id] = activity_id
 
-    def _set_activity_id(self, span: Span, activity_id: str | None) -> None:
-        if activity_id:
-            span.set_attribute(API_ATTRIBUTE_NAMES.activity_id, activity_id)
+        return ApiOutboundTelemetryMetadata(
+            operation=operation,
+            attributes=attributes,
+            on_response=on_response,
+        )
+
+
+def _set_response_activity_id(span: Span, response: httpx.Response) -> None:
+    response_body = response.json()
+    if not isinstance(response_body, dict):
+        return
+    value = cast(dict[str, object], response_body).get("id")
+    if value:
+        span.set_attribute(API_ATTRIBUTE_NAMES.activity_id, str(value))

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -16,7 +16,7 @@ from ...diagnostics._constants import (
     API_OUTBOUND_OPERATIONS,
 )
 from ...diagnostics._outbound import ApiOutboundResponseHook, ApiOutboundTelemetryMetadata
-from ...models import TeamsChannelAccount
+from ...models import AgenticIdentity, TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 
@@ -49,6 +49,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Create a new activity in a conversation.
@@ -63,11 +66,12 @@ class ConversationActivityClient(BaseClient):
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities",
             json=activity.model_dump(by_alias=True, exclude_none=True),
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.create,
                 conversation_id,
+                service_url=service_url,
                 activity=activity,
                 on_response=_set_response_activity_id,
             ),
@@ -85,6 +89,9 @@ class ConversationActivityClient(BaseClient):
         conversation_id: str,
         activity_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Update an existing activity in a conversation.
@@ -99,11 +106,12 @@ class ConversationActivityClient(BaseClient):
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.put(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             json=activity.model_dump(by_alias=True, exclude_none=True),
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.update,
                 conversation_id,
+                service_url=service_url,
                 activity=activity,
                 activity_id=activity_id,
                 on_response=_set_response_activity_id,
@@ -117,6 +125,9 @@ class ConversationActivityClient(BaseClient):
         conversation_id: str,
         activity_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Reply to an activity in a conversation.
@@ -133,11 +144,12 @@ class ConversationActivityClient(BaseClient):
         activity_json = activity.model_dump(by_alias=True, exclude_none=True)
         activity_json["replyToId"] = activity_id
         response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             json=activity_json,
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.reply,
                 conversation_id,
+                service_url=service_url,
                 activity=activity,
                 activity_id=activity_id,
                 on_response=_set_response_activity_id,
@@ -150,6 +162,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> None:
         """
         Delete an activity from a conversation.
@@ -159,10 +174,11 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         await self.http.delete(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.delete,
                 conversation_id,
+                service_url=service_url,
                 activity_id=activity_id,
             ),
         )
@@ -171,6 +187,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> List[TeamsChannelAccount]:
         """
         Get the members associated with an activity.
@@ -184,7 +203,7 @@ class ConversationActivityClient(BaseClient):
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.get(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}/members",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}/members",
         )
         return [TeamsChannelAccount.model_validate(member) for member in response.json()]
 
@@ -193,6 +212,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Create a new targeted activity in a conversation.
@@ -212,11 +234,12 @@ class ConversationActivityClient(BaseClient):
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.create_targeted,
                 conversation_id,
+                service_url=service_url,
                 activity=activity,
                 on_response=_set_response_activity_id,
             ),
@@ -231,6 +254,9 @@ class ConversationActivityClient(BaseClient):
         conversation_id: str,
         activity_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Update an existing targeted activity in a conversation.
@@ -249,11 +275,12 @@ class ConversationActivityClient(BaseClient):
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
         response = await self.http.put(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.update_targeted,
                 conversation_id,
+                service_url=service_url,
                 activity=activity,
                 activity_id=activity_id,
                 on_response=_set_response_activity_id,
@@ -267,6 +294,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> None:
         """
         Delete a targeted activity from a conversation.
@@ -281,10 +311,11 @@ class ConversationActivityClient(BaseClient):
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
         await self.http.delete(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.delete_targeted,
                 conversation_id,
+                service_url=service_url,
                 activity_id=activity_id,
             ),
         )
@@ -294,13 +325,14 @@ class ConversationActivityClient(BaseClient):
         operation: str,
         conversation_id: str,
         *,
+        service_url: str | None = None,
         activity: ActivityParams | None = None,
         activity_id: str | None = None,
         on_response: ApiOutboundResponseHook | None = None,
     ) -> ApiOutboundTelemetryMetadata:
         attributes = {
             API_ATTRIBUTE_NAMES.operation: operation,
-            API_ATTRIBUTE_NAMES.service_url: self._get_service_url(),
+            API_ATTRIBUTE_NAMES.service_url: self._get_service_url(service_url),
             API_ATTRIBUTE_NAMES.conversation_id: conversation_id,
         }
         if activity is not None:

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -3,12 +3,20 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Optional
+from contextlib import contextmanager
+from typing import Iterator, List, Optional
 
 from microsoft_teams.common.experimental import experimental
 from microsoft_teams.common.http import Client
+from opentelemetry.trace import Span
 
 from ...activities import ActivityParams, SentActivity
+from ...diagnostics._constants import (
+    API_ATTRIBUTE_NAMES,
+    API_OUTBOUND_OPERATIONS,
+    API_SPAN_NAMES,
+)
+from ...diagnostics._helpers import get_tracer, record_exception, record_outbound_call, record_outbound_error
 from ...models import TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -55,16 +63,19 @@ class ConversationActivityClient(BaseClient):
         """
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities",
-            json=activity.model_dump(by_alias=True, exclude_none=True),
-        )
+        with self._trace_activity_operation(API_OUTBOUND_OPERATIONS.create, conversation_id, activity=activity) as span:
+            response = await self.http.post(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities",
+                json=activity.model_dump(by_alias=True, exclude_none=True),
+            )
 
-        # Note: Typing activities (non-streaming) always produce empty responses.
-        # Note: For streaming activities, the first response includes the stream id.
-        # Note: Subsequent responses for streaming activities are empty (both typing and message type).
-        id = response.json().get("id", _PLACEHOLDER_ACTIVITY_ID)
-        return SentActivity(id=id, activity_params=activity)
+            # Note: Typing activities (non-streaming) always produce empty responses.
+            # Note: For streaming activities, the first response includes the stream id.
+            # Note: Subsequent responses for streaming activities are empty (both typing and message type).
+            response_body = response.json()
+            id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
+            self._set_activity_id(span, response_body.get("id"))
+            return SentActivity(id=id, activity_params=activity)
 
     async def update(
         self,
@@ -84,12 +95,16 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        response = await self.http.put(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
-            json=activity.model_dump(by_alias=True, exclude_none=True),
-        )
-        id = response.json()["id"]
-        return SentActivity(id=id, activity_params=activity)
+        with self._trace_activity_operation(
+            API_OUTBOUND_OPERATIONS.update, conversation_id, activity=activity, activity_id=activity_id
+        ) as span:
+            response = await self.http.put(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+                json=activity.model_dump(by_alias=True, exclude_none=True),
+            )
+            id = response.json()["id"]
+            self._set_activity_id(span, id)
+            return SentActivity(id=id, activity_params=activity)
 
     async def reply(
         self,
@@ -109,14 +124,18 @@ class ConversationActivityClient(BaseClient):
             The created reply activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        activity_json = activity.model_dump(by_alias=True, exclude_none=True)
-        activity_json["replyToId"] = activity_id
-        response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
-            json=activity_json,
-        )
-        id = response.json()["id"]
-        return SentActivity(id=id, activity_params=activity)
+        with self._trace_activity_operation(
+            API_OUTBOUND_OPERATIONS.reply, conversation_id, activity=activity, activity_id=activity_id
+        ) as span:
+            activity_json = activity.model_dump(by_alias=True, exclude_none=True)
+            activity_json["replyToId"] = activity_id
+            response = await self.http.post(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+                json=activity_json,
+            )
+            id = response.json()["id"]
+            self._set_activity_id(span, id)
+            return SentActivity(id=id, activity_params=activity)
 
     async def delete(
         self,
@@ -130,9 +149,10 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
-        await self.http.delete(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
-        )
+        with self._trace_activity_operation(API_OUTBOUND_OPERATIONS.delete, conversation_id, activity_id=activity_id):
+            await self.http.delete(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            )
 
     async def get_members(
         self,
@@ -178,12 +198,17 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
-            json=activity.model_dump(by_alias=True, exclude_none=True),
-        )
-        id = response.json().get("id", _PLACEHOLDER_ACTIVITY_ID)
-        return SentActivity(id=id, activity_params=activity)
+        with self._trace_activity_operation(
+            API_OUTBOUND_OPERATIONS.create_targeted, conversation_id, activity=activity
+        ) as span:
+            response = await self.http.post(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
+                json=activity.model_dump(by_alias=True, exclude_none=True),
+            )
+            response_body = response.json()
+            id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
+            self._set_activity_id(span, response_body.get("id"))
+            return SentActivity(id=id, activity_params=activity)
 
     @experimental("ExperimentalTeamsTargeted")
     async def update_targeted(
@@ -208,12 +233,16 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        response = await self.http.put(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
-            json=activity.model_dump(by_alias=True, exclude_none=True),
-        )
-        id = response.json()["id"]
-        return SentActivity(id=id, activity_params=activity)
+        with self._trace_activity_operation(
+            API_OUTBOUND_OPERATIONS.update_targeted, conversation_id, activity=activity, activity_id=activity_id
+        ) as span:
+            response = await self.http.put(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+                json=activity.model_dump(by_alias=True, exclude_none=True),
+            )
+            id = response.json()["id"]
+            self._set_activity_id(span, id)
+            return SentActivity(id=id, activity_params=activity)
 
     @experimental("ExperimentalTeamsTargeted")
     async def delete_targeted(
@@ -233,6 +262,41 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        await self.http.delete(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true"
-        )
+        with self._trace_activity_operation(
+            API_OUTBOUND_OPERATIONS.delete_targeted, conversation_id, activity_id=activity_id
+        ):
+            await self.http.delete(
+                f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true"
+            )
+
+    @contextmanager
+    def _trace_activity_operation(
+        self,
+        operation: str,
+        conversation_id: str,
+        *,
+        activity: ActivityParams | None = None,
+        activity_id: str | None = None,
+    ) -> Iterator[Span]:
+        record_outbound_call(operation)
+        with get_tracer().start_as_current_span(
+            API_SPAN_NAMES.conversation_client,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            span.set_attribute(API_ATTRIBUTE_NAMES.operation, operation)
+            span.set_attribute(API_ATTRIBUTE_NAMES.service_url, self._get_service_url())
+            span.set_attribute(API_ATTRIBUTE_NAMES.conversation_id, conversation_id)
+            if activity is not None:
+                span.set_attribute(API_ATTRIBUTE_NAMES.activity_type, str(activity.type))
+            self._set_activity_id(span, activity_id)
+            try:
+                yield span
+            except Exception as exception:
+                record_exception(span, exception)
+                record_outbound_error(operation)
+                raise
+
+    def _set_activity_id(self, span: Span, activity_id: str | None) -> None:
+        if activity_id:
+            span.set_attribute(API_ATTRIBUTE_NAMES.activity_id, activity_id)

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Optional, cast
+from typing import Callable, List, Optional, cast
 
 import httpx
 from microsoft_teams.common.experimental import experimental
@@ -21,6 +21,7 @@ from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 
 _PLACEHOLDER_ACTIVITY_ID = "DO_NOT_USE_PLACEHOLDER_ID"
+ActivityScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationActivityClient"]
 
 
 class ConversationActivityClient(BaseClient):
@@ -33,6 +34,7 @@ class ConversationActivityClient(BaseClient):
         service_url: str,
         http_client: Optional[Client] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        scope_factory: ActivityScopeFactory | None = None,
     ):
         """
         Initialize the conversation activity client.
@@ -44,6 +46,16 @@ class ConversationActivityClient(BaseClient):
         """
         super().__init__(http_client, api_client_settings)
         self.service_url = service_url.rstrip("/")
+        self._scope_factory = scope_factory
+
+    def _scoped_client(
+        self,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+    ) -> "ConversationActivityClient":
+        if (service_url is None and agentic_identity is None) or self._scope_factory is None:
+            return self
+        return self._scope_factory(service_url, agentic_identity)
 
     async def create(
         self,
@@ -65,6 +77,10 @@ class ConversationActivityClient(BaseClient):
         """
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create(conversation_id, activity)
+
         response = await self.http.post(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -105,6 +121,10 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update(conversation_id, activity_id, activity)
+
         response = await self.http.put(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -141,6 +161,10 @@ class ConversationActivityClient(BaseClient):
             The created reply activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.reply(conversation_id, activity_id, activity)
+
         activity_json = activity.model_dump(by_alias=True, exclude_none=True)
         activity_json["replyToId"] = activity_id
         response = await self.http.post(
@@ -173,6 +197,10 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete(conversation_id, activity_id)
+
         await self.http.delete(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             _metadata=self._create_activity_telemetry_metadata(
@@ -202,6 +230,10 @@ class ConversationActivityClient(BaseClient):
             List of TeamsChannelAccount objects representing the activity members
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.get_members(conversation_id, activity_id)
+
         response = await self.http.get(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}/members",
         )
@@ -233,6 +265,10 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create_targeted(conversation_id, activity)
+
         response = await self.http.post(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -274,6 +310,10 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update_targeted(conversation_id, activity_id, activity)
+
         response = await self.http.put(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
@@ -310,6 +350,10 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete_targeted(conversation_id, activity_id)
+
         await self.http.delete(
             f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
             _metadata=self._create_activity_telemetry_metadata(

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -3,13 +3,14 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
+from ...activities import SentActivity
 from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
-from ...models import ConversationResource
+from ...models import AgenticIdentity, ConversationResource, TeamsChannelAccount
 from ...models.message import MessageReactionType
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -17,6 +18,8 @@ from ..reaction import ReactionClient
 from .activity import ActivityParams, ConversationActivityClient
 from .member import ConversationMemberClient
 from .params import CreateConversationParams
+
+ConversationScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationClient"]
 
 
 class ConversationOperations:
@@ -30,32 +33,126 @@ class ConversationOperations:
 class ActivityOperations(ConversationOperations):
     """Operations for managing activities in a conversation."""
 
-    async def create(self, activity: ActivityParams):
-        return await self._client.activities_client.create(self._conversation_id, activity)
+    async def create(
+        self,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        return await self._client.create_activity(
+            self._conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update(self, activity_id: str, activity: ActivityParams):
-        return await self._client.activities_client.update(self._conversation_id, activity_id, activity)
+    async def update(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        return await self._client.update_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def reply(self, activity_id: str, activity: ActivityParams):
-        return await self._client.activities_client.reply(self._conversation_id, activity_id, activity)
+    async def reply(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        return await self._client.reply_to_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete(self, activity_id: str):
-        await self._client.activities_client.delete(self._conversation_id, activity_id)
+    async def delete(
+        self,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
+        await self._client.delete_activity(
+            self._conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def get_members(self, activity_id: str):
-        return await self._client.activities_client.get_members(self._conversation_id, activity_id)
+    async def get_members(
+        self,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> list[TeamsChannelAccount]:
+        return await self._client.get_activity_members(
+            self._conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def create_targeted(self, activity: ActivityParams):
+    async def create_targeted(
+        self,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Create a new targeted activity visible only to the specified recipient."""
-        return await self._client.activities_client.create_targeted(self._conversation_id, activity)
+        return await self._client.create_targeted_activity(
+            self._conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update_targeted(self, activity_id: str, activity: ActivityParams):
+    async def update_targeted(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Update an existing targeted activity."""
-        return await self._client.activities_client.update_targeted(self._conversation_id, activity_id, activity)
+        return await self._client.update_targeted_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete_targeted(self, activity_id: str):
+    async def delete_targeted(
+        self,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
         """Delete a targeted activity."""
-        await self._client.activities_client.delete_targeted(self._conversation_id, activity_id)
+        await self._client.delete_targeted_activity(
+            self._conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
 
 class MemberOperations(ConversationOperations):
@@ -87,6 +184,7 @@ class ConversationClient(BaseClient):
         service_url: str,
         options: Optional[Union[Client, ClientOptions]] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        scope_factory: ConversationScopeFactory | None = None,
     ) -> None:
         """Initialize the client.
 
@@ -97,6 +195,7 @@ class ConversationClient(BaseClient):
         """
         super().__init__(options, api_client_settings)
         self.service_url = service_url.rstrip("/")
+        self._scope_factory = scope_factory
 
         self._activities_client = ConversationActivityClient(
             self.service_url,
@@ -166,37 +265,172 @@ class ConversationClient(BaseClient):
         """
         return MemberOperations(self, conversation_id)
 
-    async def create_activity(self, conversation_id: str, activity: ActivityParams):
+    def _scoped_client(
+        self,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+    ) -> "ConversationClient":
+        if (service_url is None and agentic_identity is None) or self._scope_factory is None:
+            return self
+        return self._scope_factory(service_url, agentic_identity)
+
+    async def create_activity(
+        self,
+        conversation_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Create an activity in a conversation."""
-        return await self._activities_client.create(conversation_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create_activity(conversation_id, activity)
+        return await self._activities_client.create(
+            conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+    async def update_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Update an activity in a conversation."""
-        return await self._activities_client.update(conversation_id, activity_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.update(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def reply_to_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+    async def reply_to_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Reply to an activity in a conversation."""
-        return await self._activities_client.reply(conversation_id, activity_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.reply_to_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.reply(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete_activity(self, conversation_id: str, activity_id: str):
+    async def delete_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
         """Delete an activity in a conversation."""
-        return await self._activities_client.delete(conversation_id, activity_id)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete_activity(conversation_id, activity_id)
+        return await self._activities_client.delete(
+            conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def get_activity_members(self, conversation_id: str, activity_id: str):
+    async def get_activity_members(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> list[TeamsChannelAccount]:
         """Get the members of an activity in a conversation."""
-        return await self._activities_client.get_members(conversation_id, activity_id)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.get_activity_members(conversation_id, activity_id)
+        return await self._activities_client.get_members(
+            conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def create_targeted_activity(self, conversation_id: str, activity: ActivityParams):
+    async def create_targeted_activity(
+        self,
+        conversation_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Create a targeted activity in a conversation."""
-        return await self._activities_client.create_targeted(conversation_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create_targeted_activity(conversation_id, activity)
+        return await self._activities_client.create_targeted(
+            conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update_targeted_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+    async def update_targeted_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Update a targeted activity in a conversation."""
-        return await self._activities_client.update_targeted(conversation_id, activity_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update_targeted_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.update_targeted(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete_targeted_activity(self, conversation_id: str, activity_id: str):
+    async def delete_targeted_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
         """Delete a targeted activity in a conversation."""
-        return await self._activities_client.delete_targeted(conversation_id, activity_id)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete_targeted_activity(conversation_id, activity_id)
+        return await self._activities_client.delete_targeted(
+            conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
     async def get_members(self, conversation_id: str):
         """Get the members of a conversation."""

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -201,6 +201,9 @@ class ConversationClient(BaseClient):
             self.service_url,
             self.http,
             self._api_client_settings,
+            scope_factory=lambda service_url, agentic_identity: self._scoped_client(
+                service_url, agentic_identity
+            ).activities_client,
         )
         self._members_client = ConversationMemberClient(
             self.service_url,

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
+from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ...models import ConversationResource
 from ...models.message import MessageReactionType
 from ..api_client_settings import ApiClientSettings
@@ -117,6 +118,7 @@ class ConversationClient(BaseClient):
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
         self._activities_client.http = value
         self._members_client.http = value

--- a/packages/api/src/microsoft_teams/api/clients/user/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/user/client.py
@@ -11,6 +11,7 @@ from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
 from ...auth.cloud_environment import PUBLIC, CloudEnvironment
+from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ...models import TokenResponse, TokenStatus
 from ..api_client_settings import ApiClientSettings, merge_api_client_settings
 from ..base_client import BaseClient
@@ -54,6 +55,7 @@ class UserClient(BaseClient):
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
         self._token.http = value
 

--- a/packages/api/src/microsoft_teams/api/diagnostics/__init__.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from ._telemetry import TEAMS_API_METER_NAME, TEAMS_API_TRACER_NAME, TeamsApiTelemetry
+
+__all__ = ["TEAMS_API_METER_NAME", "TEAMS_API_TRACER_NAME", "TeamsApiTelemetry"]

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -24,8 +24,8 @@ class _ApiAuthFlows:
 
 @dataclass(frozen=True)
 class _ApiMetricNames:
-    outbound_calls: str = "teams.outbound.calls"
-    outbound_errors: str = "teams.outbound.errors"
+    outbound_calls: str = "microsoft.teams.outbound.calls"
+    outbound_errors: str = "microsoft.teams.outbound.errors"
 
 
 @dataclass(frozen=True)
@@ -41,8 +41,8 @@ class _ApiOutboundOperations:
 
 @dataclass(frozen=True)
 class _ApiSpanNames:
-    conversation_client: str = "conversation_client"
-    auth_outbound: str = "auth.outbound"
+    conversation_client: str = "microsoft.teams.conversation.client"
+    auth_outbound: str = "microsoft.teams.auth.outbound"
 
 
 API_ATTRIBUTE_NAMES = _ApiAttributeNames()

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _ApiAttributeNames:
+    activity_id: str = "activity.id"
+    activity_type: str = "activity.type"
+    auth_flow: str = "auth.flow"
+    conversation_id: str = "conversation.id"
+    operation: str = "operation"
+    service_url: str = "service.url"
+
+
+@dataclass(frozen=True)
+class _ApiAuthFlows:
+    agentic: str = "agentic"
+    app_only: str = "app_only"
+
+
+@dataclass(frozen=True)
+class _ApiMetricNames:
+    outbound_calls: str = "teams.outbound.calls"
+    outbound_errors: str = "teams.outbound.errors"
+
+
+@dataclass(frozen=True)
+class _ApiOutboundOperations:
+    create: str = "create"
+    create_targeted: str = "create_targeted"
+    delete: str = "delete"
+    delete_targeted: str = "delete_targeted"
+    reply: str = "reply"
+    update: str = "update"
+    update_targeted: str = "update_targeted"
+
+
+@dataclass(frozen=True)
+class _ApiSpanNames:
+    conversation_client: str = "conversation_client"
+    auth_outbound: str = "auth.outbound"
+
+
+API_ATTRIBUTE_NAMES = _ApiAttributeNames()
+API_AUTH_FLOWS = _ApiAuthFlows()
+API_METRIC_NAMES = _ApiMetricNames()
+API_OUTBOUND_OPERATIONS = _ApiOutboundOperations()
+API_SPAN_NAMES = _ApiSpanNames()

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -41,7 +41,7 @@ class _ApiOutboundOperations:
 
 @dataclass(frozen=True)
 class _ApiSpanNames:
-    conversation_client: str = "microsoft.teams.conversation.client"
+    api_client: str = "microsoft.teams.api.client"
     auth_outbound: str = "microsoft.teams.auth.outbound"
 
 

--- a/packages/api/src/microsoft_teams/api/diagnostics/_helpers.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_helpers.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from opentelemetry import metrics, trace
+from opentelemetry.metrics import Counter, Meter
+from opentelemetry.trace import Span, Status, StatusCode, Tracer
+
+from ._constants import API_ATTRIBUTE_NAMES, API_METRIC_NAMES
+from ._telemetry import TeamsApiTelemetry
+
+
+def get_tracer() -> Tracer:
+    return trace.get_tracer(TeamsApiTelemetry.tracer_name)
+
+
+def get_meter() -> Meter:
+    return metrics.get_meter(TeamsApiTelemetry.meter_name)
+
+
+def get_outbound_calls_counter() -> Counter:
+    return get_meter().create_counter(API_METRIC_NAMES.outbound_calls)
+
+
+def get_outbound_errors_counter() -> Counter:
+    return get_meter().create_counter(API_METRIC_NAMES.outbound_errors)
+
+
+def record_outbound_call(operation: str) -> None:
+    get_outbound_calls_counter().add(1, {API_ATTRIBUTE_NAMES.operation: operation})
+
+
+def record_outbound_error(operation: str) -> None:
+    get_outbound_errors_counter().add(1, {API_ATTRIBUTE_NAMES.operation: operation})
+
+
+def record_exception(span: Span, exception: BaseException) -> None:
+    span.record_exception(exception)
+    span.set_status(Status(StatusCode.ERROR, str(exception)))

--- a/packages/api/src/microsoft_teams/api/diagnostics/_helpers.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_helpers.py
@@ -12,11 +12,17 @@ from ._telemetry import TeamsApiTelemetry
 
 
 def get_tracer() -> Tracer:
-    return trace.get_tracer(TeamsApiTelemetry.tracer_name)
+    return trace.get_tracer(
+        TeamsApiTelemetry.tracer_name,
+        instrumenting_library_version=TeamsApiTelemetry.instrumentation_version,
+    )
 
 
 def get_meter() -> Meter:
-    return metrics.get_meter(TeamsApiTelemetry.meter_name)
+    return metrics.get_meter(
+        TeamsApiTelemetry.meter_name,
+        version=TeamsApiTelemetry.instrumentation_version,
+    )
 
 
 def get_outbound_calls_counter() -> Counter:

--- a/packages/api/src/microsoft_teams/api/diagnostics/_outbound.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_outbound.py
@@ -1,0 +1,62 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+
+import httpx
+from microsoft_teams.common import Client
+from microsoft_teams.common.http import MiddlewareContext, MiddlewareNext
+from opentelemetry.trace import Span, SpanKind
+
+from ._constants import API_SPAN_NAMES
+from ._helpers import get_tracer, record_exception, record_outbound_call, record_outbound_error
+
+ApiOutboundResponseHook = Callable[[Span, httpx.Response], None | Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ApiOutboundTelemetryMetadata:
+    operation: str
+    attributes: Mapping[str, str] = field(default_factory=dict[str, str])
+    on_response: ApiOutboundResponseHook | None = None
+
+
+class ApiOutboundTelemetryMiddleware:
+    async def send(
+        self,
+        context: MiddlewareContext,
+        next: MiddlewareNext,
+    ) -> httpx.Response:
+        metadata = context.metadata
+        if not isinstance(metadata, ApiOutboundTelemetryMetadata):
+            return await next()
+
+        record_outbound_call(metadata.operation)
+        with get_tracer().start_as_current_span(
+            API_SPAN_NAMES.api_client,
+            attributes=dict(metadata.attributes),
+            kind=SpanKind.CLIENT,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                response = await next()
+            except Exception as exception:
+                record_exception(span, exception)
+                record_outbound_error(metadata.operation)
+                raise
+
+            if metadata.on_response is not None:
+                hook_result = metadata.on_response(span, response)
+                if inspect.isawaitable(hook_result):
+                    await hook_result
+            return response
+
+
+def ensure_outbound_telemetry_middleware(client: Client) -> None:
+    if not any(isinstance(middleware, ApiOutboundTelemetryMiddleware) for middleware in client.middlewares):
+        client.use(ApiOutboundTelemetryMiddleware())

--- a/packages/api/src/microsoft_teams/api/diagnostics/_telemetry.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_telemetry.py
@@ -3,8 +3,11 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import importlib.metadata
+
 TEAMS_API_TRACER_NAME = "Microsoft.Teams.Api"
 TEAMS_API_METER_NAME = "Microsoft.Teams.Api"
+TEAMS_API_INSTRUMENTATION_VERSION = importlib.metadata.version("microsoft-teams-api")
 
 
 class TeamsApiTelemetry:
@@ -12,3 +15,4 @@ class TeamsApiTelemetry:
 
     tracer_name = TEAMS_API_TRACER_NAME
     meter_name = TEAMS_API_METER_NAME
+    instrumentation_version = TEAMS_API_INSTRUMENTATION_VERSION

--- a/packages/api/src/microsoft_teams/api/diagnostics/_telemetry.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_telemetry.py
@@ -1,0 +1,14 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+TEAMS_API_TRACER_NAME = "Microsoft.Teams.Api"
+TEAMS_API_METER_NAME = "Microsoft.Teams.Api"
+
+
+class TeamsApiTelemetry:
+    """OpenTelemetry source names for the Teams API package."""
+
+    tracer_name = TEAMS_API_TRACER_NAME
+    meter_name = TEAMS_API_METER_NAME

--- a/packages/api/src/microsoft_teams/api/models/account.py
+++ b/packages/api/src/microsoft_teams/api/models/account.py
@@ -46,6 +46,14 @@ class Account(CustomBaseModel):
     """
     The name of the account.
     """
+    email: Optional[str] = None
+    """
+    Email address for the account, when provided by the channel.
+    """
+    user_role: Optional[str] = None
+    """
+    Role description for the account, when provided by the channel.
+    """
     role: Optional[AccountRole | str] = None
     """The role of the account in the activity."""
     agentic_user_id: Optional[str] = None

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -2,6 +2,11 @@
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
+# pyright: basic
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -10,6 +15,27 @@ from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.base_client import BaseClient
 from microsoft_teams.api.models import AgenticIdentity
 from microsoft_teams.common import Client, ClientOptions, Token
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any]):
+        self.name = name
+        self.options = options
+        self.attributes: dict[str, str] = {}
+
+    def set_attribute(self, key: str, value: str) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+        span = RecordingSpan(name, kwargs)
+        self.spans.append(span)
+        yield span
 
 
 class RequestRecorder:
@@ -38,6 +64,21 @@ class RecordingAuthProvider:
     ) -> str | None:
         self.calls.append((scope, agentic_identity))
         return self._token_value
+
+
+class RaisingAuthProvider(RecordingAuthProvider):
+    def __init__(self):
+        super().__init__()
+        self.exception = RuntimeError("token failure")
+
+    def token(
+        self,
+        *,
+        scope: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ):
+        self.calls.append((scope, agentic_identity))
+        raise self.exception
 
 
 class HarnessClient(BaseClient):
@@ -135,6 +176,48 @@ async def test_auth_provider_token_is_used_when_request_has_no_auth():
 
     assert auth_provider.calls == [(None, None)]
     assert recorder.last_request.headers["authorization"] == "Bearer auth-provider-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agentic_identity", "expected_flow"),
+    [
+        (None, "app_only"),
+        (AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id"), "agentic"),
+    ],
+)
+async def test_auth_provider_token_records_auth_outbound_span(agentic_identity, expected_flow):
+    auth_provider = RecordingAuthProvider()
+    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_identity=agentic_identity)
+    tracer = RecordingTracer()
+
+    with patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer):
+        await client.post_resource()
+
+    assert "authorization" in recorder.last_request.headers
+    assert len(tracer.spans) == 1
+    span = tracer.spans[0]
+    assert span.name == "auth.outbound"
+    assert span.options == {"record_exception": False, "set_status_on_exception": False}
+    assert span.attributes == {"auth.flow": expected_flow}
+
+
+@pytest.mark.asyncio
+async def test_auth_provider_token_records_exception_before_reraising():
+    auth_provider = RaisingAuthProvider()
+    client, _ = create_auth_provider_harness(auth_provider)
+    tracer = RecordingTracer()
+
+    with (
+        patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer),
+        patch("microsoft_teams.api.clients.api_client.record_exception") as record_exception,
+        pytest.raises(RuntimeError, match="token failure"),
+    ):
+        await client.post_resource()
+
+    assert auth_provider.calls == [(None, None)]
+    assert tracer.spans[0].attributes == {"auth.flow": "app_only"}
+    record_exception.assert_called_once_with(tracer.spans[0], auth_provider.exception)
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -197,7 +197,7 @@ async def test_auth_provider_token_records_auth_outbound_span(agentic_identity, 
     assert "authorization" in recorder.last_request.headers
     assert len(tracer.spans) == 1
     span = tracer.spans[0]
-    assert span.name == "auth.outbound"
+    assert span.name == "microsoft.teams.auth.outbound"
     assert span.options == {"record_exception": False, "set_status_on_exception": False}
     assert span.attributes == {"auth.flow": expected_flow}
 

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -13,8 +13,10 @@ import pytest
 from microsoft_teams.api.auth.cloud_environment import US_GOV
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.base_client import BaseClient
+from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMiddleware
 from microsoft_teams.api.models import AgenticIdentity
 from microsoft_teams.common import Client, ClientOptions, Token
+from opentelemetry.trace import SpanKind
 
 
 class RecordingSpan:
@@ -129,6 +131,17 @@ def test_api_client_uses_http_token_for_auth_provider_without_mutating_source_cl
     assert api_client.http.interceptors == http_client.interceptors
 
 
+def test_api_client_registers_outbound_telemetry_middleware_once_across_clones():
+    api_client = ApiClient("https://test.service.url")
+
+    scoped = api_client.from_service_url("https://override.service.url")
+
+    assert (
+        sum(isinstance(middleware, ApiOutboundTelemetryMiddleware) for middleware in api_client.http.middlewares) == 1
+    )
+    assert sum(isinstance(middleware, ApiOutboundTelemetryMiddleware) for middleware in scoped.http.middlewares) == 1
+
+
 def test_api_client_uses_cloud_token_service_url_for_default_settings():
     client = ApiClient("https://test.service.url", cloud=US_GOV)
 
@@ -198,7 +211,11 @@ async def test_auth_provider_token_records_auth_outbound_span(agentic_identity, 
     assert len(tracer.spans) == 1
     span = tracer.spans[0]
     assert span.name == "microsoft.teams.auth.outbound"
-    assert span.options == {"record_exception": False, "set_status_on_exception": False}
+    assert span.options == {
+        "kind": SpanKind.CLIENT,
+        "record_exception": False,
+        "set_status_on_exception": False,
+    }
     assert span.attributes == {"auth.flow": expected_flow}
 
 

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -15,8 +15,10 @@ from microsoft_teams.api.auth.cloud_environment import PUBLIC, with_overrides
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.conversation import ConversationClient
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
+from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMetadata
 from microsoft_teams.api.models import AgenticIdentity, ConversationResource, PagedMembersResult, TeamsChannelAccount
 from microsoft_teams.common.http import Client, ClientOptions
+from opentelemetry.trace import Span, SpanKind
 
 
 class RecordingSpan:
@@ -379,9 +381,9 @@ class TestConversationActivityOperations:
         client = ConversationClient("https://test.service.url/", request_capture)
 
         with (
-            patch("microsoft_teams.api.clients.conversation.activity.get_tracer", return_value=tracer),
-            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_call") as record_outbound_call,
-            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
         ):
             result = await client.create_activity("conv-1", mock_activity)
 
@@ -390,8 +392,12 @@ class TestConversationActivityOperations:
         record_outbound_error.assert_not_called()
         assert len(tracer.spans) == 1
         span = tracer.spans[0]
-        assert span.name == "microsoft.teams.conversation.client"
-        assert span.options == {"record_exception": False, "set_status_on_exception": False}
+        assert span.name == "microsoft.teams.api.client"
+        assert span.options == {
+            "kind": SpanKind.CLIENT,
+            "record_exception": False,
+            "set_status_on_exception": False,
+        }
         assert span.attributes == {
             "operation": "create",
             "service.url": "https://test.service.url",
@@ -400,17 +406,181 @@ class TestConversationActivityOperations:
             "activity.id": "mock_conversation_id",
         }
 
-    async def test_activity_create_records_diagnostics_on_error(self, mock_http_client, mock_activity):
+    async def test_request_without_metadata_does_not_record_api_client_telemetry(self, request_capture):
         tracer = RecordingTracer()
-        client = ConversationClient("https://test.service.url", mock_http_client)
-        error = RuntimeError("send failed")
+        api_client = ApiClient("https://test.service.url", request_capture)
 
         with (
-            patch.object(mock_http_client, "post", new_callable=AsyncMock, side_effect=error),
-            patch("microsoft_teams.api.clients.conversation.activity.get_tracer", return_value=tracer),
-            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_call") as record_outbound_call,
-            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_error") as record_outbound_error,
-            patch("microsoft_teams.api.clients.conversation.activity.record_exception") as record_exception,
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+        ):
+            await api_client.http.post("https://test.service.url/v3/conversations", json={"ok": True})
+
+        assert tracer.spans == []
+        record_outbound_call.assert_not_called()
+        record_outbound_error.assert_not_called()
+
+    async def test_api_client_middleware_uses_supplied_attributes_without_deriving_semantics(self, request_capture):
+        tracer = RecordingTracer()
+        api_client = ApiClient("https://test.service.url", request_capture)
+        attributes = {
+            "operation": "create",
+            "custom.attribute": "custom-value",
+        }
+
+        with patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer):
+            await api_client.http.post(
+                "https://test.service.url/v3/conversations/conv-1/activities",
+                json={"ok": True},
+                _metadata=ApiOutboundTelemetryMetadata(operation="create", attributes=attributes),
+            )
+
+        assert len(tracer.spans) == 1
+        assert tracer.spans[0].attributes == attributes
+
+    async def test_api_client_middleware_invokes_response_hook(self):
+        tracer = RecordingTracer()
+        hook_responses: list[httpx.Response] = []
+        http_client = Client(ClientOptions(base_url="https://test.service.url"))
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": "response-id"}, headers={"content-type": "application/json"})
+
+        http_client.http._transport = httpx.MockTransport(handler)
+        api_client = ApiClient("https://test.service.url", http_client)
+
+        async def on_response(span: Span, response: httpx.Response) -> None:
+            hook_responses.append(response)
+            span.set_attribute("hook.attribute", str(response.json()["id"]))
+
+        with patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer):
+            await api_client.http.post(
+                "/v3/conversations/conv-1/activities",
+                json={"ok": True},
+                _metadata=ApiOutboundTelemetryMetadata(
+                    operation="create",
+                    attributes={"operation": "create"},
+                    on_response=on_response,
+                ),
+            )
+
+        assert len(hook_responses) == 1
+        assert tracer.spans[0].attributes == {
+            "operation": "create",
+            "hook.attribute": "response-id",
+        }
+
+    async def test_activity_send_paths_set_response_activity_id_from_client_owned_hooks(
+        self, request_capture, mock_activity
+    ):
+        tracer = RecordingTracer()
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        with patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer):
+            await client.create_activity("conv-1", mock_activity)
+            await client.update_activity("conv-1", "act-1", mock_activity)
+            await client.reply_to_activity("conv-1", "act-1", mock_activity)
+            await client.create_targeted_activity("conv-1", mock_activity)
+            await client.update_targeted_activity("conv-1", "act-1", mock_activity)
+
+        assert [span.attributes["activity.id"] for span in tracer.spans] == [
+            "mock_conversation_id",
+            "mock_activity_id",
+            "mock_conversation_id",
+            "mock_conversation_id",
+            "mock_activity_id",
+        ]
+
+    async def test_activity_create_nests_auth_outbound_under_api_outbound_span(self, request_capture, mock_activity):
+        tracer = RecordingTracer()
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "bot-token"
+
+        client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer),
+        ):
+            await client.create_activity("conv-1", mock_activity)
+
+        assert calls == [(None, None)]
+        assert [span.name for span in tracer.spans[:2]] == [
+            "microsoft.teams.api.client",
+            "microsoft.teams.auth.outbound",
+        ]
+
+    async def test_activity_create_auth_failure_records_api_client_error(self, request_capture, mock_activity):
+        tracer = RecordingTracer()
+        error = RuntimeError("token failure")
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                raise error
+
+        client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.diagnostics._outbound.record_exception") as record_outbound_exception,
+            patch("microsoft_teams.api.clients.api_client.record_exception"),
+            pytest.raises(RuntimeError, match="token failure"),
+        ):
+            await client.create_activity("conv-1", mock_activity)
+
+        assert [span.name for span in tracer.spans[:2]] == [
+            "microsoft.teams.api.client",
+            "microsoft.teams.auth.outbound",
+        ]
+        record_outbound_call.assert_called_once_with("create")
+        record_outbound_error.assert_called_once_with("create")
+        record_outbound_exception.assert_called_once_with(tracer.spans[0], error)
+
+    async def test_request_authorization_header_bypasses_auth_provider_with_metadata(self, request_capture):
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "bot-token"
+
+        api_client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider())
+
+        await api_client.http.post(
+            "https://test.service.url/v3/conversations",
+            headers={"Authorization": "******"},
+            json={"ok": True},
+            _metadata=ApiOutboundTelemetryMetadata(operation="create"),
+        )
+
+        assert calls == []
+        request = request_capture._capture.last_request
+        assert request.headers["authorization"] == "******"
+
+    async def test_activity_create_records_diagnostics_on_error(self, mock_http_client, mock_activity):
+        tracer = RecordingTracer()
+        error = RuntimeError("send failed")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise error
+
+        http_client = Client(ClientOptions(base_url="https://mock.api.com"))
+        http_client.http._transport = httpx.MockTransport(handler)
+        client = ConversationClient("https://test.service.url", http_client)
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.diagnostics._outbound.record_exception") as record_exception,
             pytest.raises(RuntimeError, match="send failed"),
         ):
             await client.create_activity("conv-1", mock_activity)
@@ -422,7 +592,7 @@ class TestConversationActivityOperations:
     async def test_targeted_activity_operations_record_diagnostics_operations(self, mock_http_client, mock_activity):
         client = ConversationClient("https://test.service.url", mock_http_client)
 
-        with patch("microsoft_teams.api.clients.conversation.activity.record_outbound_call") as record_outbound_call:
+        with patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call:
             await client.create_targeted_activity("conv-1", mock_activity)
             await client.update_targeted_activity("conv-1", "act-1", mock_activity)
             await client.delete_targeted_activity("conv-1", "act-1")

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -390,7 +390,7 @@ class TestConversationActivityOperations:
         record_outbound_error.assert_not_called()
         assert len(tracer.spans) == 1
         span = tracer.spans[0]
-        assert span.name == "conversation_client"
+        assert span.name == "microsoft.teams.conversation.client"
         assert span.options == {"record_exception": False, "set_status_on_exception": False}
         assert span.attributes == {
             "operation": "create",

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -5,7 +5,9 @@ Licensed under the MIT License.
 # pyright: basic
 
 import json
-from unittest.mock import AsyncMock, patch
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import AsyncMock, call, patch
 
 import httpx
 import pytest
@@ -15,6 +17,28 @@ from microsoft_teams.api.clients.conversation import ConversationClient
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
 from microsoft_teams.api.models import AgenticIdentity, ConversationResource, PagedMembersResult, TeamsChannelAccount
 from microsoft_teams.common.http import Client, ClientOptions
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any], attributes: dict[str, str]):
+        self.name = name
+        self.options = options
+        self.attributes = attributes
+
+    def set_attribute(self, key: str, value: str) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+        attributes = kwargs.pop("attributes", {})
+        span = RecordingSpan(name, kwargs, attributes)
+        self.spans.append(span)
+        yield span
 
 
 @pytest.mark.unit
@@ -349,6 +373,65 @@ class TestConversationActivityOperations:
 
         last_request = request_capture._capture.last_request
         assert "authorization" not in last_request.headers
+
+    async def test_activity_create_records_diagnostics(self, request_capture, mock_activity):
+        tracer = RecordingTracer()
+        client = ConversationClient("https://test.service.url/", request_capture)
+
+        with (
+            patch("microsoft_teams.api.clients.conversation.activity.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_error") as record_outbound_error,
+        ):
+            result = await client.create_activity("conv-1", mock_activity)
+
+        assert result.id == "mock_conversation_id"
+        record_outbound_call.assert_called_once_with("create")
+        record_outbound_error.assert_not_called()
+        assert len(tracer.spans) == 1
+        span = tracer.spans[0]
+        assert span.name == "conversation_client"
+        assert span.options == {"record_exception": False, "set_status_on_exception": False}
+        assert span.attributes == {
+            "operation": "create",
+            "service.url": "https://test.service.url",
+            "conversation.id": "conv-1",
+            "activity.type": "message",
+            "activity.id": "mock_conversation_id",
+        }
+
+    async def test_activity_create_records_diagnostics_on_error(self, mock_http_client, mock_activity):
+        tracer = RecordingTracer()
+        client = ConversationClient("https://test.service.url", mock_http_client)
+        error = RuntimeError("send failed")
+
+        with (
+            patch.object(mock_http_client, "post", new_callable=AsyncMock, side_effect=error),
+            patch("microsoft_teams.api.clients.conversation.activity.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.clients.conversation.activity.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.clients.conversation.activity.record_exception") as record_exception,
+            pytest.raises(RuntimeError, match="send failed"),
+        ):
+            await client.create_activity("conv-1", mock_activity)
+
+        record_outbound_call.assert_called_once_with("create")
+        record_outbound_error.assert_called_once_with("create")
+        record_exception.assert_called_once_with(tracer.spans[0], error)
+
+    async def test_targeted_activity_operations_record_diagnostics_operations(self, mock_http_client, mock_activity):
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        with patch("microsoft_teams.api.clients.conversation.activity.record_outbound_call") as record_outbound_call:
+            await client.create_targeted_activity("conv-1", mock_activity)
+            await client.update_targeted_activity("conv-1", "act-1", mock_activity)
+            await client.delete_targeted_activity("conv-1", "act-1")
+
+        assert record_outbound_call.call_args_list == [
+            call("create_targeted"),
+            call("update_targeted"),
+            call("delete_targeted"),
+        ]
 
     async def test_activity_update(self, request_capture, mock_activity):
         """Test updating an activity."""

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -393,6 +393,87 @@ class TestConversationActivityOperations:
         assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
         assert "authorization" in last_request.headers
 
+    async def test_direct_activities_client_methods_accept_service_url_and_agentic_identity_kwargs(
+        self, request_capture, mock_activity
+    ):
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "override-token"
+
+        identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        activities_client = ApiClient(
+            "https://default.service.url",
+            request_capture,
+            auth_provider=TestAuthProvider(),
+        ).conversations.activities_client
+        service_url = "https://override.service.url/"
+
+        await activities_client.create(
+            "test_conversation_id",
+            mock_activity,
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.update(
+            "test_conversation_id",
+            "activity-id",
+            mock_activity,
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.reply(
+            "test_conversation_id",
+            "activity-id",
+            mock_activity,
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.delete(
+            "test_conversation_id",
+            "activity-id",
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.get_members(
+            "test_conversation_id",
+            "activity-id",
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id/members"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+        assert calls == [(None, identity)] * 5
+
     async def test_grouped_activity_methods_accept_service_url_kwarg(self, request_capture, mock_activity):
         client = ConversationClient("https://default.service.url", request_capture)
         activities = client.activities("test_conversation_id")

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -364,6 +364,90 @@ class TestConversationActivityOperations:
         last_request = request_capture._capture.last_request
         assert last_request.headers["authorization"] == "Bearer override-token"
 
+    async def test_flattened_activity_create_accepts_service_url_and_agentic_identity_kwargs(
+        self, request_capture, mock_activity
+    ):
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "override-token"
+
+        identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        client = ApiClient(
+            "https://default.service.url",
+            request_capture,
+            auth_provider=TestAuthProvider(),
+        ).conversations
+
+        await client.create_activity(
+            "test_conversation_id",
+            mock_activity,
+            service_url="https://override.service.url/",
+            agentic_identity=identity,
+        )
+
+        assert calls == [(None, identity)]
+        last_request = request_capture._capture.last_request
+        assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+        assert "authorization" in last_request.headers
+
+    async def test_grouped_activity_methods_accept_service_url_kwarg(self, request_capture, mock_activity):
+        client = ConversationClient("https://default.service.url", request_capture)
+        activities = client.activities("test_conversation_id")
+        service_url = "https://override.service.url/"
+
+        await activities.create(mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+        )
+
+        await activities.update("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+
+        await activities.reply("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+
+        await activities.delete("activity-id", service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+
+        await activities.get_members("activity-id", service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id/members"
+        )
+
+        await activities.create_targeted(mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities?isTargetedActivity=true"
+        )
+
+        await activities.update_targeted("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+            "?isTargetedActivity=true"
+        )
+
+        await activities.delete_targeted("activity-id", service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+            "?isTargetedActivity=true"
+        )
+
     async def test_activity_create_agentic_identity_without_auth_provider_uses_http_client_auth(
         self, request_capture, mock_activity
     ):

--- a/packages/api/tests/unit/test_diagnostics.py
+++ b/packages/api/tests/unit/test_diagnostics.py
@@ -1,0 +1,95 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+# pyright: basic
+
+from unittest.mock import MagicMock, patch
+
+import microsoft_teams.api as api
+from microsoft_teams.api import TEAMS_API_METER_NAME, TEAMS_API_TRACER_NAME, TeamsApiTelemetry
+from microsoft_teams.api.diagnostics._helpers import (
+    get_meter,
+    get_tracer,
+    record_exception,
+    record_outbound_call,
+    record_outbound_error,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.trace import StatusCode
+
+
+def test_public_telemetry_names_are_exported():
+    assert TEAMS_API_TRACER_NAME == "Microsoft.Teams.Api"
+    assert TEAMS_API_METER_NAME == "Microsoft.Teams.Api"
+    assert TeamsApiTelemetry.tracer_name == "Microsoft.Teams.Api"
+    assert TeamsApiTelemetry.meter_name == "Microsoft.Teams.Api"
+    assert "TEAMS_API_TRACER_NAME" in api.__all__
+    assert "TEAMS_API_METER_NAME" in api.__all__
+    assert "TeamsApiTelemetry" in api.__all__
+
+
+def test_runtime_instrumentation_names_stay_internal():
+    private_groups = [
+        "API_ATTRIBUTE_NAMES",
+        "API_AUTH_FLOWS",
+        "API_METRIC_NAMES",
+        "API_OUTBOUND_OPERATIONS",
+        "API_SPAN_NAMES",
+    ]
+    for group in private_groups:
+        assert group not in api.__all__
+        assert not hasattr(api, group)
+
+
+def test_helpers_use_canonical_source_names():
+    with patch("microsoft_teams.api.diagnostics._helpers.trace.get_tracer") as mock_get_tracer:
+        tracer = get_tracer()
+
+    mock_get_tracer.assert_called_once_with("Microsoft.Teams.Api")
+    assert tracer is mock_get_tracer.return_value
+
+    with patch("microsoft_teams.api.diagnostics._helpers.metrics.get_meter") as mock_get_meter:
+        meter = get_meter()
+
+    mock_get_meter.assert_called_once_with("Microsoft.Teams.Api")
+    assert meter is mock_get_meter.return_value
+
+
+def test_outbound_metrics_are_recorded_with_operation_attribute():
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    meter = meter_provider.get_meter("Microsoft.Teams.Api")
+
+    with patch("microsoft_teams.api.diagnostics._helpers.get_meter", return_value=meter):
+        record_outbound_call("create")
+        record_outbound_error("create")
+
+    metrics = {}
+    metrics_data = metric_reader.get_metrics_data()
+    assert metrics_data is not None
+    for resource_metric in metrics_data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                metrics[metric.name] = metric
+
+    calls_point = metrics["teams.outbound.calls"].data.data_points[0]
+    errors_point = metrics["teams.outbound.errors"].data.data_points[0]
+    assert calls_point.value == 1
+    assert calls_point.attributes == {"operation": "create"}
+    assert errors_point.value == 1
+    assert errors_point.attributes == {"operation": "create"}
+    meter_provider.shutdown()
+
+
+def test_record_exception_marks_span_error():
+    span = MagicMock()
+    exception = RuntimeError("boom")
+
+    record_exception(span, exception)
+
+    span.record_exception.assert_called_once_with(exception)
+    status = span.set_status.call_args.args[0]
+    assert status.status_code == StatusCode.ERROR
+    assert status.description == "boom"

--- a/packages/api/tests/unit/test_diagnostics.py
+++ b/packages/api/tests/unit/test_diagnostics.py
@@ -74,8 +74,8 @@ def test_outbound_metrics_are_recorded_with_operation_attribute():
             for metric in scope_metric.metrics:
                 metrics[metric.name] = metric
 
-    calls_point = metrics["teams.outbound.calls"].data.data_points[0]
-    errors_point = metrics["teams.outbound.errors"].data.data_points[0]
+    calls_point = metrics["microsoft.teams.outbound.calls"].data.data_points[0]
+    errors_point = metrics["microsoft.teams.outbound.errors"].data.data_points[0]
     assert calls_point.value == 1
     assert calls_point.attributes == {"operation": "create"}
     assert errors_point.value == 1

--- a/packages/api/tests/unit/test_diagnostics.py
+++ b/packages/api/tests/unit/test_diagnostics.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 # pyright: basic
 
+import importlib.metadata
 from unittest.mock import MagicMock, patch
 
 import microsoft_teams.api as api
@@ -25,6 +26,7 @@ def test_public_telemetry_names_are_exported():
     assert TEAMS_API_METER_NAME == "Microsoft.Teams.Api"
     assert TeamsApiTelemetry.tracer_name == "Microsoft.Teams.Api"
     assert TeamsApiTelemetry.meter_name == "Microsoft.Teams.Api"
+    assert TeamsApiTelemetry.instrumentation_version == importlib.metadata.version("microsoft-teams-api")
     assert "TEAMS_API_TRACER_NAME" in api.__all__
     assert "TEAMS_API_METER_NAME" in api.__all__
     assert "TeamsApiTelemetry" in api.__all__
@@ -47,13 +49,19 @@ def test_helpers_use_canonical_source_names():
     with patch("microsoft_teams.api.diagnostics._helpers.trace.get_tracer") as mock_get_tracer:
         tracer = get_tracer()
 
-    mock_get_tracer.assert_called_once_with("Microsoft.Teams.Api")
+    mock_get_tracer.assert_called_once_with(
+        "Microsoft.Teams.Api",
+        instrumenting_library_version=TeamsApiTelemetry.instrumentation_version,
+    )
     assert tracer is mock_get_tracer.return_value
 
     with patch("microsoft_teams.api.diagnostics._helpers.metrics.get_meter") as mock_get_meter:
         meter = get_meter()
 
-    mock_get_meter.assert_called_once_with("Microsoft.Teams.Api")
+    mock_get_meter.assert_called_once_with(
+        "Microsoft.Teams.Api",
+        version=TeamsApiTelemetry.instrumentation_version,
+    )
     assert meter is mock_get_meter.return_value
 
 

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyjwt[crypto]>=2.12.0",
     "dependency-injector>=4.48.1",
     "msal>=1.37.0",
+    "opentelemetry-api>=1.41.0",
     "python-dotenv>=1.0.0",
     "pydantic-settings>=2.11.0",
 ]

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -5,10 +5,11 @@ Licensed under the MIT License.
 
 import logging
 
-from . import auth, contexts, events, plugins
+from . import auth, contexts, diagnostics, events, plugins
 from .app import App
 from .auth import *  # noqa: F403
 from .contexts import *  # noqa: F403
+from .diagnostics import *  # noqa: F403
 from .events import *  # noqa: F401, F403
 from .http import FastAPIAdapter, HttpServerAdapter
 from .http_stream import HttpStream
@@ -30,6 +31,7 @@ __all__: list[str] = [
     "to_threaded_conversation_id",
 ]
 __all__.extend(auth.__all__)
+__all__.extend(diagnostics.__all__)
 __all__.extend(events.__all__)
 __all__.extend(plugins.__all__)
 __all__.extend(contexts.__all__)

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -11,7 +11,7 @@ from .auth import *  # noqa: F403
 from .contexts import *  # noqa: F403
 from .diagnostics import *  # noqa: F403
 from .events import *  # noqa: F401, F403
-from .http import FastAPIAdapter, HttpServerAdapter
+from .http import FastAPIAdapter, HttpServer, HttpServerAdapter
 from .http_stream import HttpStream
 from .options import AppOptions
 from .plugins import *  # noqa: F401, F403
@@ -24,6 +24,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 __all__: list[str] = [
     "App",
     "AppOptions",
+    "HttpServer",
     "HttpServerAdapter",
     "FastAPIAdapter",
     "HttpStream",

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -297,6 +297,7 @@ class App(ActivityHandlerMixin):
         conversation_id: str,
         activity: str | ActivityParams | AdaptiveCard,
         *,
+        service_url: Optional[str] = None,
         agentic_identity: Optional[AgenticIdentity] = None,
     ) -> SentActivity:
         """Send an activity proactively to a conversation.
@@ -314,7 +315,7 @@ class App(ActivityHandlerMixin):
 
         conversation_ref = ConversationReference(
             channel_id="msteams",
-            service_url=self.api.service_url,
+            service_url=service_url or self.api.service_url,
             bot=Account(id=self.id),
             conversation=ConversationAccount(id=conversation_id),
         )
@@ -365,6 +366,7 @@ class App(ActivityHandlerMixin):
         message_id: str,
         activity: str | ActivityParams | AdaptiveCard,
         *,
+        service_url: Optional[str] = None,
         agentic_identity: Optional[AgenticIdentity] = None,
     ) -> SentActivity: ...
 
@@ -374,6 +376,7 @@ class App(ActivityHandlerMixin):
         conversation_id: str,
         message_id: str | ActivityParams | AdaptiveCard,
         *,
+        service_url: Optional[str] = None,
         agentic_identity: Optional[AgenticIdentity] = None,
     ) -> SentActivity: ...
 
@@ -383,6 +386,7 @@ class App(ActivityHandlerMixin):
         message_id: str | ActivityParams | AdaptiveCard = "",
         activity: str | ActivityParams | AdaptiveCard | None = None,
         *,
+        service_url: Optional[str] = None,
         agentic_identity: Optional[AgenticIdentity] = None,
     ) -> SentActivity:
         """Send an activity proactively to a conversation, optionally as a threaded reply.
@@ -407,12 +411,14 @@ class App(ActivityHandlerMixin):
             return await self.send(
                 to_threaded_conversation_id(conversation_id, message_id),
                 activity,
+                service_url=service_url,
                 agentic_identity=agentic_identity,
             )
 
         return await self.send(
             conversation_id,
             message_id,
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
 

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -117,7 +117,7 @@ class OauthHandlers:
                         record_exception(span, e)
                         record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.token_exchange, error_type)
 
-                    result = APP_OAUTH_RESULTS.precondition_failed
+                    result = APP_OAUTH_RESULTS.failure
                     span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
                     span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                     return InvokeResponse(
@@ -279,13 +279,13 @@ class OauthHandlers:
                             span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
                             span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                             return InvokeResponse(status=status)
-                        result = APP_OAUTH_RESULTS.precondition_failed
+                        result = APP_OAUTH_RESULTS.failure
                     else:
                         error_type = APP_OAUTH_ERROR_TYPES.exception
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                         record_exception(span, e)
                         record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
-                        result = APP_OAUTH_RESULTS.precondition_failed
+                        result = APP_OAUTH_RESULTS.failure
                     span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
                     span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                     return InvokeResponse(

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import logging
+from time import perf_counter
 from typing import Optional, Union
 
 from httpx import HTTPStatusError
@@ -20,6 +21,14 @@ from microsoft_teams.api import (
 )
 from microsoft_teams.common import EventEmitter
 
+from .diagnostics._constants import (
+    APP_ATTRIBUTE_NAMES,
+    APP_OAUTH_ERROR_TYPES,
+    APP_OAUTH_OPERATIONS,
+    APP_OAUTH_RESULTS,
+    APP_SPAN_NAMES,
+)
+from .diagnostics._helpers import get_tracer, record_exception, record_oauth_error, record_oauth_operation
 from .events import ErrorEvent, EventType, SignInEvent
 from .routing import ActivityContext
 
@@ -40,56 +49,92 @@ class OauthHandlers:
         activity = ctx.activity
         api = ctx.api
         next_handler = ctx.next
+        connection_name = activity.value.connection_name
+        result = APP_OAUTH_RESULTS.failure
+        started_at = perf_counter()
         try:
-            if activity.value.connection_name != self.default_connection_name:
-                logger.warning(
-                    f"Sign-in token exchange invoked with connection name '{activity.value.connection_name}', "
-                    f"but default connection name is '{self.default_connection_name}'. "
-                    f"Token verification will likely fail."
-                )
+            with get_tracer().start_as_current_span(
+                APP_SPAN_NAMES.oauth_token_exchange,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.token_exchange)
 
-            try:
-                token = await api.users.exchange_token(
-                    ExchangeUserTokenParams(
-                        connection_name=activity.value.connection_name,
-                        user_id=activity.from_.id,
-                        channel_id=activity.channel_id,
-                        exchange_request=TokenExchangeRequest(
-                            token=activity.value.token,
-                        ),
+                if connection_name != self.default_connection_name:
+                    logger.warning(
+                        f"Sign-in token exchange invoked with connection name '{connection_name}', "
+                        f"but default connection name is '{self.default_connection_name}'. "
+                        f"Token verification will likely fail."
                     )
-                )
-                self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
-                return None
-            except Exception as e:
-                if isinstance(e, HTTPStatusError):
-                    status = e.response.status_code
-                    if status not in (404, 400, 412):
+
+                try:
+                    token = await api.users.exchange_token(
+                        ExchangeUserTokenParams(
+                            connection_name=connection_name,
+                            user_id=activity.from_.id,
+                            channel_id=activity.channel_id,
+                            exchange_request=TokenExchangeRequest(
+                                token=activity.value.token,
+                            ),
+                        )
+                    )
+                    self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
+                    result = APP_OAUTH_RESULTS.success
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    return None
+                except Exception as e:
+                    if isinstance(e, HTTPStatusError):
+                        status = e.response.status_code
+                        if status not in (404, 400, 412):
+                            logger.error(
+                                f"Error exchanging token for user {activity.from_.id} in "
+                                f"conversation {activity.conversation.id}: {e}"
+                            )
+                            self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
+                            error_type = APP_OAUTH_ERROR_TYPES.http_error
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                            record_exception(span, e)
+                            record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.token_exchange, error_type)
+                            status = status or 500
+                            result = APP_OAUTH_RESULTS.failure
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                            return InvokeResponse(status=status)
+                        logger.info(
+                            f"Unable to exchange token for user {activity.from_.id} in "
+                            f"conversation {activity.conversation.id}: {e}"
+                        )
+                    else:
                         logger.error(
-                            f"Error exchanging token for user {activity.from_.id} in "
+                            f"Unable to exchange token for user {activity.from_.id} in "
                             f"conversation {activity.conversation.id}: {e}"
                         )
                         self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
-                        return InvokeResponse(status=status or 500)
-                    logger.info(
-                        f"Unable to exchange token for user {activity.from_.id} in "
-                        f"conversation {activity.conversation.id}: {e}"
+                        error_type = APP_OAUTH_ERROR_TYPES.exception
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                        record_exception(span, e)
+                        record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.token_exchange, error_type)
+
+                    result = APP_OAUTH_RESULTS.precondition_failed
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    return InvokeResponse(
+                        status=412,
+                        body=TokenExchangeInvokeResponse(
+                            id=activity.value.id,
+                            connection_name=connection_name,
+                            failure_detail=str(e) or "unable to exchange token...",
+                        ),
                     )
-                else:
-                    logger.error(
-                        f"Unable to exchange token for user {activity.from_.id} in "
-                        f"conversation {activity.conversation.id}: {e}"
-                    )
-                    self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
-                return InvokeResponse(
-                    status=412,
-                    body=TokenExchangeInvokeResponse(
-                        id=activity.value.id,
-                        connection_name=activity.value.connection_name,
-                        failure_detail=str(e) or "unable to exchange token...",
-                    ),
-                )
         finally:
+            record_oauth_operation(
+                connection_name,
+                APP_OAUTH_OPERATIONS.token_exchange,
+                result,
+                (perf_counter() - started_at) * 1000,
+            )
             await next_handler()
 
     async def sign_in_failure(
@@ -122,25 +167,45 @@ class OauthHandlers:
         """
         activity = ctx.activity
         next_handler = ctx.next
+        connection_name = self.default_connection_name
+        result = APP_OAUTH_RESULTS.notified
+        started_at = perf_counter()
         try:
-            failure = activity.value
-            ctx.logger.warning(
-                f"Sign-in failed for user {activity.from_.id} in "
-                f"conversation {activity.conversation.id}: "
-                f"{failure.code} — {failure.message}. "
-                f"If the code is 'resourcematchfailed', verify that your Entra app "
-                f"registration has 'Expose an API' configured with the correct "
-                f"Application ID URI matching your OAuth connection's Token Exchange URL."
-            )
-            self.event_emitter.emit(
-                "error",
-                ErrorEvent(
-                    error=Exception(f"Sign-in failure: {failure.code} — {failure.message}"),
-                    context={"activity": activity},
-                ),
-            )
-            return None
+            with get_tracer().start_as_current_span(
+                APP_SPAN_NAMES.oauth_signin_failure,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.signin_failure)
+                failure = activity.value
+                if failure.code:
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_failure_code, failure.code)
+                ctx.logger.warning(
+                    f"Sign-in failed for user {activity.from_.id} in "
+                    f"conversation {activity.conversation.id}: "
+                    f"{failure.code} — {failure.message}. "
+                    f"If the code is 'resourcematchfailed', verify that your Entra app "
+                    f"registration has 'Expose an API' configured with the correct "
+                    f"Application ID URI matching your OAuth connection's Token Exchange URL."
+                )
+                self.event_emitter.emit(
+                    "error",
+                    ErrorEvent(
+                        error=Exception(f"Sign-in failure: {failure.code} — {failure.message}"),
+                        context={"activity": activity},
+                    ),
+                )
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                return None
         finally:
+            record_oauth_operation(
+                connection_name,
+                APP_OAUTH_OPERATIONS.signin_failure,
+                result,
+                (perf_counter() - started_at) * 1000,
+            )
             await next_handler()
 
     async def sign_in_verify_state(
@@ -152,45 +217,85 @@ class OauthHandlers:
         activity = ctx.activity
         api = ctx.api
         next_handler = ctx.next
+        connection_name = self.default_connection_name
+        result = APP_OAUTH_RESULTS.failure
+        started_at = perf_counter()
         try:
-            if not activity.value.state:
-                logger.warning(
-                    f"Auth state not present for conversation id '{activity.conversation.id}' "
-                    f"and user id '{activity.from_.id}'. "
-                )
-                return InvokeResponse(status=404)
+            with get_tracer().start_as_current_span(
+                APP_SPAN_NAMES.oauth_verify_state,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.verify_state)
 
-            logger.debug(
-                f"Verifying sign-in state for user {activity.from_.id} in conversation"
-                f"{activity.conversation.id} with state {activity.value.state}"
-            )
-
-            try:
-                token = await api.users.get_token(
-                    GetUserTokenParams(
-                        connection_name=self.default_connection_name,
-                        user_id=activity.from_.id,
-                        channel_id=activity.channel_id,
-                        code=activity.value.state,
+                if not activity.value.state:
+                    logger.warning(
+                        f"Auth state not present for conversation id '{activity.conversation.id}' "
+                        f"and user id '{activity.from_.id}'. "
                     )
-                )
-                self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
+                    result = APP_OAUTH_RESULTS.no_token
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 404)
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    return InvokeResponse(status=404)
+
                 logger.debug(
-                    f"Sign-in state verified for user {activity.from_.id} in conversation {activity.conversation.id}"
+                    f"Verifying sign-in state for user {activity.from_.id} in conversation"
+                    f"{activity.conversation.id} with state {activity.value.state}"
                 )
-                return None
-            except Exception as e:
-                logger.error(
-                    f"Error verifying sign-in state for user {activity.from_.id} in conversation"
-                    f"{activity.conversation.id}: {e}"
-                )
-                if isinstance(e, HTTPStatusError):
-                    status = e.response.status_code
-                    if status not in (404, 400, 412):
-                        self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
-                        return InvokeResponse(status=status or 500)
-                return InvokeResponse(
-                    status=412,
-                )
+
+                try:
+                    token = await api.users.get_token(
+                        GetUserTokenParams(
+                            connection_name=connection_name,
+                            user_id=activity.from_.id,
+                            channel_id=activity.channel_id,
+                            code=activity.value.state,
+                        )
+                    )
+                    self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
+                    logger.debug(
+                        f"Sign-in state verified for user {activity.from_.id} in conversation "
+                        f"{activity.conversation.id}"
+                    )
+                    result = APP_OAUTH_RESULTS.success
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    return None
+                except Exception as e:
+                    logger.error(
+                        f"Error verifying sign-in state for user {activity.from_.id} in conversation"
+                        f"{activity.conversation.id}: {e}"
+                    )
+                    if isinstance(e, HTTPStatusError):
+                        status = e.response.status_code
+                        if status not in (404, 400, 412):
+                            self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
+                            error_type = APP_OAUTH_ERROR_TYPES.http_error
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                            record_exception(span, e)
+                            record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
+                            status = status or 500
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                            return InvokeResponse(status=status)
+                        result = APP_OAUTH_RESULTS.precondition_failed
+                    else:
+                        error_type = APP_OAUTH_ERROR_TYPES.exception
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                        record_exception(span, e)
+                        record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
+                        result = APP_OAUTH_RESULTS.precondition_failed
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    return InvokeResponse(
+                        status=412,
+                    )
         finally:
+            record_oauth_operation(
+                connection_name,
+                APP_OAUTH_OPERATIONS.verify_state,
+                result,
+                (perf_counter() - started_at) * 1000,
+            )
             await next_handler()

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from .app_events import EventManager
 
 from .auth_provider import AppAuthProvider
+from .diagnostics import with_teams_baggage
 from .diagnostics._constants import APP_ATTRIBUTE_NAMES, APP_HANDLER_DISPATCHES, APP_SPAN_NAMES
 from .diagnostics._helpers import (
     get_tracer,
@@ -195,20 +196,21 @@ class ActivityProcessor:
         activity_type = activity.type
         record_activity_received(activity_type)
 
-        with get_tracer().start_as_current_span(
-            APP_SPAN_NAMES.turn,
-            record_exception=False,
-            set_status_on_exception=False,
-        ) as turn_span:
-            self._set_turn_span_attributes(turn_span, activity)
-            turn_started_at = perf_counter()
-            try:
-                response = await self._process_activity_core(plugins, event, activity)
-            except Exception as error:
-                record_exception(turn_span, error)
-                raise
-            finally:
-                record_turn_duration((perf_counter() - turn_started_at) * 1000, activity_type)
+        with with_teams_baggage(activity):
+            with get_tracer().start_as_current_span(
+                APP_SPAN_NAMES.turn,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as turn_span:
+                self._set_turn_span_attributes(turn_span, activity)
+                turn_started_at = perf_counter()
+                try:
+                    response = await self._process_activity_core(plugins, event, activity)
+                except Exception as error:
+                    record_exception(turn_span, error)
+                    raise
+                finally:
+                    record_turn_duration((perf_counter() - turn_started_at) * 1000, activity_type)
 
         return response
 
@@ -233,7 +235,6 @@ class ActivityProcessor:
                 )
                 await ctx.next()
 
-            route._teams_handler_dispatch = APP_HANDLER_DISPATCHES.plugin  # type: ignore[attr-defined]
             return route
 
         plugin_routes = [
@@ -294,13 +295,14 @@ class ActivityProcessor:
             attributes[APP_ATTRIBUTE_NAMES.service_url] = activity.service_url
         return attributes
 
-    def _handler_dispatch(self, handler: ActivityHandler) -> str:
-        dispatch = getattr(handler, "_teams_handler_dispatch", None)
-        return dispatch if isinstance(dispatch, str) else APP_HANDLER_DISPATCHES.route
+    def _handler_dispatch(self, activity: ActivityBase) -> str:
+        if isinstance(activity, InvokeActivityBase):
+            return APP_HANDLER_DISPATCHES.invoke
+        return APP_HANDLER_DISPATCHES.type
 
     def _handler_type(self, activity: ActivityBase) -> str:
         if isinstance(activity, InvokeActivityBase):
-            return f"invoke.{activity.name}"
+            return activity.name
         return activity.type
 
     def _invoke_name(self, activity: ActivityBase) -> str | None:
@@ -362,7 +364,7 @@ class ActivityProcessor:
 
     async def _execute_handler(self, ctx: ActivityContext[ActivityBase], handler: ActivityHandler) -> Optional[Any]:
         handler_type = self._handler_type(ctx.activity)
-        handler_dispatch = self._handler_dispatch(handler)
+        handler_dispatch = self._handler_dispatch(ctx.activity)
         attributes = {
             APP_ATTRIBUTE_NAMES.handler_type: handler_type,
             APP_ATTRIBUTE_NAMES.handler_dispatch: handler_dispatch,

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import logging
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from microsoft_teams.api import (
@@ -18,15 +19,29 @@ from microsoft_teams.api import (
     TokenProtocol,
     is_invoke_response,
 )
+from microsoft_teams.api.activities import Activity as ValidatedActivity
+from microsoft_teams.api.activities.invoke_activity import InvokeActivity as InvokeActivityBase
 from microsoft_teams.api.auth.cloud_environment import PUBLIC, CloudEnvironment
 from microsoft_teams.api.clients.user.params import GetUserTokenParams
 from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Client, LocalStorage, Storage
+from opentelemetry.trace import Span
 
 if TYPE_CHECKING:
     from .app_events import EventManager
 
 from .auth_provider import AppAuthProvider
+from .diagnostics._constants import APP_ATTRIBUTE_NAMES, APP_HANDLER_DISPATCHES, APP_SPAN_NAMES
+from .diagnostics._helpers import (
+    get_tracer,
+    record_activity_received,
+    record_exception,
+    record_handler_dispatched,
+    record_handler_duration,
+    record_handler_failure,
+    record_handler_unmatched,
+    record_turn_duration,
+)
 from .events import ActivityEvent, ActivityResponseEvent, ActivitySentEvent, ErrorEvent
 from .plugins import PluginActivityEvent, PluginBase, StreamCancelledError
 from .routing.activity_context import ActivityContext
@@ -177,7 +192,29 @@ class ActivityProcessor:
     async def process_activity(self, plugins: List[PluginBase], event: ActivityEvent) -> InvokeResponse[Any]:
         activity_dict = event.body.model_dump(by_alias=True, exclude_none=True)
         activity = ActivityTypeAdapter.validate_python(activity_dict)
+        activity_type = activity.type
+        record_activity_received(activity_type)
 
+        with get_tracer().start_as_current_span(
+            APP_SPAN_NAMES.turn,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as turn_span:
+            self._set_turn_span_attributes(turn_span, activity)
+            turn_started_at = perf_counter()
+            try:
+                response = await self._process_activity_core(plugins, event, activity)
+            except Exception as error:
+                record_exception(turn_span, error)
+                raise
+            finally:
+                record_turn_duration((perf_counter() - turn_started_at) * 1000, activity_type)
+
+        return response
+
+    async def _process_activity_core(
+        self, plugins: List[PluginBase], event: ActivityEvent, activity: ValidatedActivity
+    ) -> InvokeResponse[Any]:
         activityCtx = await self._build_context(activity, event.token, plugins)
 
         logger.debug(f"Received activity: {activityCtx.activity}")
@@ -196,6 +233,7 @@ class ActivityProcessor:
                 )
                 await ctx.next()
 
+            route._teams_handler_dispatch = APP_HANDLER_DISPATCHES.plugin  # type: ignore[attr-defined]
             return route
 
         plugin_routes = [
@@ -206,6 +244,9 @@ class ActivityProcessor:
         handlers = plugin_routes + handlers
 
         response: InvokeResponse[Any]
+
+        if not handlers:
+            record_handler_unmatched(activity.type, self._invoke_name(activity))
 
         if not self.event_manager:
             raise ValueError("EventManager was not initialized properly")
@@ -241,6 +282,36 @@ class ActivityProcessor:
 
         return response
 
+    def _activity_attributes(self, activity: ActivityBase) -> dict[str, str]:
+        attributes = {
+            APP_ATTRIBUTE_NAMES.activity_type: activity.type,
+            APP_ATTRIBUTE_NAMES.activity_id: activity.id,
+            APP_ATTRIBUTE_NAMES.conversation_id: activity.conversation.id,
+            APP_ATTRIBUTE_NAMES.channel_id: activity.channel_id,
+            APP_ATTRIBUTE_NAMES.bot_id: activity.recipient.id,
+        }
+        if activity.service_url:
+            attributes[APP_ATTRIBUTE_NAMES.service_url] = activity.service_url
+        return attributes
+
+    def _handler_dispatch(self, handler: ActivityHandler) -> str:
+        dispatch = getattr(handler, "_teams_handler_dispatch", None)
+        return dispatch if isinstance(dispatch, str) else APP_HANDLER_DISPATCHES.route
+
+    def _handler_type(self, activity: ActivityBase) -> str:
+        if isinstance(activity, InvokeActivityBase):
+            return f"invoke.{activity.name}"
+        return activity.type
+
+    def _invoke_name(self, activity: ActivityBase) -> str | None:
+        if isinstance(activity, InvokeActivityBase):
+            return activity.name
+        return None
+
+    def _set_turn_span_attributes(self, span: Span, activity: ActivityBase) -> None:
+        for key, value in self._activity_attributes(activity).items():
+            span.set_attribute(key, value)
+
     async def execute_middleware_chain(
         self, ctx: ActivityContext[ActivityBase], handlers: List[ActivityHandler]
     ) -> Optional[Dict[str, Any]]:
@@ -275,7 +346,7 @@ class ActivityProcessor:
                         ctx.set_next(noop)
 
                     # Execute current handler and capture return value
-                    result = await handlers[index](ctx)
+                    result = await self._execute_handler(ctx, handlers[index])
 
                     # Update the response iff response hasn't already been received
                     if result is not None:
@@ -288,3 +359,28 @@ class ActivityProcessor:
         await first_handler()
 
         return response
+
+    async def _execute_handler(self, ctx: ActivityContext[ActivityBase], handler: ActivityHandler) -> Optional[Any]:
+        handler_type = self._handler_type(ctx.activity)
+        handler_dispatch = self._handler_dispatch(handler)
+        attributes = {
+            APP_ATTRIBUTE_NAMES.handler_type: handler_type,
+            APP_ATTRIBUTE_NAMES.handler_dispatch: handler_dispatch,
+        }
+        record_handler_dispatched(handler_type, handler_dispatch)
+        started_at = perf_counter()
+        with get_tracer().start_as_current_span(
+            APP_SPAN_NAMES.handler,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            for key, value in attributes.items():
+                span.set_attribute(key, value)
+            try:
+                return await handler(ctx)
+            except Exception as exception:
+                record_exception(span, exception)
+                record_handler_failure(handler_type, handler_dispatch)
+                raise
+            finally:
+                record_handler_duration((perf_counter() - started_at) * 1000, handler_type, handler_dispatch)

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/__init__.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from ._telemetry import (
+    TEAMS_BOT_APPLICATION_METER_NAME,
+    TEAMS_BOT_APPLICATION_TRACER_NAME,
+    TeamsBotApplicationTelemetry,
+)
+
+__all__ = [
+    "TEAMS_BOT_APPLICATION_METER_NAME",
+    "TEAMS_BOT_APPLICATION_TRACER_NAME",
+    "TeamsBotApplicationTelemetry",
+]

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/__init__.py
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from ._baggage import TeamsBaggageBuilder, with_teams_baggage
 from ._telemetry import (
     TEAMS_BOT_APPLICATION_METER_NAME,
     TEAMS_BOT_APPLICATION_TRACER_NAME,
@@ -12,5 +13,7 @@ from ._telemetry import (
 __all__ = [
     "TEAMS_BOT_APPLICATION_METER_NAME",
     "TEAMS_BOT_APPLICATION_TRACER_NAME",
+    "TeamsBaggageBuilder",
     "TeamsBotApplicationTelemetry",
+    "with_teams_baggage",
 ]

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_baggage.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_baggage.py
@@ -1,0 +1,156 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager
+from contextvars import Token
+from types import TracebackType
+from typing import TYPE_CHECKING, Self
+
+from microsoft_teams.api import ActivityBase
+from opentelemetry import baggage
+from opentelemetry import context as otel_context
+from opentelemetry.context import Context
+
+from ._constants import APP_BAGGAGE_KEYS
+
+if TYPE_CHECKING:
+    from ..routing import ActivityContext
+
+
+class _TeamsBaggageScope(AbstractContextManager[None]):
+    def __init__(self, entries: dict[str, str]) -> None:
+        self._entries = entries
+        self._token: Token[Context] | None = None
+
+    def __enter__(self) -> None:
+        ctx = otel_context.get_current()
+        for key, value in self._entries.items():
+            ctx = baggage.set_baggage(key, value, context=ctx)
+        self._token = otel_context.attach(ctx)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        if self._token is not None:
+            otel_context.detach(self._token)
+            self._token = None
+
+
+class TeamsBaggageBuilder:
+    """Builds an OpenTelemetry baggage scope for Teams Agent365 context."""
+
+    def __init__(self) -> None:
+        self._entries: dict[str, str] = {}
+
+    @classmethod
+    def from_activity(cls, activity: ActivityBase) -> Self:
+        builder = cls()
+        tenant_id = activity.recipient.tenant_id
+        if tenant_id is None and activity.channel_data is not None and activity.channel_data.tenant is not None:
+            tenant_id = activity.channel_data.tenant.id
+
+        builder.tenant_id(tenant_id)
+        builder.conversation_id(activity.conversation.id)
+        builder.conversation_item_link(activity.service_url)
+        builder.channel_name(activity.channel_id)
+        builder.user_id(activity.from_.aad_object_id)
+        builder.user_name(activity.from_.name)
+        builder.user_email(activity.from_.email)
+        builder.agent_id(activity.recipient.agentic_app_id or activity.recipient.id)
+        builder.agent_name(activity.recipient.name)
+        builder.agentic_user_id(activity.recipient.agentic_user_id)
+        builder.agentic_user_email(activity.recipient.email)
+        builder.agent_description(activity.recipient.user_role)
+        builder.agent_blueprint_id(activity.recipient.agentic_app_blueprint_id)
+        return builder
+
+    @classmethod
+    def from_activity_context(cls, ctx: "ActivityContext[ActivityBase]") -> Self:
+        return cls.from_activity(ctx.activity)
+
+    def tenant_id(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.tenant_id, value)
+
+    def conversation_id(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.conversation_id, value)
+
+    def conversation_item_link(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.conversation_item_link, value)
+
+    def channel_name(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.channel_name, value)
+
+    def channel_link(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.channel_link, value)
+
+    def agent_id(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.agent_id, value)
+
+    def agent_name(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.agent_name, value)
+
+    def agentic_user_id(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.agentic_user_id, value)
+
+    def agent_blueprint_id(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.agent_blueprint_id, value)
+
+    def user_name(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.user_name, value)
+
+    def operation_source(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.operation_source, value)
+
+    def invoke_agent_server(self, address: str | None, port: int | str | None = None) -> Self:
+        self.set(APP_BAGGAGE_KEYS.server_address, address)
+        if port is not None:
+            self.set(APP_BAGGAGE_KEYS.server_port, str(port))
+        return self
+
+    def user_id(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.user_id, value)
+
+    def user_email(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.user_email, value)
+
+    def agent_description(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.agent_description, value)
+
+    def agentic_user_email(self, value: str | None) -> Self:
+        return self.set(APP_BAGGAGE_KEYS.agentic_user_email, value)
+
+    def set(self, key: str, value: str | None) -> Self:
+        normalized_key = key.strip()
+        normalized_value = value.strip() if value is not None else None
+        if normalized_key and normalized_value:
+            self._entries[normalized_key] = normalized_value
+        return self
+
+    def build(self) -> AbstractContextManager[None]:
+        return _TeamsBaggageScope(dict(self._entries))
+
+
+@contextmanager
+def with_teams_baggage(
+    source: ActivityBase | ActivityContext[ActivityBase] | None = None,
+    configure: Callable[[TeamsBaggageBuilder], None] | None = None,
+) -> Iterator[None]:
+    builder = TeamsBaggageBuilder()
+    if isinstance(source, ActivityBase):
+        builder = TeamsBaggageBuilder.from_activity(source)
+    elif source is not None:
+        builder = TeamsBaggageBuilder.from_activity_context(source)
+
+    if configure is not None:
+        configure(builder)
+
+    with builder.build():
+        yield

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _AppAttributeNames:
+    activity_id: str = "activity.id"
+    activity_type: str = "activity.type"
+    bot_id: str = "bot.id"
+    channel_id: str = "channel.id"
+    conversation_id: str = "conversation.id"
+    handler_dispatch: str = "handler.dispatch"
+    handler_type: str = "handler.type"
+    invoke_name: str = "invoke.name"
+    service_url: str = "service.url"
+
+
+@dataclass(frozen=True)
+class _AppHandlerDispatches:
+    plugin: str = "plugin"
+    route: str = "route"
+
+
+@dataclass(frozen=True)
+class _AppMetricNames:
+    activities_received: str = "teams.activities.received"
+    handler_dispatched: str = "teams.handler.dispatched"
+    handler_duration: str = "teams.handler.duration"
+    handler_failures: str = "teams.handler.failures"
+    handler_unmatched: str = "teams.handler.unmatched"
+    turn_duration: str = "teams.turn.duration"
+
+
+@dataclass(frozen=True)
+class _AppSpanNames:
+    handler: str = "handler"
+    turn: str = "turn"
+
+
+APP_ATTRIBUTE_NAMES = _AppAttributeNames()
+APP_HANDLER_DISPATCHES = _AppHandlerDispatches()
+APP_METRIC_NAMES = _AppMetricNames()
+APP_SPAN_NAMES = _AppSpanNames()

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -7,6 +7,27 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class _AppBaggageKeys:
+    agent_blueprint_id: str = "microsoft.a365.agent.blueprint.id"
+    agent_description: str = "gen_ai.agent.description"
+    agent_id: str = "gen_ai.agent.id"
+    agent_name: str = "gen_ai.agent.name"
+    agentic_user_email: str = "microsoft.agent.user.email"
+    agentic_user_id: str = "microsoft.agent.user.id"
+    channel_link: str = "microsoft.channel.link"
+    channel_name: str = "microsoft.channel.name"
+    conversation_id: str = "gen_ai.conversation.id"
+    conversation_item_link: str = "microsoft.conversation.item.link"
+    operation_source: str = "service.name"
+    server_address: str = "server.address"
+    server_port: str = "server.port"
+    tenant_id: str = "microsoft.tenant.id"
+    user_email: str = "user.email"
+    user_id: str = "user.id"
+    user_name: str = "user.name"
+
+
+@dataclass(frozen=True)
 class _AppAttributeNames:
     activity_id: str = "activity.id"
     activity_type: str = "activity.type"
@@ -21,8 +42,8 @@ class _AppAttributeNames:
 
 @dataclass(frozen=True)
 class _AppHandlerDispatches:
-    plugin: str = "plugin"
-    route: str = "route"
+    invoke: str = "invoke"
+    type: str = "type"
 
 
 @dataclass(frozen=True)
@@ -41,6 +62,7 @@ class _AppSpanNames:
     turn: str = "turn"
 
 
+APP_BAGGAGE_KEYS = _AppBaggageKeys()
 APP_ATTRIBUTE_NAMES = _AppAttributeNames()
 APP_HANDLER_DISPATCHES = _AppHandlerDispatches()
 APP_METRIC_NAMES = _AppMetricNames()

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -37,6 +37,13 @@ class _AppAttributeNames:
     handler_dispatch: str = "handler.dispatch"
     handler_type: str = "handler.type"
     invoke_name: str = "invoke.name"
+    invoke_response_status: str = "invoke.response.status"
+    oauth_callback_invoked: str = "oauth.callback.invoked"
+    oauth_connection: str = "oauth.connection"
+    oauth_error_type: str = "oauth.error.type"
+    oauth_failure_code: str = "oauth.failure.code"
+    oauth_operation: str = "oauth.operation"
+    oauth_result: str = "oauth.result"
     service_url: str = "service.url"
 
 
@@ -53,12 +60,40 @@ class _AppMetricNames:
     handler_duration: str = "teams.handler.duration"
     handler_failures: str = "teams.handler.failures"
     handler_unmatched: str = "teams.handler.unmatched"
+    oauth_errors: str = "teams.oauth.errors"
+    oauth_operation_duration: str = "teams.oauth.operation.duration"
+    oauth_operations: str = "teams.oauth.operations"
     turn_duration: str = "teams.turn.duration"
+
+
+@dataclass(frozen=True)
+class _AppOAuthErrorTypes:
+    exception: str = "exception"
+    http_error: str = "http_error"
+
+
+@dataclass(frozen=True)
+class _AppOAuthOperations:
+    signin_failure: str = "signin_failure"
+    token_exchange: str = "token_exchange"
+    verify_state: str = "verify_state"
+
+
+@dataclass(frozen=True)
+class _AppOAuthResults:
+    failure: str = "failure"
+    no_token: str = "no_token"
+    notified: str = "notified"
+    precondition_failed: str = "precondition_failed"
+    success: str = "success"
 
 
 @dataclass(frozen=True)
 class _AppSpanNames:
     handler: str = "handler"
+    oauth_signin_failure: str = "oauth.signin_failure"
+    oauth_token_exchange: str = "oauth.token_exchange"
+    oauth_verify_state: str = "oauth.verify_state"
     turn: str = "turn"
 
 
@@ -66,4 +101,7 @@ APP_BAGGAGE_KEYS = _AppBaggageKeys()
 APP_ATTRIBUTE_NAMES = _AppAttributeNames()
 APP_HANDLER_DISPATCHES = _AppHandlerDispatches()
 APP_METRIC_NAMES = _AppMetricNames()
+APP_OAUTH_ERROR_TYPES = _AppOAuthErrorTypes()
+APP_OAUTH_OPERATIONS = _AppOAuthOperations()
+APP_OAUTH_RESULTS = _AppOAuthResults()
 APP_SPAN_NAMES = _AppSpanNames()

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -55,15 +55,15 @@ class _AppHandlerDispatches:
 
 @dataclass(frozen=True)
 class _AppMetricNames:
-    activities_received: str = "teams.activities.received"
-    handler_dispatched: str = "teams.handler.dispatched"
-    handler_duration: str = "teams.handler.duration"
-    handler_failures: str = "teams.handler.failures"
-    handler_unmatched: str = "teams.handler.unmatched"
-    oauth_errors: str = "teams.oauth.errors"
-    oauth_operation_duration: str = "teams.oauth.operation.duration"
-    oauth_operations: str = "teams.oauth.operations"
-    turn_duration: str = "teams.turn.duration"
+    activities_received: str = "microsoft.teams.activities.received"
+    handler_dispatched: str = "microsoft.teams.handler.dispatched"
+    handler_duration: str = "microsoft.teams.handler.duration"
+    handler_failures: str = "microsoft.teams.handler.failures"
+    handler_unmatched: str = "microsoft.teams.handler.unmatched"
+    oauth_errors: str = "microsoft.teams.oauth.errors"
+    oauth_operation_duration: str = "microsoft.teams.oauth.operation.duration"
+    oauth_operations: str = "microsoft.teams.oauth.operations"
+    turn_duration: str = "microsoft.teams.activity.process.duration"
 
 
 @dataclass(frozen=True)
@@ -84,17 +84,16 @@ class _AppOAuthResults:
     failure: str = "failure"
     no_token: str = "no_token"
     notified: str = "notified"
-    precondition_failed: str = "precondition_failed"
     success: str = "success"
 
 
 @dataclass(frozen=True)
 class _AppSpanNames:
-    handler: str = "handler"
-    oauth_signin_failure: str = "oauth.signin_failure"
-    oauth_token_exchange: str = "oauth.token_exchange"
-    oauth_verify_state: str = "oauth.verify_state"
-    turn: str = "turn"
+    handler: str = "microsoft.teams.handler"
+    oauth_signin_failure: str = "microsoft.teams.oauth.signin_failure"
+    oauth_token_exchange: str = "microsoft.teams.oauth.token_exchange"
+    oauth_verify_state: str = "microsoft.teams.oauth.verify_state"
+    turn: str = "microsoft.teams.activity.process"
 
 
 APP_BAGGAGE_KEYS = _AppBaggageKeys()

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
@@ -4,9 +4,10 @@ Licensed under the MIT License.
 """
 
 from opentelemetry import metrics, trace
-from opentelemetry.metrics import Meter
+from opentelemetry.metrics import Counter, Histogram, Meter
 from opentelemetry.trace import Span, Status, StatusCode, Tracer
 
+from ._constants import APP_ATTRIBUTE_NAMES, APP_METRIC_NAMES
 from ._telemetry import TeamsBotApplicationTelemetry
 
 
@@ -16,6 +17,75 @@ def get_tracer() -> Tracer:
 
 def get_meter() -> Meter:
     return metrics.get_meter(TeamsBotApplicationTelemetry.meter_name)
+
+
+def get_activities_received_counter() -> Counter:
+    return get_meter().create_counter(APP_METRIC_NAMES.activities_received)
+
+
+def get_handler_dispatched_counter() -> Counter:
+    return get_meter().create_counter(APP_METRIC_NAMES.handler_dispatched)
+
+
+def get_handler_duration_histogram() -> Histogram:
+    return get_meter().create_histogram(APP_METRIC_NAMES.handler_duration, unit="ms")
+
+
+def get_handler_failures_counter() -> Counter:
+    return get_meter().create_counter(APP_METRIC_NAMES.handler_failures)
+
+
+def get_handler_unmatched_counter() -> Counter:
+    return get_meter().create_counter(APP_METRIC_NAMES.handler_unmatched)
+
+
+def get_turn_duration_histogram() -> Histogram:
+    return get_meter().create_histogram(APP_METRIC_NAMES.turn_duration, unit="ms")
+
+
+def record_activity_received(activity_type: str) -> None:
+    get_activities_received_counter().add(1, {APP_ATTRIBUTE_NAMES.activity_type: activity_type})
+
+
+def record_handler_dispatched(handler_type: str, handler_dispatch: str) -> None:
+    get_handler_dispatched_counter().add(
+        1,
+        {
+            APP_ATTRIBUTE_NAMES.handler_type: handler_type,
+            APP_ATTRIBUTE_NAMES.handler_dispatch: handler_dispatch,
+        },
+    )
+
+
+def record_handler_duration(duration_ms: float, handler_type: str, handler_dispatch: str) -> None:
+    get_handler_duration_histogram().record(
+        duration_ms,
+        {
+            APP_ATTRIBUTE_NAMES.handler_type: handler_type,
+            APP_ATTRIBUTE_NAMES.handler_dispatch: handler_dispatch,
+        },
+    )
+
+
+def record_handler_failure(handler_type: str, handler_dispatch: str) -> None:
+    get_handler_failures_counter().add(
+        1,
+        {
+            APP_ATTRIBUTE_NAMES.handler_type: handler_type,
+            APP_ATTRIBUTE_NAMES.handler_dispatch: handler_dispatch,
+        },
+    )
+
+
+def record_handler_unmatched(activity_type: str, invoke_name: str | None = None) -> None:
+    attributes = {APP_ATTRIBUTE_NAMES.activity_type: activity_type}
+    if invoke_name:
+        attributes[APP_ATTRIBUTE_NAMES.invoke_name] = invoke_name
+    get_handler_unmatched_counter().add(1, attributes)
+
+
+def record_turn_duration(duration_ms: float, activity_type: str) -> None:
+    get_turn_duration_histogram().record(duration_ms, {APP_ATTRIBUTE_NAMES.activity_type: activity_type})
 
 
 def record_exception(span: Span, exception: BaseException) -> None:

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
@@ -12,11 +12,17 @@ from ._telemetry import TeamsBotApplicationTelemetry
 
 
 def get_tracer() -> Tracer:
-    return trace.get_tracer(TeamsBotApplicationTelemetry.tracer_name)
+    return trace.get_tracer(
+        TeamsBotApplicationTelemetry.tracer_name,
+        instrumenting_library_version=TeamsBotApplicationTelemetry.instrumentation_version,
+    )
 
 
 def get_meter() -> Meter:
-    return metrics.get_meter(TeamsBotApplicationTelemetry.meter_name)
+    return metrics.get_meter(
+        TeamsBotApplicationTelemetry.meter_name,
+        version=TeamsBotApplicationTelemetry.instrumentation_version,
+    )
 
 
 def get_activities_received_counter() -> Counter:

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
@@ -39,6 +39,18 @@ def get_handler_unmatched_counter() -> Counter:
     return get_meter().create_counter(APP_METRIC_NAMES.handler_unmatched)
 
 
+def get_oauth_errors_counter() -> Counter:
+    return get_meter().create_counter(APP_METRIC_NAMES.oauth_errors)
+
+
+def get_oauth_operation_duration_histogram() -> Histogram:
+    return get_meter().create_histogram(APP_METRIC_NAMES.oauth_operation_duration, unit="ms")
+
+
+def get_oauth_operations_counter() -> Counter:
+    return get_meter().create_counter(APP_METRIC_NAMES.oauth_operations)
+
+
 def get_turn_duration_histogram() -> Histogram:
     return get_meter().create_histogram(APP_METRIC_NAMES.turn_duration, unit="ms")
 
@@ -82,6 +94,27 @@ def record_handler_unmatched(activity_type: str, invoke_name: str | None = None)
     if invoke_name:
         attributes[APP_ATTRIBUTE_NAMES.invoke_name] = invoke_name
     get_handler_unmatched_counter().add(1, attributes)
+
+
+def record_oauth_error(connection_name: str, operation: str, error_type: str) -> None:
+    get_oauth_errors_counter().add(
+        1,
+        {
+            APP_ATTRIBUTE_NAMES.oauth_connection: connection_name,
+            APP_ATTRIBUTE_NAMES.oauth_operation: operation,
+            APP_ATTRIBUTE_NAMES.oauth_error_type: error_type,
+        },
+    )
+
+
+def record_oauth_operation(connection_name: str, operation: str, result: str, duration_ms: float) -> None:
+    attributes = {
+        APP_ATTRIBUTE_NAMES.oauth_connection: connection_name,
+        APP_ATTRIBUTE_NAMES.oauth_operation: operation,
+        APP_ATTRIBUTE_NAMES.oauth_result: result,
+    }
+    get_oauth_operations_counter().add(1, attributes)
+    get_oauth_operation_duration_histogram().record(duration_ms, attributes)
 
 
 def record_turn_duration(duration_ms: float, activity_type: str) -> None:

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
@@ -1,0 +1,23 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from opentelemetry import metrics, trace
+from opentelemetry.metrics import Meter
+from opentelemetry.trace import Span, Status, StatusCode, Tracer
+
+from ._telemetry import TeamsBotApplicationTelemetry
+
+
+def get_tracer() -> Tracer:
+    return trace.get_tracer(TeamsBotApplicationTelemetry.tracer_name)
+
+
+def get_meter() -> Meter:
+    return metrics.get_meter(TeamsBotApplicationTelemetry.meter_name)
+
+
+def record_exception(span: Span, exception: BaseException) -> None:
+    span.record_exception(exception)
+    span.set_status(Status(StatusCode.ERROR, str(exception)))

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_telemetry.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_telemetry.py
@@ -1,0 +1,14 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+TEAMS_BOT_APPLICATION_TRACER_NAME = "Microsoft.Teams.Apps"
+TEAMS_BOT_APPLICATION_METER_NAME = "Microsoft.Teams.Apps"
+
+
+class TeamsBotApplicationTelemetry:
+    """OpenTelemetry source names for the Teams app orchestration package."""
+
+    tracer_name = TEAMS_BOT_APPLICATION_TRACER_NAME
+    meter_name = TEAMS_BOT_APPLICATION_METER_NAME

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_telemetry.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_telemetry.py
@@ -3,8 +3,11 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import importlib.metadata
+
 TEAMS_BOT_APPLICATION_TRACER_NAME = "Microsoft.Teams.Apps"
 TEAMS_BOT_APPLICATION_METER_NAME = "Microsoft.Teams.Apps"
+TEAMS_BOT_APPLICATION_INSTRUMENTATION_VERSION = importlib.metadata.version("microsoft-teams-apps")
 
 
 class TeamsBotApplicationTelemetry:
@@ -12,3 +15,4 @@ class TeamsBotApplicationTelemetry:
 
     tracer_name = TEAMS_BOT_APPLICATION_TRACER_NAME
     meter_name = TEAMS_BOT_APPLICATION_METER_NAME
+    instrumentation_version = TEAMS_BOT_APPLICATION_INSTRUMENTATION_VERSION

--- a/packages/apps/src/microsoft_teams/apps/http/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/http/__init__.py
@@ -5,12 +5,14 @@ Licensed under the MIT License.
 
 from .adapter import HttpMethod, HttpRequest, HttpResponse, HttpRouteHandler, HttpServerAdapter
 from .fastapi_adapter import FastAPIAdapter
+from .http_server import HttpServer
 
 __all__ = [
     "HttpMethod",
     "HttpRequest",
     "HttpResponse",
     "HttpRouteHandler",
+    "HttpServer",
     "HttpServerAdapter",
     "FastAPIAdapter",
 ]

--- a/packages/apps/src/microsoft_teams/apps/http/http_server.py
+++ b/packages/apps/src/microsoft_teams/apps/http/http_server.py
@@ -72,6 +72,7 @@ class HttpServer:
         credentials: Optional[Credentials] = None,
         cloud: Optional[CloudEnvironment] = None,
         dangerously_allow_unauthenticated_requests: bool = False,
+        skip_auth: Optional[bool] = None,
     ) -> None:
         """
         Set up JWT validation and register the messaging endpoint route.
@@ -80,9 +81,13 @@ class HttpServer:
             credentials: App credentials for JWT validation.
             cloud: Optional cloud environment for sovereign cloud support.
             dangerously_allow_unauthenticated_requests: Whether to skip JWT validation.
+            skip_auth: Deprecated alias for dangerously_allow_unauthenticated_requests.
         """
         if self._initialized:
             return
+
+        if skip_auth is not None:
+            dangerously_allow_unauthenticated_requests = skip_auth
 
         self._dangerously_allow_unauthenticated_requests = dangerously_allow_unauthenticated_requests
         self._cloud = cloud or PUBLIC

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -882,7 +882,7 @@ class TestApp:
         assert sent_activity.conversation.id == "conv-123"
 
     @pytest.mark.asyncio
-    async def test_send_passes_agentic_identity_with_api_service_url(self, mock_storage) -> None:
+    async def test_send_passes_service_url_and_agentic_identity_to_scoped_api(self, mock_storage) -> None:
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
         app._initialized = True
@@ -895,16 +895,18 @@ class TestApp:
         _wire_flat_activity_methods(app.api, activities)
         app.api.clone = MagicMock(return_value=app.api)
         agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        service_url = "https://override.service.url"
 
         result = await app.send(
             "conv-123",
             "Hello",
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
 
         app.api.conversations.activities.assert_called_once_with("conv-123")
         app.api.clone.assert_called_once_with(
-            service_url=app.api.service_url,
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
         create.assert_called_once()
@@ -1050,19 +1052,21 @@ class TestAppReply:
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
 
     @pytest.mark.asyncio
-    async def test_reply_with_three_args_passes_agentic_identity_with_api_service_url(self, started_app):
+    async def test_reply_with_three_args_passes_service_url_and_agentic_identity_to_scoped_api(self, started_app):
         agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        service_url = "https://override.service.url"
 
         await started_app.reply(
             "19:abc@thread.skype",
             "1680000000000",
             "Hello thread",
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
         started_app.api.clone.assert_called_once_with(
-            service_url=started_app.api.service_url,
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
         create = started_app.api.conversations.activities.return_value.create
@@ -1078,18 +1082,20 @@ class TestAppReply:
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
 
     @pytest.mark.asyncio
-    async def test_reply_with_two_args_passes_agentic_identity_with_api_service_url(self, started_app):
+    async def test_reply_with_two_args_passes_service_url_and_agentic_identity_to_scoped_api(self, started_app):
         agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        service_url = "https://override.service.url"
 
         await started_app.reply(
             "19:abc@thread.skype",
             "Hello flat",
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
         started_app.api.clone.assert_called_once_with(
-            service_url=started_app.api.service_url,
+            service_url=service_url,
             agentic_identity=agentic_identity,
         )
         create = started_app.api.conversations.activities.return_value.create
@@ -1123,7 +1129,7 @@ class TestMergeAppOptions:
         from microsoft_teams.apps.options import merge_app_options_with_defaults
 
         result = merge_app_options_with_defaults(client_id="test-id")
-        assert result["client_id"] == "test-id"
-        assert result["dangerously_allow_unauthenticated_requests"] is False
-        assert result["skip_auth"] is False
-        assert result["default_connection_name"] == "graph"
+        assert result.get("client_id") == "test-id"
+        assert result.get("dangerously_allow_unauthenticated_requests") is False
+        assert result.get("skip_auth") is False
+        assert result.get("default_connection_name") == "graph"

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -3,6 +3,8 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from contextlib import contextmanager
+from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -35,6 +37,27 @@ from microsoft_teams.apps.routing.router import ActivityRouter
 from microsoft_teams.common import EventEmitter, LocalStorage
 
 # pyright: basic
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any]):
+        self.name = name
+        self.options = options
+        self.attributes: dict[str, Any] = {}
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+        span = RecordingSpan(name, kwargs)
+        self.spans.append(span)
+        yield span
 
 
 class TestOauthHandlers:
@@ -139,6 +162,39 @@ class TestOauthHandlers:
         mock_context.next.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_sign_in_token_exchange_records_success_telemetry(
+        self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
+    ):
+        mock_context.activity = token_exchange_activity
+        mock_context.api.users.exchange_token.return_value = mock_token_response
+        tracer = RecordingTracer()
+
+        with (
+            pytest.MonkeyPatch.context() as monkeypatch,
+        ):
+            operation_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert tracer.spans[0].name == "oauth.token_exchange"
+        assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "token_exchange",
+            "oauth.callback.invoked": True,
+            "oauth.result": "success",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "success")
+        assert operation_calls[0][3] >= 0
+        assert "test-token" not in tracer.spans[0].attributes.values()
+        assert "access-token" not in tracer.spans[0].attributes.values()
+
+    @pytest.mark.asyncio
     async def test_sign_in_token_exchange_connection_name_warning(
         self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
     ):
@@ -177,6 +233,44 @@ class TestOauthHandlers:
         assert result.body.failure_detail == "Not found"
 
     @pytest.mark.asyncio
+    async def test_sign_in_token_exchange_expected_http_error_records_precondition_failed_without_oauth_error(
+        self, oauth_handlers, mock_context, token_exchange_activity
+    ):
+        mock_context.activity = token_exchange_activity
+        mock_request = Mock(spec=Request)
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 404
+        http_error = HTTPStatusError("Not found", request=mock_request, response=mock_response)
+        mock_context.api.users.exchange_token.side_effect = http_error
+        tracer = RecordingTracer()
+
+        with (
+            pytest.MonkeyPatch.context() as monkeypatch,
+        ):
+            operation_calls = []
+            error_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_error",
+                lambda *args: error_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "token_exchange",
+            "invoke.response.status": 412,
+            "oauth.result": "precondition_failed",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "precondition_failed")
+        assert error_calls == []
+
+    @pytest.mark.asyncio
     async def test_sign_in_token_exchange_http_error_500(self, oauth_handlers, mock_context, token_exchange_activity):
         """Test token exchange with HTTP 500 error."""
         mock_context.activity = token_exchange_activity
@@ -201,6 +295,51 @@ class TestOauthHandlers:
         assert result.status == 500
 
     @pytest.mark.asyncio
+    async def test_sign_in_token_exchange_unexpected_http_error_records_oauth_error(
+        self, oauth_handlers, mock_context, token_exchange_activity
+    ):
+        mock_context.activity = token_exchange_activity
+        mock_request = Mock(spec=Request)
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 500
+        http_error = HTTPStatusError("Server error", request=mock_request, response=mock_response)
+        mock_context.api.users.exchange_token.side_effect = http_error
+        tracer = RecordingTracer()
+
+        with (
+            pytest.MonkeyPatch.context() as monkeypatch,
+        ):
+            operation_calls = []
+            error_calls = []
+            record_exception_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_error",
+                lambda *args: error_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_exception",
+                lambda *args: record_exception_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "token_exchange",
+            "oauth.error.type": "http_error",
+            "invoke.response.status": 500,
+            "oauth.result": "failure",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
+        assert error_calls == [("test-connection", "token_exchange", "http_error")]
+        assert record_exception_calls == [(tracer.spans[0], http_error)]
+
+    @pytest.mark.asyncio
     async def test_sign_in_token_exchange_generic_exception(
         self, oauth_handlers, mock_context, token_exchange_activity
     ):
@@ -220,6 +359,46 @@ class TestOauthHandlers:
         assert isinstance(result, InvokeResponse) and isinstance(result.body, TokenExchangeInvokeResponse)
         assert result.status == 412
         assert result.body.failure_detail == "Generic error"
+
+    @pytest.mark.asyncio
+    async def test_sign_in_token_exchange_unexpected_exception_records_precondition_failed_oauth_error(
+        self, oauth_handlers, mock_context, token_exchange_activity
+    ):
+        mock_context.activity = token_exchange_activity
+        generic_error = ValueError("Generic error")
+        mock_context.api.users.exchange_token.side_effect = generic_error
+        tracer = RecordingTracer()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            operation_calls = []
+            error_calls = []
+            record_exception_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_error",
+                lambda *args: error_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_exception",
+                lambda *args: record_exception_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "token_exchange",
+            "oauth.error.type": "exception",
+            "invoke.response.status": 412,
+            "oauth.result": "precondition_failed",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "precondition_failed")
+        assert error_calls == [("test-connection", "token_exchange", "exception")]
+        assert record_exception_calls == [(tracer.spans[0], generic_error)]
 
     @pytest.mark.asyncio
     async def test_sign_in_verify_state_success(
@@ -270,6 +449,38 @@ class TestOauthHandlers:
         mock_context.next.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_sign_in_verify_state_no_state_records_no_token_without_oauth_error(
+        self, oauth_handlers, mock_context, verify_state_activity
+    ):
+        verify_state_activity.value.state = None
+        mock_context.activity = verify_state_activity
+        tracer = RecordingTracer()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            operation_calls = []
+            error_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_error",
+                lambda *args: error_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "verify_state",
+            "invoke.response.status": 404,
+            "oauth.result": "no_token",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "no_token")
+        assert error_calls == []
+
+    @pytest.mark.asyncio
     async def test_sign_in_verify_state_http_error_500(self, oauth_handlers, mock_context, verify_state_activity):
         """Test state verification with HTTP 500 error."""
         mock_context.activity = verify_state_activity
@@ -292,6 +503,82 @@ class TestOauthHandlers:
         # Verify error response
         assert isinstance(result, InvokeResponse) and result.body is None
         assert result.status == 500
+
+    @pytest.mark.asyncio
+    async def test_sign_in_verify_state_unexpected_exception_records_oauth_error(
+        self, oauth_handlers, mock_context, verify_state_activity
+    ):
+        mock_context.activity = verify_state_activity
+        generic_error = ValueError("Generic error")
+        mock_context.api.users.get_token.side_effect = generic_error
+        tracer = RecordingTracer()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            operation_calls = []
+            error_calls = []
+            record_exception_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_error",
+                lambda *args: error_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_exception",
+                lambda *args: record_exception_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "verify_state",
+            "oauth.error.type": "exception",
+            "invoke.response.status": 412,
+            "oauth.result": "precondition_failed",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "precondition_failed")
+        assert error_calls == [("test-connection", "verify_state", "exception")]
+        assert record_exception_calls == [(tracer.spans[0], generic_error)]
+
+    @pytest.mark.asyncio
+    async def test_sign_in_verify_state_expected_http_error_records_precondition_failed_without_oauth_error(
+        self, oauth_handlers, mock_context, verify_state_activity
+    ):
+        mock_context.activity = verify_state_activity
+        mock_request = Mock(spec=Request)
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 404
+        http_error = HTTPStatusError("Not found", request=mock_request, response=mock_response)
+        mock_context.api.users.get_token.side_effect = http_error
+        tracer = RecordingTracer()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            operation_calls = []
+            error_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_error",
+                lambda *args: error_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "verify_state",
+            "invoke.response.status": 412,
+            "oauth.result": "precondition_failed",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "precondition_failed")
+        assert error_calls == []
 
     @pytest.mark.asyncio
     async def test_sign_in_verify_state_http_error_404(self, oauth_handlers, mock_context, verify_state_activity):
@@ -376,6 +663,7 @@ class TestOauthHandlers:
         error_event = call_args[0][1]
         assert isinstance(error_event, ErrorEvent)
         assert "resourcematchfailed" in str(error_event.error)
+        assert error_event.context is not None
         assert error_event.context["activity"] == failure_activity
 
     @pytest.mark.asyncio
@@ -386,6 +674,33 @@ class TestOauthHandlers:
         result = await oauth_handlers.sign_in_failure(mock_context)
 
         assert result is None
+
+    @pytest.mark.asyncio
+    async def test_sign_in_failure_records_notified_telemetry_without_message(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        mock_context.activity = failure_activity
+        tracer = RecordingTracer()
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            operation_calls = []
+            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+            monkeypatch.setattr(
+                "microsoft_teams.apps.app_oauth.record_oauth_operation",
+                lambda *args: operation_calls.append(args),
+            )
+
+            await oauth_handlers.sign_in_failure(mock_context)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "test-connection",
+            "oauth.operation": "signin_failure",
+            "oauth.failure.code": "resourcematchfailed",
+            "oauth.callback.invoked": True,
+            "oauth.result": "notified",
+        }
+        assert operation_calls[0][:3] == ("test-connection", "signin_failure", "notified")
+        assert "Resource match failed" not in tracer.spans[0].attributes.values()
 
     @pytest.mark.asyncio
     async def test_sign_in_failure_calls_next(self, oauth_handlers, mock_context, failure_activity):

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -181,7 +181,7 @@ class TestOauthHandlers:
 
             await oauth_handlers.sign_in_token_exchange(mock_context)
 
-        assert tracer.spans[0].name == "oauth.token_exchange"
+        assert tracer.spans[0].name == "microsoft.teams.oauth.token_exchange"
         assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
         assert tracer.spans[0].attributes == {
             "oauth.connection": "test-connection",
@@ -233,7 +233,7 @@ class TestOauthHandlers:
         assert result.body.failure_detail == "Not found"
 
     @pytest.mark.asyncio
-    async def test_sign_in_token_exchange_expected_http_error_records_precondition_failed_without_oauth_error(
+    async def test_sign_in_token_exchange_expected_http_error_records_failure_without_oauth_error(
         self, oauth_handlers, mock_context, token_exchange_activity
     ):
         mock_context.activity = token_exchange_activity
@@ -265,9 +265,9 @@ class TestOauthHandlers:
             "oauth.connection": "test-connection",
             "oauth.operation": "token_exchange",
             "invoke.response.status": 412,
-            "oauth.result": "precondition_failed",
+            "oauth.result": "failure",
         }
-        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "precondition_failed")
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
         assert error_calls == []
 
     @pytest.mark.asyncio
@@ -361,7 +361,7 @@ class TestOauthHandlers:
         assert result.body.failure_detail == "Generic error"
 
     @pytest.mark.asyncio
-    async def test_sign_in_token_exchange_unexpected_exception_records_precondition_failed_oauth_error(
+    async def test_sign_in_token_exchange_unexpected_exception_records_failure_oauth_error(
         self, oauth_handlers, mock_context, token_exchange_activity
     ):
         mock_context.activity = token_exchange_activity
@@ -394,9 +394,9 @@ class TestOauthHandlers:
             "oauth.operation": "token_exchange",
             "oauth.error.type": "exception",
             "invoke.response.status": 412,
-            "oauth.result": "precondition_failed",
+            "oauth.result": "failure",
         }
-        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "precondition_failed")
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
         assert error_calls == [("test-connection", "token_exchange", "exception")]
         assert record_exception_calls == [(tracer.spans[0], generic_error)]
 
@@ -538,14 +538,14 @@ class TestOauthHandlers:
             "oauth.operation": "verify_state",
             "oauth.error.type": "exception",
             "invoke.response.status": 412,
-            "oauth.result": "precondition_failed",
+            "oauth.result": "failure",
         }
-        assert operation_calls[0][:3] == ("test-connection", "verify_state", "precondition_failed")
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "failure")
         assert error_calls == [("test-connection", "verify_state", "exception")]
         assert record_exception_calls == [(tracer.spans[0], generic_error)]
 
     @pytest.mark.asyncio
-    async def test_sign_in_verify_state_expected_http_error_records_precondition_failed_without_oauth_error(
+    async def test_sign_in_verify_state_expected_http_error_records_failure_without_oauth_error(
         self, oauth_handlers, mock_context, verify_state_activity
     ):
         mock_context.activity = verify_state_activity
@@ -575,9 +575,9 @@ class TestOauthHandlers:
             "oauth.connection": "test-connection",
             "oauth.operation": "verify_state",
             "invoke.response.status": 412,
-            "oauth.result": "precondition_failed",
+            "oauth.result": "failure",
         }
-        assert operation_calls[0][:3] == ("test-connection", "verify_state", "precondition_failed")
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "failure")
         assert error_calls == []
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -200,7 +200,7 @@ class TestActivityProcessor:
             result = await activity_processor.process_activity([], mock_activity_event)
 
         assert result.status == 200
-        assert [span.name for span in tracer.spans] == ["turn"]
+        assert [span.name for span in tracer.spans] == ["microsoft.teams.activity.process"]
         assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
         assert tracer.spans[0].attributes == {
             "activity.type": "message",
@@ -297,7 +297,7 @@ class TestActivityProcessor:
             response = await activity_processor.execute_middleware_chain(context, [handler])
 
         assert response == "handler_result"
-        assert [span.name for span in tracer.spans] == ["handler"]
+        assert [span.name for span in tracer.spans] == ["microsoft.teams.handler"]
         assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
         assert tracer.spans[0].attributes == {
             "handler.type": "message",

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -25,6 +25,7 @@ from microsoft_teams.apps.events import CoreActivity
 from microsoft_teams.apps.routing.router import ActivityHandler, ActivityRouter
 from microsoft_teams.apps.token_manager import TokenManager
 from microsoft_teams.common import Client, LocalStorage
+from opentelemetry import baggage
 
 
 class RecordingSpan:
@@ -62,6 +63,23 @@ def _message_activity(activity_id: str = "activity-123") -> Activity:
         id=activity_id,
         service_url="https://service.url",
         **{
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-789"},
+            "recipient": {"id": "bot-456", "name": "Test Bot"},
+            "channelId": "msteams",
+        },
+    )
+    return ActivityTypeAdapter.validate_python(core_activity.model_dump(by_alias=True, exclude_none=True))
+
+
+def _invoke_activity(activity_id: str = "activity-invoke") -> Activity:
+    core_activity = CoreActivity(
+        type="invoke",
+        id=activity_id,
+        service_url="https://service.url",
+        **{
+            "name": "config/fetch",
+            "value": {},
             "from": {"id": "user-123", "name": "Test User"},
             "conversation": {"id": "conv-789"},
             "recipient": {"id": "bot-456", "name": "Test Bot"},
@@ -198,6 +216,60 @@ class TestActivityProcessor:
         assert record_turn_duration.call_args.args[1] == "message"
 
     @pytest.mark.asyncio
+    async def test_process_activity_applies_agent365_baggage_during_turn(self, activity_processor):
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-baggage",
+            service_url="https://service.url",
+            **{
+                "from": {
+                    "id": "user-123",
+                    "aadObjectId": "caller-aad-1",
+                    "name": "Caller",
+                    "email": "caller@example.com",
+                },
+                "conversation": {"id": "conv-789"},
+                "recipient": {
+                    "id": "bot-456",
+                    "name": "Agent",
+                    "tenantId": "tenant-1",
+                    "agenticAppId": "agent-app-1",
+                    "agenticUserId": "agent-user-1",
+                    "agenticAppBlueprintId": "blueprint-1",
+                    "email": "agentic-user@example.com",
+                    "userRole": "assistant",
+                },
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        async def process_core(plugins, event, activity):
+            assert baggage.get_baggage("microsoft.tenant.id") == "tenant-1"
+            assert baggage.get_baggage("gen_ai.conversation.id") == "conv-789"
+            assert baggage.get_baggage("microsoft.conversation.item.link") == "https://service.url"
+            assert baggage.get_baggage("microsoft.channel.name") == "msteams"
+            assert baggage.get_baggage("user.id") == "caller-aad-1"
+            assert baggage.get_baggage("user.name") == "Caller"
+            assert baggage.get_baggage("user.email") == "caller@example.com"
+            assert baggage.get_baggage("gen_ai.agent.id") == "agent-app-1"
+            assert baggage.get_baggage("gen_ai.agent.name") == "Agent"
+            assert baggage.get_baggage("microsoft.agent.user.id") == "agent-user-1"
+            assert baggage.get_baggage("microsoft.agent.user.email") == "agentic-user@example.com"
+            assert baggage.get_baggage("gen_ai.agent.description") == "assistant"
+            assert baggage.get_baggage("microsoft.a365.agent.blueprint.id") == "blueprint-1"
+            return InvokeResponse[Any](status=200)
+
+        activity_processor._process_activity_core = AsyncMock(side_effect=process_core)
+
+        await activity_processor.process_activity([], mock_activity_event)
+
+        assert baggage.get_baggage("microsoft.tenant.id") is None
+        assert baggage.get_baggage("gen_ai.agent.id") is None
+
+    @pytest.mark.asyncio
     async def test_execute_middleware_chain_records_handler_span_and_metrics(self, activity_processor):
         context = ActivityContext(
             activity=_message_activity(),
@@ -229,11 +301,45 @@ class TestActivityProcessor:
         assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
         assert tracer.spans[0].attributes == {
             "handler.type": "message",
-            "handler.dispatch": "route",
+            "handler.dispatch": "type",
         }
-        record_handler_dispatched.assert_called_once_with("message", "route")
+        record_handler_dispatched.assert_called_once_with("message", "type")
         assert record_handler_duration.call_args.args[0] >= 0
-        assert record_handler_duration.call_args.args[1:] == ("message", "route")
+        assert record_handler_duration.call_args.args[1:] == ("message", "type")
+
+    @pytest.mark.asyncio
+    async def test_execute_middleware_chain_records_invoke_handler_tags(self, activity_processor):
+        context = ActivityContext(
+            activity=_invoke_activity(),
+            app_id="app_id",
+            storage=MagicMock(spec=LocalStorage),
+            api=MagicMock(),
+            user_token=None,
+            conversation_ref=MagicMock(spec=ConversationReference),
+            is_signed_in=True,
+            connection_name="default_connection",
+            app_token=lambda: None,
+            cloud=PUBLIC,
+        )
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            return None
+
+        tracer = RecordingTracer()
+
+        with (
+            patch("microsoft_teams.apps.app_process.get_tracer", return_value=tracer),
+            patch("microsoft_teams.apps.app_process.record_handler_dispatched") as record_handler_dispatched,
+            patch("microsoft_teams.apps.app_process.record_handler_duration") as record_handler_duration,
+        ):
+            await activity_processor.execute_middleware_chain(context, [handler])
+
+        assert tracer.spans[0].attributes == {
+            "handler.type": "config/fetch",
+            "handler.dispatch": "invoke",
+        }
+        record_handler_dispatched.assert_called_once_with("config/fetch", "invoke")
+        assert record_handler_duration.call_args.args[1:] == ("config/fetch", "invoke")
 
     @pytest.mark.asyncio
     async def test_execute_middleware_chain_records_handler_exception(self, activity_processor):
@@ -267,7 +373,7 @@ class TestActivityProcessor:
                 await activity_processor.execute_middleware_chain(context, [handler])
 
         record_exception.assert_called_once_with(tracer.spans[0], error)
-        record_handler_failure.assert_called_once_with("message", "route")
+        record_handler_failure.assert_called_once_with("message", "type")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -4,13 +4,14 @@ Licensed under the MIT License.
 """
 # pyright: basic
 
-from typing import Any
+from contextlib import contextmanager
+from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from microsoft_teams.api import (
     Activity,
-    ActivityBase,
+    ActivityTypeAdapter,
     ConversationReference,
     InvokeResponse,
     TokenProtocol,
@@ -24,6 +25,50 @@ from microsoft_teams.apps.events import CoreActivity
 from microsoft_teams.apps.routing.router import ActivityHandler, ActivityRouter
 from microsoft_teams.apps.token_manager import TokenManager
 from microsoft_teams.common import Client, LocalStorage
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any]):
+        self.name = name
+        self.options = options
+        self.attributes: dict[str, str] = {}
+        self.exceptions: list[BaseException] = []
+        self.status = None
+
+    def set_attribute(self, key: str, value: str) -> None:
+        self.attributes[key] = value
+
+    def record_exception(self, exception: BaseException) -> None:
+        self.exceptions.append(exception)
+
+    def set_status(self, status) -> None:
+        self.status = status
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+        span = RecordingSpan(name, kwargs)
+        self.spans.append(span)
+        yield span
+
+
+def _message_activity(activity_id: str = "activity-123") -> Activity:
+    core_activity = CoreActivity(
+        type="message",
+        id=activity_id,
+        service_url="https://service.url",
+        **{
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-789"},
+            "recipient": {"id": "bot-456", "name": "Test Bot"},
+            "channelId": "msteams",
+        },
+    )
+    return ActivityTypeAdapter.validate_python(core_activity.model_dump(by_alias=True, exclude_none=True))
 
 
 class TestActivityProcessor:
@@ -71,7 +116,7 @@ class TestActivityProcessor:
         """Test the execute_middleware_chain method with two handlers."""
         api = MagicMock()
         context = ActivityContext(
-            activity=MagicMock(spec=ActivityBase),
+            activity=_message_activity(),
             app_id="app_id",
             storage=MagicMock(spec=LocalStorage),
             api=api,
@@ -104,6 +149,125 @@ class TestActivityProcessor:
         handler_one.assert_called_once_with(context)
         handler_two.assert_called_once_with(context)
         assert response == "handler_one"
+
+    @pytest.mark.asyncio
+    async def test_process_activity_records_turn_span_metrics_and_unmatched(self, activity_processor):
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-otel",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-123", "name": "Test User"},
+                "conversation": {"id": "conv-789"},
+                "recipient": {"id": "bot-456", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+        tracer = RecordingTracer()
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        with (
+            patch("microsoft_teams.apps.app_process.get_tracer", return_value=tracer),
+            patch("microsoft_teams.apps.app_process.record_activity_received") as record_activity_received,
+            patch("microsoft_teams.apps.app_process.record_handler_unmatched") as record_handler_unmatched,
+            patch("microsoft_teams.apps.app_process.record_turn_duration") as record_turn_duration,
+        ):
+            result = await activity_processor.process_activity([], mock_activity_event)
+
+        assert result.status == 200
+        assert [span.name for span in tracer.spans] == ["turn"]
+        assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
+        assert tracer.spans[0].attributes == {
+            "activity.type": "message",
+            "activity.id": "activity-otel",
+            "conversation.id": "conv-789",
+            "channel.id": "msteams",
+            "bot.id": "bot-456",
+            "service.url": "https://service.url",
+        }
+        record_activity_received.assert_called_once_with("message")
+        record_handler_unmatched.assert_called_once_with("message", None)
+        assert record_turn_duration.call_args.args[0] >= 0
+        assert record_turn_duration.call_args.args[1] == "message"
+
+    @pytest.mark.asyncio
+    async def test_execute_middleware_chain_records_handler_span_and_metrics(self, activity_processor):
+        context = ActivityContext(
+            activity=_message_activity(),
+            app_id="app_id",
+            storage=MagicMock(spec=LocalStorage),
+            api=MagicMock(),
+            user_token=None,
+            conversation_ref=MagicMock(spec=ConversationReference),
+            is_signed_in=True,
+            connection_name="default_connection",
+            app_token=lambda: None,
+            cloud=PUBLIC,
+        )
+
+        async def handler(ctx: ActivityContext[Activity]) -> str:
+            return "handler_result"
+
+        tracer = RecordingTracer()
+
+        with (
+            patch("microsoft_teams.apps.app_process.get_tracer", return_value=tracer),
+            patch("microsoft_teams.apps.app_process.record_handler_dispatched") as record_handler_dispatched,
+            patch("microsoft_teams.apps.app_process.record_handler_duration") as record_handler_duration,
+        ):
+            response = await activity_processor.execute_middleware_chain(context, [handler])
+
+        assert response == "handler_result"
+        assert [span.name for span in tracer.spans] == ["handler"]
+        assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
+        assert tracer.spans[0].attributes == {
+            "handler.type": "message",
+            "handler.dispatch": "route",
+        }
+        record_handler_dispatched.assert_called_once_with("message", "route")
+        assert record_handler_duration.call_args.args[0] >= 0
+        assert record_handler_duration.call_args.args[1:] == ("message", "route")
+
+    @pytest.mark.asyncio
+    async def test_execute_middleware_chain_records_handler_exception(self, activity_processor):
+        context = ActivityContext(
+            activity=_message_activity(),
+            app_id="app_id",
+            storage=MagicMock(spec=LocalStorage),
+            api=MagicMock(),
+            user_token=None,
+            conversation_ref=MagicMock(spec=ConversationReference),
+            is_signed_in=True,
+            connection_name="default_connection",
+            app_token=lambda: None,
+            cloud=PUBLIC,
+        )
+        error = RuntimeError("boom")
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            raise error
+
+        tracer = RecordingTracer()
+
+        with (
+            patch("microsoft_teams.apps.app_process.get_tracer", return_value=tracer),
+            patch("microsoft_teams.apps.app_process.record_handler_dispatched"),
+            patch("microsoft_teams.apps.app_process.record_handler_duration"),
+            patch("microsoft_teams.apps.app_process.record_handler_failure") as record_handler_failure,
+            patch("microsoft_teams.apps.app_process.record_exception") as record_exception,
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await activity_processor.execute_middleware_chain(context, [handler])
+
+        record_exception.assert_called_once_with(tracer.spans[0], error)
+        record_handler_failure.assert_called_once_with("message", "route")
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 # pyright: basic
 
+import importlib.metadata
 from unittest.mock import MagicMock, patch
 
 import microsoft_teams.apps as apps
@@ -42,6 +43,7 @@ def test_public_telemetry_names_are_exported():
     assert TEAMS_BOT_APPLICATION_METER_NAME == "Microsoft.Teams.Apps"
     assert TeamsBotApplicationTelemetry.tracer_name == "Microsoft.Teams.Apps"
     assert TeamsBotApplicationTelemetry.meter_name == "Microsoft.Teams.Apps"
+    assert TeamsBotApplicationTelemetry.instrumentation_version == importlib.metadata.version("microsoft-teams-apps")
     assert "TEAMS_BOT_APPLICATION_TRACER_NAME" in apps.__all__
     assert "TEAMS_BOT_APPLICATION_METER_NAME" in apps.__all__
     assert "TeamsBaggageBuilder" in apps.__all__
@@ -71,13 +73,19 @@ def test_helpers_use_canonical_source_names():
     with patch("microsoft_teams.apps.diagnostics._helpers.trace.get_tracer") as mock_get_tracer:
         tracer = get_tracer()
 
-    mock_get_tracer.assert_called_once_with("Microsoft.Teams.Apps")
+    mock_get_tracer.assert_called_once_with(
+        "Microsoft.Teams.Apps",
+        instrumenting_library_version=TeamsBotApplicationTelemetry.instrumentation_version,
+    )
     assert tracer is mock_get_tracer.return_value
 
     with patch("microsoft_teams.apps.diagnostics._helpers.metrics.get_meter") as mock_get_meter:
         meter = get_meter()
 
-    mock_get_meter.assert_called_once_with("Microsoft.Teams.Apps")
+    mock_get_meter.assert_called_once_with(
+        "Microsoft.Teams.Apps",
+        version=TeamsBotApplicationTelemetry.instrumentation_version,
+    )
     assert meter is mock_get_meter.return_value
 
 

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+# pyright: basic
+
+from unittest.mock import MagicMock, patch
+
+import microsoft_teams.apps as apps
+from microsoft_teams.apps import (
+    TEAMS_BOT_APPLICATION_METER_NAME,
+    TEAMS_BOT_APPLICATION_TRACER_NAME,
+    TeamsBotApplicationTelemetry,
+)
+from microsoft_teams.apps.diagnostics._helpers import get_meter, get_tracer, record_exception
+from opentelemetry.trace import StatusCode
+
+
+def test_public_telemetry_names_are_exported():
+    assert TEAMS_BOT_APPLICATION_TRACER_NAME == "Microsoft.Teams.Apps"
+    assert TEAMS_BOT_APPLICATION_METER_NAME == "Microsoft.Teams.Apps"
+    assert TeamsBotApplicationTelemetry.tracer_name == "Microsoft.Teams.Apps"
+    assert TeamsBotApplicationTelemetry.meter_name == "Microsoft.Teams.Apps"
+    assert "TEAMS_BOT_APPLICATION_TRACER_NAME" in apps.__all__
+    assert "TEAMS_BOT_APPLICATION_METER_NAME" in apps.__all__
+    assert "TeamsBotApplicationTelemetry" in apps.__all__
+
+
+def test_helpers_use_canonical_source_names():
+    with patch("microsoft_teams.apps.diagnostics._helpers.trace.get_tracer") as mock_get_tracer:
+        tracer = get_tracer()
+
+    mock_get_tracer.assert_called_once_with("Microsoft.Teams.Apps")
+    assert tracer is mock_get_tracer.return_value
+
+    with patch("microsoft_teams.apps.diagnostics._helpers.metrics.get_meter") as mock_get_meter:
+        meter = get_meter()
+
+    mock_get_meter.assert_called_once_with("Microsoft.Teams.Apps")
+    assert meter is mock_get_meter.return_value
+
+
+def test_record_exception_marks_span_error():
+    span = MagicMock()
+    exception = RuntimeError("boom")
+
+    record_exception(span, exception)
+
+    span.record_exception.assert_called_once_with(exception)
+    status = span.set_status.call_args.args[0]
+    assert status.status_code == StatusCode.ERROR
+    assert status.description == "boom"

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -239,31 +239,31 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
             for metric in scope_metric.metrics:
                 metrics[metric.name] = metric
 
-    activities_point = metrics["teams.activities.received"].data.data_points[0]
+    activities_point = metrics["microsoft.teams.activities.received"].data.data_points[0]
     assert activities_point.value == 1
     assert activities_point.attributes == {"activity.type": "message"}
 
-    turn_duration_point = metrics["teams.turn.duration"].data.data_points[0]
+    turn_duration_point = metrics["microsoft.teams.activity.process.duration"].data.data_points[0]
     assert turn_duration_point.sum == 5.5
     assert turn_duration_point.attributes == {"activity.type": "message"}
 
-    dispatched_point = metrics["teams.handler.dispatched"].data.data_points[0]
+    dispatched_point = metrics["microsoft.teams.handler.dispatched"].data.data_points[0]
     assert dispatched_point.value == 1
     assert dispatched_point.attributes == {"handler.type": "message", "handler.dispatch": "type"}
 
-    handler_duration_point = metrics["teams.handler.duration"].data.data_points[0]
+    handler_duration_point = metrics["microsoft.teams.handler.duration"].data.data_points[0]
     assert handler_duration_point.sum == 2.5
     assert handler_duration_point.attributes == {"handler.type": "message", "handler.dispatch": "type"}
 
-    failures_point = metrics["teams.handler.failures"].data.data_points[0]
+    failures_point = metrics["microsoft.teams.handler.failures"].data.data_points[0]
     assert failures_point.value == 1
     assert failures_point.attributes == {"handler.type": "message", "handler.dispatch": "type"}
 
-    unmatched_point = metrics["teams.handler.unmatched"].data.data_points[0]
+    unmatched_point = metrics["microsoft.teams.handler.unmatched"].data.data_points[0]
     assert unmatched_point.value == 1
     assert unmatched_point.attributes == {"activity.type": "invoke", "invoke.name": "composeExtension/query"}
 
-    oauth_operations_point = metrics["teams.oauth.operations"].data.data_points[0]
+    oauth_operations_point = metrics["microsoft.teams.oauth.operations"].data.data_points[0]
     assert oauth_operations_point.value == 1
     assert oauth_operations_point.attributes == {
         "oauth.connection": "test-connection",
@@ -271,7 +271,7 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
         "oauth.result": "success",
     }
 
-    oauth_duration_point = metrics["teams.oauth.operation.duration"].data.data_points[0]
+    oauth_duration_point = metrics["microsoft.teams.oauth.operation.duration"].data.data_points[0]
     assert oauth_duration_point.sum == 3.5
     assert oauth_duration_point.attributes == {
         "oauth.connection": "test-connection",
@@ -279,7 +279,7 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
         "oauth.result": "success",
     }
 
-    oauth_errors_point = metrics["teams.oauth.errors"].data.data_points[0]
+    oauth_errors_point = metrics["microsoft.teams.oauth.errors"].data.data_points[0]
     assert oauth_errors_point.value == 1
     assert oauth_errors_point.attributes == {
         "oauth.connection": "test-connection",

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -25,6 +25,8 @@ from microsoft_teams.apps.diagnostics._helpers import (
     record_handler_duration,
     record_handler_failure,
     record_handler_unmatched,
+    record_oauth_error,
+    record_oauth_operation,
     record_turn_duration,
 )
 from microsoft_teams.apps.events import CoreActivity
@@ -55,6 +57,9 @@ def test_runtime_instrumentation_names_stay_internal():
         "APP_BAGGAGE_KEYS",
         "APP_HANDLER_DISPATCHES",
         "APP_METRIC_NAMES",
+        "APP_OAUTH_ERROR_TYPES",
+        "APP_OAUTH_OPERATIONS",
+        "APP_OAUTH_RESULTS",
         "APP_SPAN_NAMES",
     ]
     for group in private_groups:
@@ -223,6 +228,8 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
         record_handler_duration(2.5, "message", "type")
         record_handler_failure("message", "type")
         record_handler_unmatched("invoke", "composeExtension/query")
+        record_oauth_operation("test-connection", "token_exchange", "success", 3.5)
+        record_oauth_error("test-connection", "token_exchange", "http_error")
 
     metrics = {}
     metrics_data = metric_reader.get_metrics_data()
@@ -255,6 +262,30 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
     unmatched_point = metrics["teams.handler.unmatched"].data.data_points[0]
     assert unmatched_point.value == 1
     assert unmatched_point.attributes == {"activity.type": "invoke", "invoke.name": "composeExtension/query"}
+
+    oauth_operations_point = metrics["teams.oauth.operations"].data.data_points[0]
+    assert oauth_operations_point.value == 1
+    assert oauth_operations_point.attributes == {
+        "oauth.connection": "test-connection",
+        "oauth.operation": "token_exchange",
+        "oauth.result": "success",
+    }
+
+    oauth_duration_point = metrics["teams.oauth.operation.duration"].data.data_points[0]
+    assert oauth_duration_point.sum == 3.5
+    assert oauth_duration_point.attributes == {
+        "oauth.connection": "test-connection",
+        "oauth.operation": "token_exchange",
+        "oauth.result": "success",
+    }
+
+    oauth_errors_point = metrics["teams.oauth.errors"].data.data_points[0]
+    assert oauth_errors_point.value == 1
+    assert oauth_errors_point.attributes == {
+        "oauth.connection": "test-connection",
+        "oauth.operation": "token_exchange",
+        "oauth.error.type": "http_error",
+    }
     meter_provider.shutdown()
 
 

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -12,7 +12,19 @@ from microsoft_teams.apps import (
     TEAMS_BOT_APPLICATION_TRACER_NAME,
     TeamsBotApplicationTelemetry,
 )
-from microsoft_teams.apps.diagnostics._helpers import get_meter, get_tracer, record_exception
+from microsoft_teams.apps.diagnostics._helpers import (
+    get_meter,
+    get_tracer,
+    record_activity_received,
+    record_exception,
+    record_handler_dispatched,
+    record_handler_duration,
+    record_handler_failure,
+    record_handler_unmatched,
+    record_turn_duration,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.trace import StatusCode
 
 
@@ -24,6 +36,18 @@ def test_public_telemetry_names_are_exported():
     assert "TEAMS_BOT_APPLICATION_TRACER_NAME" in apps.__all__
     assert "TEAMS_BOT_APPLICATION_METER_NAME" in apps.__all__
     assert "TeamsBotApplicationTelemetry" in apps.__all__
+
+
+def test_runtime_instrumentation_names_stay_internal():
+    private_groups = [
+        "APP_ATTRIBUTE_NAMES",
+        "APP_HANDLER_DISPATCHES",
+        "APP_METRIC_NAMES",
+        "APP_SPAN_NAMES",
+    ]
+    for group in private_groups:
+        assert group not in apps.__all__
+        assert not hasattr(apps, group)
 
 
 def test_helpers_use_canonical_source_names():
@@ -38,6 +62,53 @@ def test_helpers_use_canonical_source_names():
 
     mock_get_meter.assert_called_once_with("Microsoft.Teams.Apps")
     assert meter is mock_get_meter.return_value
+
+
+def test_app_metrics_are_recorded_with_allowed_attributes():
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    meter = meter_provider.get_meter("Microsoft.Teams.Apps")
+
+    with patch("microsoft_teams.apps.diagnostics._helpers.get_meter", return_value=meter):
+        record_activity_received("message")
+        record_turn_duration(5.5, "message")
+        record_handler_dispatched("message", "route")
+        record_handler_duration(2.5, "message", "route")
+        record_handler_failure("message", "route")
+        record_handler_unmatched("invoke", "composeExtension/query")
+
+    metrics = {}
+    metrics_data = metric_reader.get_metrics_data()
+    assert metrics_data is not None
+    for resource_metric in metrics_data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                metrics[metric.name] = metric
+
+    activities_point = metrics["teams.activities.received"].data.data_points[0]
+    assert activities_point.value == 1
+    assert activities_point.attributes == {"activity.type": "message"}
+
+    turn_duration_point = metrics["teams.turn.duration"].data.data_points[0]
+    assert turn_duration_point.sum == 5.5
+    assert turn_duration_point.attributes == {"activity.type": "message"}
+
+    dispatched_point = metrics["teams.handler.dispatched"].data.data_points[0]
+    assert dispatched_point.value == 1
+    assert dispatched_point.attributes == {"handler.type": "message", "handler.dispatch": "route"}
+
+    handler_duration_point = metrics["teams.handler.duration"].data.data_points[0]
+    assert handler_duration_point.sum == 2.5
+    assert handler_duration_point.attributes == {"handler.type": "message", "handler.dispatch": "route"}
+
+    failures_point = metrics["teams.handler.failures"].data.data_points[0]
+    assert failures_point.value == 1
+    assert failures_point.attributes == {"handler.type": "message", "handler.dispatch": "route"}
+
+    unmatched_point = metrics["teams.handler.unmatched"].data.data_points[0]
+    assert unmatched_point.value == 1
+    assert unmatched_point.attributes == {"activity.type": "invoke", "invoke.name": "composeExtension/query"}
+    meter_provider.shutdown()
 
 
 def test_record_exception_marks_span_error():

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -7,10 +7,14 @@ Licensed under the MIT License.
 from unittest.mock import MagicMock, patch
 
 import microsoft_teams.apps as apps
+from microsoft_teams.api import ActivityTypeAdapter
 from microsoft_teams.apps import (
     TEAMS_BOT_APPLICATION_METER_NAME,
     TEAMS_BOT_APPLICATION_TRACER_NAME,
+    ActivityContext,
+    TeamsBaggageBuilder,
     TeamsBotApplicationTelemetry,
+    with_teams_baggage,
 )
 from microsoft_teams.apps.diagnostics._helpers import (
     get_meter,
@@ -23,6 +27,9 @@ from microsoft_teams.apps.diagnostics._helpers import (
     record_handler_unmatched,
     record_turn_duration,
 )
+from microsoft_teams.apps.events import CoreActivity
+from opentelemetry import baggage
+from opentelemetry import context as otel_context
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.trace import StatusCode
@@ -35,12 +42,17 @@ def test_public_telemetry_names_are_exported():
     assert TeamsBotApplicationTelemetry.meter_name == "Microsoft.Teams.Apps"
     assert "TEAMS_BOT_APPLICATION_TRACER_NAME" in apps.__all__
     assert "TEAMS_BOT_APPLICATION_METER_NAME" in apps.__all__
+    assert "TeamsBaggageBuilder" in apps.__all__
     assert "TeamsBotApplicationTelemetry" in apps.__all__
+    assert "with_teams_baggage" in apps.__all__
+    assert apps.TeamsBaggageBuilder is TeamsBaggageBuilder
+    assert apps.with_teams_baggage is with_teams_baggage
 
 
 def test_runtime_instrumentation_names_stay_internal():
     private_groups = [
         "APP_ATTRIBUTE_NAMES",
+        "APP_BAGGAGE_KEYS",
         "APP_HANDLER_DISPATCHES",
         "APP_METRIC_NAMES",
         "APP_SPAN_NAMES",
@@ -64,6 +76,141 @@ def test_helpers_use_canonical_source_names():
     assert meter is mock_get_meter.return_value
 
 
+def test_baggage_builder_typed_setters_attach_and_restore_context():
+    token = otel_context.attach(baggage.set_baggage("service.name", "previous"))
+    try:
+        builder = (
+            TeamsBaggageBuilder()
+            .tenant_id("tenant-1")
+            .conversation_id("conversation-1")
+            .conversation_item_link("https://service.url")
+            .channel_name("msteams")
+            .channel_link("https://channel.url")
+            .agent_id("agent-1")
+            .agent_name("Agent")
+            .agentic_user_id("agent-user-1")
+            .agent_blueprint_id("blueprint-1")
+            .user_name("User")
+            .operation_source("service")
+            .invoke_agent_server("server.example", 443)
+            .user_id("user-aad-1")
+            .user_email("user@example.com")
+            .agent_description("assistant")
+            .agentic_user_email("agent-user@example.com")
+            .set("custom.key", " custom-value ")
+            .set("blank.value", " ")
+        )
+
+        with builder.build():
+            assert baggage.get_baggage("microsoft.tenant.id") == "tenant-1"
+            assert baggage.get_baggage("gen_ai.conversation.id") == "conversation-1"
+            assert baggage.get_baggage("microsoft.conversation.item.link") == "https://service.url"
+            assert baggage.get_baggage("microsoft.channel.name") == "msteams"
+            assert baggage.get_baggage("microsoft.channel.link") == "https://channel.url"
+            assert baggage.get_baggage("gen_ai.agent.id") == "agent-1"
+            assert baggage.get_baggage("gen_ai.agent.name") == "Agent"
+            assert baggage.get_baggage("microsoft.agent.user.id") == "agent-user-1"
+            assert baggage.get_baggage("microsoft.a365.agent.blueprint.id") == "blueprint-1"
+            assert baggage.get_baggage("user.name") == "User"
+            assert baggage.get_baggage("service.name") == "service"
+            assert baggage.get_baggage("server.address") == "server.example"
+            assert baggage.get_baggage("server.port") == "443"
+            assert baggage.get_baggage("user.id") == "user-aad-1"
+            assert baggage.get_baggage("user.email") == "user@example.com"
+            assert baggage.get_baggage("gen_ai.agent.description") == "assistant"
+            assert baggage.get_baggage("microsoft.agent.user.email") == "agent-user@example.com"
+            assert baggage.get_baggage("custom.key") == "custom-value"
+            assert baggage.get_baggage("blank.value") is None
+
+        assert baggage.get_baggage("service.name") == "previous"
+        assert baggage.get_baggage("server.address") is None
+    finally:
+        otel_context.detach(token)
+
+
+def test_baggage_builder_from_activity_extracts_agent365_keys():
+    core_activity = CoreActivity(
+        type="message",
+        id="activity-1",
+        service_url="https://service.url",
+        **{
+            "from": {
+                "id": "caller-1",
+                "aadObjectId": "caller-aad-1",
+                "name": "Caller",
+                "email": "caller@example.com",
+            },
+            "conversation": {"id": "conversation-1"},
+            "recipient": {
+                "id": "bot-1",
+                "name": "Agent",
+                "email": "agentic-user@example.com",
+                "tenantId": "recipient-tenant",
+                "agenticAppId": "agent-app-1",
+                "agenticUserId": "agent-user-1",
+                "agenticAppBlueprintId": "blueprint-1",
+                "userRole": "assistant",
+            },
+            "channelId": "msteams",
+            "channelData": {"tenant": {"id": "channel-tenant"}},
+        },
+    )
+    activity = ActivityTypeAdapter.validate_python(core_activity.model_dump(by_alias=True, exclude_none=True))
+    ctx = MagicMock(spec=ActivityContext)
+    ctx.activity = activity
+
+    def configure_service(builder: TeamsBaggageBuilder) -> None:
+        builder.operation_source("service")
+
+    with with_teams_baggage(ctx, configure_service):
+        assert baggage.get_baggage("microsoft.tenant.id") == "recipient-tenant"
+        assert baggage.get_baggage("gen_ai.conversation.id") == "conversation-1"
+        assert baggage.get_baggage("microsoft.conversation.item.link") == "https://service.url"
+        assert baggage.get_baggage("microsoft.channel.name") == "msteams"
+        assert baggage.get_baggage("microsoft.channel.link") is None
+        assert baggage.get_baggage("user.id") == "caller-aad-1"
+        assert baggage.get_baggage("user.name") == "Caller"
+        assert baggage.get_baggage("user.email") == "caller@example.com"
+        assert baggage.get_baggage("gen_ai.agent.id") == "agent-app-1"
+        assert baggage.get_baggage("gen_ai.agent.name") == "Agent"
+        assert baggage.get_baggage("microsoft.agent.user.id") == "agent-user-1"
+        assert baggage.get_baggage("microsoft.agent.user.email") == "agentic-user@example.com"
+        assert baggage.get_baggage("gen_ai.agent.description") == "assistant"
+        assert baggage.get_baggage("microsoft.a365.agent.blueprint.id") == "blueprint-1"
+        assert baggage.get_baggage("service.name") == "service"
+
+
+def test_with_teams_baggage_supports_configure_without_source():
+    def configure_service(builder: TeamsBaggageBuilder) -> None:
+        builder.operation_source("service")
+
+    with with_teams_baggage(configure=configure_service):
+        assert baggage.get_baggage("service.name") == "service"
+
+    assert baggage.get_baggage("service.name") is None
+
+
+def test_baggage_builder_from_activity_falls_back_to_channel_tenant_and_bot_id():
+    core_activity = CoreActivity(
+        type="message",
+        id="activity-1",
+        **{
+            "from": {"id": "caller-1"},
+            "conversation": {"id": "conversation-1"},
+            "recipient": {"id": "bot-1"},
+            "channelId": "msteams",
+            "channelData": {"tenant": {"id": "channel-tenant"}},
+        },
+    )
+    activity = ActivityTypeAdapter.validate_python(core_activity.model_dump(by_alias=True, exclude_none=True))
+
+    with TeamsBaggageBuilder.from_activity(activity).build():
+        assert baggage.get_baggage("microsoft.tenant.id") == "channel-tenant"
+        assert baggage.get_baggage("gen_ai.agent.id") == "bot-1"
+        assert baggage.get_baggage("user.id") is None
+        assert baggage.get_baggage("user.email") is None
+
+
 def test_app_metrics_are_recorded_with_allowed_attributes():
     metric_reader = InMemoryMetricReader()
     meter_provider = MeterProvider(metric_readers=[metric_reader])
@@ -72,9 +219,9 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
     with patch("microsoft_teams.apps.diagnostics._helpers.get_meter", return_value=meter):
         record_activity_received("message")
         record_turn_duration(5.5, "message")
-        record_handler_dispatched("message", "route")
-        record_handler_duration(2.5, "message", "route")
-        record_handler_failure("message", "route")
+        record_handler_dispatched("message", "type")
+        record_handler_duration(2.5, "message", "type")
+        record_handler_failure("message", "type")
         record_handler_unmatched("invoke", "composeExtension/query")
 
     metrics = {}
@@ -95,15 +242,15 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
 
     dispatched_point = metrics["teams.handler.dispatched"].data.data_points[0]
     assert dispatched_point.value == 1
-    assert dispatched_point.attributes == {"handler.type": "message", "handler.dispatch": "route"}
+    assert dispatched_point.attributes == {"handler.type": "message", "handler.dispatch": "type"}
 
     handler_duration_point = metrics["teams.handler.duration"].data.data_points[0]
     assert handler_duration_point.sum == 2.5
-    assert handler_duration_point.attributes == {"handler.type": "message", "handler.dispatch": "route"}
+    assert handler_duration_point.attributes == {"handler.type": "message", "handler.dispatch": "type"}
 
     failures_point = metrics["teams.handler.failures"].data.data_points[0]
     assert failures_point.value == 1
-    assert failures_point.attributes == {"handler.type": "message", "handler.dispatch": "route"}
+    assert failures_point.attributes == {"handler.type": "message", "handler.dispatch": "type"}
 
     unmatched_point = metrics["teams.handler.unmatched"].data.data_points[0]
     assert unmatched_point.value == 1

--- a/packages/apps/tests/test_http_server.py
+++ b/packages/apps/tests/test_http_server.py
@@ -20,15 +20,15 @@ from microsoft_teams.apps.http.http_server import HttpServer
 class TestHttpServer:
     """Test cases for HttpServer implementation."""
 
-    def test_http_server_is_not_publicly_exported(self):
-        """HttpServer is an implementation detail and should not be exported."""
+    def test_http_server_is_publicly_exported(self):
+        """HttpServer remains publicly exported for compatibility."""
         import microsoft_teams.apps as apps
         import microsoft_teams.apps.http as http
 
-        assert "HttpServer" not in apps.__all__
-        assert not hasattr(apps, "HttpServer")
-        assert "HttpServer" not in http.__all__
-        assert not hasattr(http, "HttpServer")
+        assert "HttpServer" in apps.__all__
+        assert apps.HttpServer is HttpServer
+        assert "HttpServer" in http.__all__
+        assert http.HttpServer is HttpServer
 
     @pytest.fixture
     def mock_adapter(self):
@@ -56,6 +56,13 @@ class TestHttpServer:
         server.initialize(dangerously_allow_unauthenticated_requests=True)
         # Should only register route once
         assert mock_adapter.register_route.call_count == 1
+
+    def test_initialize_accepts_skip_auth_alias(self, server, mock_adapter):
+        """skip_auth remains a deprecated alias for unauthenticated local development."""
+        server.initialize(skip_auth=True)
+
+        assert server._dangerously_allow_unauthenticated_requests is True
+        mock_adapter.register_route.assert_called_once()
 
     def test_invalid_messaging_endpoint_raises(self, mock_adapter):
         """Test that invalid messaging endpoint raises ValueError."""
@@ -288,7 +295,7 @@ class TestFastAPIAdapter:
         adapter.register_route("POST", "/test", handler)
 
         # Verify a route was registered on the FastAPI app
-        routes = [r for r in adapter.app.routes if hasattr(r, "path") and r.path == "/test"]
+        routes = [r for r in adapter.app.routes if getattr(r, "path", None) == "/test"]
         assert len(routes) == 1
 
     def test_serve_static(self, tmp_path):
@@ -297,7 +304,7 @@ class TestFastAPIAdapter:
         adapter.serve_static("/static", str(tmp_path))
 
         # Verify a mount was registered
-        mounts = [r for r in adapter.app.routes if hasattr(r, "path") and r.path == "/static"]
+        mounts = [r for r in adapter.app.routes if getattr(r, "path", None) == "/static"]
         assert len(mounts) == 1
 
     @pytest.mark.asyncio

--- a/packages/common/src/microsoft_teams/common/http/__init__.py
+++ b/packages/common/src/microsoft_teams/common/http/__init__.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from .client import Client, ClientOptions
+from .client import Client, ClientOptions, Middleware, MiddlewareContext, MiddlewareNext, MiddlewareResult
 from .client_token import Token, TokenFactory, resolve_token
 from .interceptor import Interceptor, InterceptorRequestContext, InterceptorResponseContext
 
@@ -13,6 +13,10 @@ __all__ = [
     "Interceptor",
     "InterceptorRequestContext",
     "InterceptorResponseContext",
+    "Middleware",
+    "MiddlewareContext",
+    "MiddlewareNext",
+    "MiddlewareResult",
     "Token",
     "TokenFactory",
     "resolve_token",

--- a/packages/common/src/microsoft_teams/common/http/client.py
+++ b/packages/common/src/microsoft_teams/common/http/client.py
@@ -7,7 +7,7 @@ import inspect
 import json
 import logging
 from dataclasses import dataclass, field, replace
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol
 
 import httpx
 from httpx._models import Request, Response
@@ -92,6 +92,43 @@ class ClientOptions:
     interceptors: Optional[List[Interceptor]] = None
 
 
+@dataclass
+class MiddlewareContext:
+    """Context passed to HTTP middleware around terminal dispatch."""
+
+    method: str
+    url: str
+    headers: Dict[str, str]
+    token: Optional[Token]
+    params: Optional[QueryParamTypes] = None
+    content: Optional[RequestContent] = None
+    data: Optional[RequestData] = None
+    files: Optional[RequestFiles] = None
+    json: object | None = None
+    kwargs: Dict[str, Any] = field(default_factory=dict[str, Any])
+    logger: logging.Logger = logger
+    metadata: object | None = None
+
+
+MiddlewareNext = Callable[[], Awaitable[httpx.Response]]
+MiddlewareResult = httpx.Response | Awaitable[httpx.Response]
+
+
+class Middleware(Protocol):
+    """Protocol for HTTP middleware.
+
+    Middleware wraps the full terminal dispatch, including token resolution,
+    existing interceptor/event-hook execution, response status handling, and
+    response JSON wrapping.
+    """
+
+    def send(
+        self,
+        context: MiddlewareContext,
+        next: MiddlewareNext,
+    ) -> MiddlewareResult: ...
+
+
 class Client:
     """
     HTTP Client abstraction for making requests with configurable options.
@@ -117,6 +154,7 @@ class Client:
 
         # Maintain interceptors as a separate instance attribute (do not mutate options)
         self._interceptors = list(options.interceptors or [])
+        self._middlewares: list[Middleware] = []
 
         self.http = _http or httpx.AsyncClient(
             base_url=httpx.URL(options.base_url) if options.base_url else "",
@@ -129,6 +167,11 @@ class Client:
     def interceptors(self) -> tuple[Interceptor, ...]:
         """Get the registered interceptors."""
         return tuple(self._interceptors)
+
+    @property
+    def middlewares(self) -> tuple[Middleware, ...]:
+        """Get the registered middleware."""
+        return tuple(self._middlewares)
 
     @property
     def token(self) -> Optional[Token]:
@@ -182,11 +225,7 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.get(url, headers=req_headers, params=params, **kwargs)
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
+        return await self._send("GET", url, headers=headers, token=token, params=params, **kwargs)
 
     async def post(
         self,
@@ -218,20 +257,18 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.post(
+        return await self._send(
+            "POST",
             url,
             data=data,
             files=files,
             json=json,
             content=content,
             params=params,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
 
     async def put(
         self,
@@ -263,20 +300,18 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.put(
+        return await self._send(
+            "PUT",
             url,
             data=data,
             files=files,
             json=json,
             content=content,
             params=params,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
 
     async def patch(
         self,
@@ -308,20 +343,18 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.patch(
+        return await self._send(
+            "PATCH",
             url,
             data=data,
             files=files,
             json=json,
             content=content,
             params=params,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
 
     async def delete(
         self,
@@ -345,11 +378,7 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.delete(url, headers=req_headers, params=params, **kwargs)
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
+        return await self._send("DELETE", url, headers=headers, token=token, params=params, **kwargs)
 
     async def request(
         self,
@@ -383,11 +412,11 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.request(
+        return await self._send(
             method,
             url,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             params=params,
             content=content,
             data=data,
@@ -395,9 +424,73 @@ class Client:
             json=json,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
+
+    async def _send(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[QueryParamTypes] = None,
+        headers: Optional[Dict[str, str]] = None,
+        token: Optional[Token] = None,
+        content: Optional[RequestContent] = None,
+        data: Optional[RequestData] = None,
+        files: Optional[RequestFiles] = None,
+        json: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        metadata = kwargs.pop("_metadata", None)
+        context = MiddlewareContext(
+            method=method.upper(),
+            url=url,
+            headers=dict(headers or {}),
+            token=token,
+            params=params,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            kwargs=kwargs,
+            logger=logger,
+            metadata=metadata,
+        )
+
+        async def send() -> httpx.Response:
+            req_headers = await self._prepare_headers(context.headers, context.token)
+            response = await self.http.request(
+                context.method,
+                context.url,
+                headers=req_headers,
+                params=context.params,
+                content=context.content,
+                data=context.data,
+                files=context.files,
+                json=context.json,
+                **context.kwargs,
+            )
+            response.raise_for_status()
+            _wrap_response_json(response)
+            return response
+
+        sender: MiddlewareNext = send
+        for middleware in reversed(self._middlewares):
+            sender = self._wrap_request_middleware(middleware, context, sender)
+
+        return await sender()
+
+    def _wrap_request_middleware(
+        self,
+        middleware: Middleware,
+        context: MiddlewareContext,
+        next_sender: MiddlewareNext,
+    ) -> MiddlewareNext:
+        async def sender() -> httpx.Response:
+            result = middleware.send(context, next_sender)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return sender
 
     async def _resolve_token(self, token: Optional[Token]) -> Optional[str]:
         """
@@ -423,6 +516,15 @@ class Client:
         """
         self._interceptors.append(interceptor)
         self._update_event_hooks()
+
+    def use(self, middleware: Middleware) -> None:
+        """
+        Register middleware for terminal request dispatch.
+
+        Middleware runs in insertion order, with the first registered
+        middleware as the outermost wrapper.
+        """
+        self._middlewares.append(middleware)
 
     def _update_event_hooks(self) -> None:
         """
@@ -476,4 +578,6 @@ class Client:
             if overrides.interceptors is not None
             else list(self._interceptors),
         )
-        return Client(merged_options, _http=self.http if share_http else None)
+        cloned = Client(merged_options, _http=self.http if share_http else None)
+        cloned._middlewares = list(self._middlewares)
+        return cloned

--- a/packages/common/src/microsoft_teams/common/http/client.py
+++ b/packages/common/src/microsoft_teams/common/http/client.py
@@ -196,7 +196,7 @@ class Client:
             Final headers dict for the request.
         """
         req_headers = {**self._options.headers, **(headers or {})}
-        if headers and any(key.lower() == "authorization" for key in headers):
+        if any(key.lower() == "authorization" for key in req_headers):
             return req_headers
         resolved_token = await self._resolve_token(token)
         if resolved_token:

--- a/packages/common/tests/test_client.py
+++ b/packages/common/tests/test_client.py
@@ -434,6 +434,23 @@ async def test_explicit_authorization_header_wins_over_default_token(mock_transp
     assert data["headers"]["authorization"] == "******"
 
 
+@pytest.mark.asyncio
+async def test_default_authorization_header_bypasses_token_resolution(mock_transport):
+    client = Client(
+        ClientOptions(
+            base_url="https://example.com",
+            headers={"Authorization": "******"},
+            token=failing_token_factory,
+        )
+    )
+    client.http._transport = mock_transport
+
+    resp = await client.get("/token-test")
+    data = resp.json()
+
+    assert data["headers"]["authorization"] == "******"
+
+
 # Test token factory that raises an exception
 def failing_token_factory() -> str:
     raise ValueError("Token factory failed")

--- a/packages/common/tests/test_client.py
+++ b/packages/common/tests/test_client.py
@@ -2,10 +2,19 @@
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
+# pyright: basic
 
 import httpx
 import pytest
-from microsoft_teams.common.http import Client, ClientOptions, Interceptor
+from microsoft_teams.common.http import (
+    Client,
+    ClientOptions,
+    Interceptor,
+    InterceptorRequestContext,
+    InterceptorResponseContext,
+    MiddlewareContext,
+    MiddlewareNext,
+)
 from microsoft_teams.common.http.client_token import StringLike
 
 
@@ -31,6 +40,18 @@ class DummySyncInterceptor:
 
     def response(self, ctx):
         self.response_called = True
+
+
+class RecordingMiddleware:
+    def __init__(self, name: str, events: list[str]) -> None:
+        self.name = name
+        self.events = events
+
+    async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+        self.events.append(f"{self.name}:before:{context.method}")
+        response = await next()
+        self.events.append(f"{self.name}:after:{response.status_code}")
+        return response
 
 
 class CustomStringLike(StringLike):
@@ -126,6 +147,14 @@ def test_interceptors_returns_read_only_copy():
     assert client.interceptors == (interceptor1,)
 
 
+def test_middlewares_returns_read_only_copy():
+    middleware = RecordingMiddleware("middleware", [])
+    client = Client()
+    client.use(middleware)
+
+    assert client.middlewares == (middleware,)
+
+
 def test_clone_copies_interceptor_list_independently():
     interceptor1 = DummyAsyncInterceptor()
     client = Client(ClientOptions(interceptors=[interceptor1]))
@@ -139,6 +168,31 @@ def test_clone_copies_interceptor_list_independently():
     assert client.interceptors is not clone.interceptors
 
 
+def test_clone_copies_middleware_list_independently():
+    middleware1 = RecordingMiddleware("one", [])
+    client = Client()
+    client.use(middleware1)
+
+    clone = client.clone()
+    middleware2 = RecordingMiddleware("two", [])
+    clone.use(middleware2)
+
+    assert client.middlewares == (middleware1,)
+    assert clone.middlewares == (middleware1, middleware2)
+    assert client.middlewares is not clone.middlewares
+
+
+def test_middlewares_support_deduping_by_inspection():
+    middleware = RecordingMiddleware("one", [])
+    client = Client()
+    client.use(middleware)
+
+    if not any(isinstance(existing, RecordingMiddleware) for existing in client.middlewares):
+        client.use(RecordingMiddleware("duplicate", []))
+
+    assert client.middlewares == (middleware,)
+
+
 def test_clone_reuses_underlying_http_client_when_requested():
     client = Client(ClientOptions(base_url="https://example.com"))
 
@@ -146,6 +200,156 @@ def test_clone_reuses_underlying_http_client_when_requested():
 
     assert clone is not client
     assert clone.http is client.http
+
+
+@pytest.mark.asyncio
+async def test_middleware_runs_in_insertion_order_with_first_outermost():
+    events: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        events.append("terminal")
+        return httpx.Response(200, json={"ok": True}, headers={"content-type": "application/json"})
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(RecordingMiddleware("one", events))
+    client.use(RecordingMiddleware("two", events))
+
+    await client.get("/ordered")
+
+    assert events == [
+        "one:before:GET",
+        "two:before:GET",
+        "terminal",
+        "two:after:200",
+        "one:after:200",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_middleware_can_mutate_headers_and_kwargs():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "header": request.headers["x-middleware"],
+                "extension": request.extensions["middleware"],
+            },
+            headers={"content-type": "application/json"},
+        )
+
+    class MutatingMiddleware:
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            context.headers["X-Middleware"] = "header-value"
+            context.kwargs["extensions"] = {"middleware": "extension-value"}
+            return await next()
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(MutatingMiddleware())
+
+    response = await client.get("/mutated")
+
+    assert response.json() == {"header": "header-value", "extension": "extension-value"}
+
+
+@pytest.mark.asyncio
+async def test_middleware_can_short_circuit_response():
+    class ShortCircuitMiddleware:
+        def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            return httpx.Response(204)
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(lambda request: httpx.Response(500))
+    client.use(ShortCircuitMiddleware())
+
+    response = await client.get("/short-circuit")
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_middleware_observes_and_propagates_terminal_errors():
+    events: list[str] = []
+    error = RuntimeError("boom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise error
+
+    class ErrorRecordingMiddleware:
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            try:
+                return await next()
+            except Exception as exception:
+                events.append(str(exception))
+                raise
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(ErrorRecordingMiddleware())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await client.get("/error")
+
+    assert events == ["boom"]
+
+
+@pytest.mark.asyncio
+async def test_middleware_runs_around_existing_interceptors(mock_transport):
+    events: list[str] = []
+
+    class RecordingInterceptor(Interceptor):
+        def request(self, ctx: InterceptorRequestContext) -> None:
+            events.append("interceptor:request")
+
+        def response(self, ctx: InterceptorResponseContext) -> None:
+            events.append("interceptor:response")
+
+    class EventMiddleware:
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            events.append("middleware:before")
+            response = await next()
+            events.append("middleware:after")
+            return response
+
+    client = Client(ClientOptions(base_url="https://example.com", interceptors=[RecordingInterceptor()]))
+    client.http._transport = mock_transport
+    client.use(EventMiddleware())
+
+    await client.get("/with-interceptors")
+
+    assert events == ["middleware:before", "interceptor:request", "interceptor:response", "middleware:after"]
+
+
+@pytest.mark.asyncio
+async def test_request_metadata_is_not_sent_over_wire():
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"ok": True}, headers={"content-type": "application/json"})
+
+    class MetadataMiddleware:
+        def __init__(self) -> None:
+            self.metadata: object | None = None
+
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            self.metadata = context.metadata
+            return await next()
+
+    metadata = object()
+    middleware = MetadataMiddleware()
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(middleware)
+
+    await client.get("/metadata", _metadata=metadata)
+
+    assert middleware.metadata is metadata
+    request = captured[0]
+    assert "_metadata" not in str(request.url)
+    assert "_metadata" not in request.headers
+    assert "_metadata" not in request.extensions
 
 
 def test_clone_uses_current_token_value():

--- a/uv.lock
+++ b/uv.lock
@@ -1794,6 +1794,7 @@ source = { editable = "packages/api" }
 dependencies = [
     { name = "microsoft-teams-cards" },
     { name = "microsoft-teams-common" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
 ]
@@ -1809,6 +1810,7 @@ dev = [
 requires-dist = [
     { name = "microsoft-teams-cards", editable = "packages/cards" },
     { name = "microsoft-teams-common", editable = "packages/common" },
+    { name = "opentelemetry-api", specifier = ">=1.41.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
 ]
@@ -1830,6 +1832,7 @@ dependencies = [
     { name = "microsoft-teams-api" },
     { name = "microsoft-teams-common" },
     { name = "msal" },
+    { name = "opentelemetry-api" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
@@ -1857,6 +1860,7 @@ requires-dist = [
     { name = "microsoft-teams-common", editable = "packages/common" },
     { name = "microsoft-teams-graph", marker = "extra == 'graph'", editable = "packages/graph" },
     { name = "msal", specifier = ">=1.37.0" },
+    { name = "opentelemetry-api", specifier = ">=1.41.0" },
     { name = "pydantic-settings", specifier = ">=2.11.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
Adds the first cut of OpenTelemetry observability across the Python Teams SDK runtime.

## Why

This gives developers a real trace through the SDK: inbound activity → handler → outbound Teams API call → auth. Makes it way easier to debug whether Teams called us, whether the handler ran, whether we sent the reply, and which auth flow was used.

It also sets up the Agent 365 story. Teams SDK spans are the useful diagnostic detail; Agent 365 product visibility still comes from explicit A365 scopes like invoke_agent / execute_tool / chat.

## Interesting bits

- Adds public common HTTP middleware support so API telemetry can wrap auth + transport cleanly.
- Adds API outbound telemetry middleware for `microsoft.teams.api.client`.
- Emits `microsoft.teams.auth.outbound` from the API auth token callback.
- Adds Apps spans/metrics for `microsoft.teams.activity.process` and `microsoft.teams.handler`.
- Adds Agent365-compatible baggage from inbound Teams activities.
- Adds package version as the OTel instrumentation scope version for `Microsoft.Teams.Api` and `Microsoft.Teams.Apps`.
- Keeps the generic HTTP middleware mechanics-only. Client methods own semantic attrs and response hooks.
- Restores compatibility for public `service_url` / `agentic_identity` scoping kwargs, `HttpServer` exports, `skip_auth`, and explicit/default Authorization header behavior after the middleware refactor.

TS/Python intentionally differ from .NET right now: .NET still has Core-shaped names like `Microsoft.Teams.Core`, `turn`, and `conversation_client`. This PR uses the newer API/Apps split and `microsoft.teams.api.client` middleware model.

## Reviewer tips

Start with common HTTP middleware, then API outbound middleware, then conversation activity methods that attach semantic attrs/hooks. The compatibility commits are worth reviewing too: they preserve per-call service URL / agentic identity behavior and legacy app/http server surface.

## Testing

- Ruff, format, and pyright passed on affected files.
- Targeted pytest suites passed, including common HTTP client, diagnostics, conversation client, app, and HTTP server tests.
- Live Teams smokes passed for Agent365 / ACF and Echo / PokemonCatcher.
- Aspire inspection confirmed traces + metrics, expected span nesting, API/auth spans, and response-derived activity IDs.
- Fixed issues found during smoke/review: API/auth spans now use client span kind, compatibility surfaces are restored, and direct conversation activity clients now respect per-call agentic identity.
