### PR TITLE
Add OpenTelemetry API middleware

### DIFF
--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 ]
 requires-python = ">=3.11,<4.0"
 dependencies = [
+    "opentelemetry-api>=1.41.0",
     "pydantic>=2.0.0",
     "microsoft-teams-common",
     "microsoft-teams-cards",

--- a/packages/api/src/microsoft_teams/api/__init__.py
+++ b/packages/api/src/microsoft_teams/api/__init__.py
@@ -5,10 +5,11 @@ Licensed under the MIT License.
 
 import logging
 
-from . import activities, auth, clients, models
+from . import activities, auth, clients, diagnostics, models
 from .activities import *  # noqa: F403
 from .auth import *  # noqa: F403
 from .clients import *  # noqa: F403
+from .diagnostics import *  # noqa: F403
 from .models import *  # noqa: F403
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -18,4 +19,5 @@ __all__: list[str] = []
 __all__.extend(activities.__all__)
 __all__.extend(auth.__all__)
 __all__.extend(clients.__all__)
+__all__.extend(diagnostics.__all__)
 __all__.extend(models.__all__)

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -5,13 +5,19 @@ Licensed under the MIT License.
 
 from __future__ import annotations
 
+import inspect
 from typing import Literal, Optional, TypeAlias, Union
 
 from microsoft_teams.common import Client as HttpClient
 from microsoft_teams.common import ClientOptions, Token
+from microsoft_teams.common.http.client_token import StringLike
+from opentelemetry.trace import SpanKind
 from typing_extensions import deprecated
 
 from ..auth.cloud_environment import PUBLIC, CloudEnvironment
+from ..diagnostics._constants import API_ATTRIBUTE_NAMES, API_AUTH_FLOWS, API_SPAN_NAMES
+from ..diagnostics._helpers import get_tracer, record_exception
+from ..diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ..models import AgenticIdentity
 from ._auth_provider import AuthProvider
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
@@ -65,7 +71,12 @@ class ApiClient(BaseClient):
             self._http, self._api_client_settings, cloud=self._cloud
         )
         self.users = UserClient(self._http, self._api_client_settings, cloud=self._cloud)
-        self.conversations = ConversationClient(self.service_url, self._http, self._api_client_settings)
+        self.conversations = ConversationClient(
+            self.service_url,
+            self._http,
+            self._api_client_settings,
+            scope_factory=self._scope_conversations,
+        )
         self.teams = TeamClient(self.service_url, self._http, self._api_client_settings)
         self.meetings = MeetingClient(self.service_url, self._http, self._api_client_settings)
         self._reactions: Optional[ReactionClient] = None
@@ -129,6 +140,13 @@ class ApiClient(BaseClient):
         """Alias for from_agentic_identity."""
         return self.from_agentic_identity(agentic_identity)
 
+    def _scope_conversations(
+        self,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+    ) -> ConversationClient:
+        return self.clone(service_url=service_url, agentic_identity=agentic_identity).conversations
+
     def _get_scoped_http(self, agentic_identity: AgenticIdentity | None) -> HttpClient:
         if self._auth_provider is None:
             return self._http.clone(share_http=True)
@@ -149,7 +167,25 @@ class ApiClient(BaseClient):
         if auth_provider is None:
             return None
 
-        return lambda: auth_provider.token(agentic_identity=agentic_identity)
+        async def resolve_auth_provider_token() -> str | StringLike | None:
+            with get_tracer().start_as_current_span(
+                API_SPAN_NAMES.auth_outbound,
+                kind=SpanKind.CLIENT,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                flow = API_AUTH_FLOWS.agentic if agentic_identity is not None else API_AUTH_FLOWS.app_only
+                span.set_attribute(API_ATTRIBUTE_NAMES.auth_flow, flow)
+                try:
+                    token = auth_provider.token(agentic_identity=agentic_identity)
+                    if inspect.isawaitable(token):
+                        return await token
+                    return token
+                except Exception as exception:
+                    record_exception(span, exception)
+                    raise
+
+        return resolve_auth_provider_token
 
     @property
     def http(self) -> HttpClient:
@@ -161,6 +197,7 @@ class ApiClient(BaseClient):
         """Set the HTTP client instance and propagate to all sub-clients."""
         self._http = value
         self._apply_auth_provider_token()
+        ensure_outbound_telemetry_middleware(self._http)
         self._bots.http = self._http
         self.conversations.http = self._http
         self.users.http = self._http

--- a/packages/api/src/microsoft_teams/api/clients/base_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/base_client.py
@@ -7,6 +7,7 @@ from typing import Optional, Union, cast
 
 from microsoft_teams.common import Client, ClientOptions
 
+from ..diagnostics._outbound import ensure_outbound_telemetry_middleware
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
 
 
@@ -32,6 +33,7 @@ class BaseClient:
             self._http = Client(options)
 
         self._api_client_settings = merge_api_client_settings(api_client_settings)
+        ensure_outbound_telemetry_middleware(self._http)
 
     @property
     def http(self) -> Client:
@@ -41,10 +43,12 @@ class BaseClient:
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
 
-    def _get_service_url(self) -> str:
+    def _get_service_url(self, service_url: str | None = None) -> str:
         current_service_url = cast(str | None, getattr(self, "service_url", None))
-        if current_service_url is None:
+        resolved_service_url = service_url or current_service_url
+        if resolved_service_url is None:
             raise ValueError("service_url is required")
-        return current_service_url.rstrip("/")
+        return resolved_service_url.rstrip("/")

--- a/packages/api/src/microsoft_teams/api/clients/bot/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/client.py
@@ -11,6 +11,7 @@ from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
 from ...auth.cloud_environment import PUBLIC, CloudEnvironment
+from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ..api_client_settings import ApiClientSettings, merge_api_client_settings
 from ..base_client import BaseClient
 from .sign_in_client import BotSignInClient
@@ -48,6 +49,7 @@ class BotClient(BaseClient):
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
         self.token.http = value
         self.sign_in.http = value

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import logging
 from typing import Callable, List, Optional, cast
 
 import httpx
@@ -22,6 +23,7 @@ from ..base_client import BaseClient
 
 _PLACEHOLDER_ACTIVITY_ID = "DO_NOT_USE_PLACEHOLDER_ID"
 ActivityScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationActivityClient"]
+logger = logging.getLogger(__name__)
 
 
 class ConversationActivityClient(BaseClient):
@@ -392,7 +394,11 @@ class ConversationActivityClient(BaseClient):
 
 
 def _set_response_activity_id(span: Span, response: httpx.Response) -> None:
-    response_body = response.json()
+    try:
+        response_body = response.json()
+    except ValueError as exception:
+        logger.warning("Failed to read activity response JSON for telemetry", exc_info=exception)
+        return
     if not isinstance(response_body, dict):
         return
     value = cast(dict[str, object], response_body).get("id")

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -3,17 +3,25 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Optional
+from typing import Callable, List, Optional, cast
 
+import httpx
 from microsoft_teams.common.experimental import experimental
 from microsoft_teams.common.http import Client
+from opentelemetry.trace import Span
 
 from ...activities import ActivityParams, SentActivity
-from ...models import TeamsChannelAccount
+from ...diagnostics._constants import (
+    API_ATTRIBUTE_NAMES,
+    API_OUTBOUND_OPERATIONS,
+)
+from ...diagnostics._outbound import ApiOutboundResponseHook, ApiOutboundTelemetryMetadata
+from ...models import AgenticIdentity, TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 
 _PLACEHOLDER_ACTIVITY_ID = "DO_NOT_USE_PLACEHOLDER_ID"
+ActivityScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationActivityClient"]
 
 
 class ConversationActivityClient(BaseClient):
@@ -26,6 +34,7 @@ class ConversationActivityClient(BaseClient):
         service_url: str,
         http_client: Optional[Client] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        scope_factory: ActivityScopeFactory | None = None,
     ):
         """
         Initialize the conversation activity client.
@@ -37,11 +46,24 @@ class ConversationActivityClient(BaseClient):
         """
         super().__init__(http_client, api_client_settings)
         self.service_url = service_url.rstrip("/")
+        self._scope_factory = scope_factory
+
+    def _scoped_client(
+        self,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+    ) -> "ConversationActivityClient":
+        if (service_url is None and agentic_identity is None) or self._scope_factory is None:
+            return self
+        return self._scope_factory(service_url, agentic_identity)
 
     async def create(
         self,
         conversation_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Create a new activity in a conversation.
@@ -55,15 +77,27 @@ class ConversationActivityClient(BaseClient):
         """
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create(conversation_id, activity)
+
         response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities",
             json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.create,
+                conversation_id,
+                service_url=service_url,
+                activity=activity,
+                on_response=_set_response_activity_id,
+            ),
         )
 
         # Note: Typing activities (non-streaming) always produce empty responses.
         # Note: For streaming activities, the first response includes the stream id.
         # Note: Subsequent responses for streaming activities are empty (both typing and message type).
-        id = response.json().get("id", _PLACEHOLDER_ACTIVITY_ID)
+        response_body = response.json()
+        id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
         return SentActivity(id=id, activity_params=activity)
 
     async def update(
@@ -71,6 +105,9 @@ class ConversationActivityClient(BaseClient):
         conversation_id: str,
         activity_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Update an existing activity in a conversation.
@@ -84,9 +121,21 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update(conversation_id, activity_id, activity)
+
         response = await self.http.put(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.update,
+                conversation_id,
+                service_url=service_url,
+                activity=activity,
+                activity_id=activity_id,
+                on_response=_set_response_activity_id,
+            ),
         )
         id = response.json()["id"]
         return SentActivity(id=id, activity_params=activity)
@@ -96,6 +145,9 @@ class ConversationActivityClient(BaseClient):
         conversation_id: str,
         activity_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Reply to an activity in a conversation.
@@ -109,11 +161,23 @@ class ConversationActivityClient(BaseClient):
             The created reply activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.reply(conversation_id, activity_id, activity)
+
         activity_json = activity.model_dump(by_alias=True, exclude_none=True)
         activity_json["replyToId"] = activity_id
         response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
             json=activity_json,
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.reply,
+                conversation_id,
+                service_url=service_url,
+                activity=activity,
+                activity_id=activity_id,
+                on_response=_set_response_activity_id,
+            ),
         )
         id = response.json()["id"]
         return SentActivity(id=id, activity_params=activity)
@@ -122,6 +186,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> None:
         """
         Delete an activity from a conversation.
@@ -130,14 +197,27 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete(conversation_id, activity_id)
+
         await self.http.delete(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.delete,
+                conversation_id,
+                service_url=service_url,
+                activity_id=activity_id,
+            ),
         )
 
     async def get_members(
         self,
         conversation_id: str,
         activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> List[TeamsChannelAccount]:
         """
         Get the members associated with an activity.
@@ -150,8 +230,12 @@ class ConversationActivityClient(BaseClient):
             List of TeamsChannelAccount objects representing the activity members
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.get_members(conversation_id, activity_id)
+
         response = await self.http.get(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}/members",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}/members",
         )
         return [TeamsChannelAccount.model_validate(member) for member in response.json()]
 
@@ -160,6 +244,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Create a new targeted activity in a conversation.
@@ -178,11 +265,23 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create_targeted(conversation_id, activity)
+
         response = await self.http.post(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.create_targeted,
+                conversation_id,
+                service_url=service_url,
+                activity=activity,
+                on_response=_set_response_activity_id,
+            ),
         )
-        id = response.json().get("id", _PLACEHOLDER_ACTIVITY_ID)
+        response_body = response.json()
+        id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
         return SentActivity(id=id, activity_params=activity)
 
     @experimental("ExperimentalTeamsTargeted")
@@ -191,6 +290,9 @@ class ConversationActivityClient(BaseClient):
         conversation_id: str,
         activity_id: str,
         activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> SentActivity:
         """
         Update an existing targeted activity in a conversation.
@@ -208,9 +310,21 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update_targeted(conversation_id, activity_id, activity)
+
         response = await self.http.put(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
             json=activity.model_dump(by_alias=True, exclude_none=True),
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.update_targeted,
+                conversation_id,
+                service_url=service_url,
+                activity=activity,
+                activity_id=activity_id,
+                on_response=_set_response_activity_id,
+            ),
         )
         id = response.json()["id"]
         return SentActivity(id=id, activity_params=activity)
@@ -220,6 +334,9 @@ class ConversationActivityClient(BaseClient):
         self,
         conversation_id: str,
         activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
     ) -> None:
         """
         Delete a targeted activity from a conversation.
@@ -233,6 +350,51 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete_targeted(conversation_id, activity_id)
+
         await self.http.delete(
-            f"{self._get_service_url()}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true"
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}?isTargetedActivity=true",
+            _metadata=self._create_activity_telemetry_metadata(
+                API_OUTBOUND_OPERATIONS.delete_targeted,
+                conversation_id,
+                service_url=service_url,
+                activity_id=activity_id,
+            ),
         )
+
+    def _create_activity_telemetry_metadata(
+        self,
+        operation: str,
+        conversation_id: str,
+        *,
+        service_url: str | None = None,
+        activity: ActivityParams | None = None,
+        activity_id: str | None = None,
+        on_response: ApiOutboundResponseHook | None = None,
+    ) -> ApiOutboundTelemetryMetadata:
+        attributes = {
+            API_ATTRIBUTE_NAMES.operation: operation,
+            API_ATTRIBUTE_NAMES.service_url: self._get_service_url(service_url),
+            API_ATTRIBUTE_NAMES.conversation_id: conversation_id,
+        }
+        if activity is not None:
+            attributes[API_ATTRIBUTE_NAMES.activity_type] = str(activity.type)
+        if activity_id is not None:
+            attributes[API_ATTRIBUTE_NAMES.activity_id] = activity_id
+
+        return ApiOutboundTelemetryMetadata(
+            operation=operation,
+            attributes=attributes,
+            on_response=on_response,
+        )
+
+
+def _set_response_activity_id(span: Span, response: httpx.Response) -> None:
+    response_body = response.json()
+    if not isinstance(response_body, dict):
+        return
+    value = cast(dict[str, object], response_body).get("id")
+    if value:
+        span.set_attribute(API_ATTRIBUTE_NAMES.activity_id, str(value))

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -3,12 +3,14 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
-from ...models import ConversationResource
+from ...activities import SentActivity
+from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
+from ...models import AgenticIdentity, ConversationResource, TeamsChannelAccount
 from ...models.message import MessageReactionType
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -16,6 +18,8 @@ from ..reaction import ReactionClient
 from .activity import ActivityParams, ConversationActivityClient
 from .member import ConversationMemberClient
 from .params import CreateConversationParams
+
+ConversationScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationClient"]
 
 
 class ConversationOperations:
@@ -29,32 +33,126 @@ class ConversationOperations:
 class ActivityOperations(ConversationOperations):
     """Operations for managing activities in a conversation."""
 
-    async def create(self, activity: ActivityParams):
-        return await self._client.activities_client.create(self._conversation_id, activity)
+    async def create(
+        self,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        return await self._client.create_activity(
+            self._conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update(self, activity_id: str, activity: ActivityParams):
-        return await self._client.activities_client.update(self._conversation_id, activity_id, activity)
+    async def update(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        return await self._client.update_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def reply(self, activity_id: str, activity: ActivityParams):
-        return await self._client.activities_client.reply(self._conversation_id, activity_id, activity)
+    async def reply(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        return await self._client.reply_to_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete(self, activity_id: str):
-        await self._client.activities_client.delete(self._conversation_id, activity_id)
+    async def delete(
+        self,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
+        await self._client.delete_activity(
+            self._conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def get_members(self, activity_id: str):
-        return await self._client.activities_client.get_members(self._conversation_id, activity_id)
+    async def get_members(
+        self,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> list[TeamsChannelAccount]:
+        return await self._client.get_activity_members(
+            self._conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def create_targeted(self, activity: ActivityParams):
+    async def create_targeted(
+        self,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Create a new targeted activity visible only to the specified recipient."""
-        return await self._client.activities_client.create_targeted(self._conversation_id, activity)
+        return await self._client.create_targeted_activity(
+            self._conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update_targeted(self, activity_id: str, activity: ActivityParams):
+    async def update_targeted(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Update an existing targeted activity."""
-        return await self._client.activities_client.update_targeted(self._conversation_id, activity_id, activity)
+        return await self._client.update_targeted_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete_targeted(self, activity_id: str):
+    async def delete_targeted(
+        self,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
         """Delete a targeted activity."""
-        await self._client.activities_client.delete_targeted(self._conversation_id, activity_id)
+        await self._client.delete_targeted_activity(
+            self._conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
 
 class MemberOperations(ConversationOperations):
@@ -86,6 +184,7 @@ class ConversationClient(BaseClient):
         service_url: str,
         options: Optional[Union[Client, ClientOptions]] = None,
         api_client_settings: Optional[ApiClientSettings] = None,
+        scope_factory: ConversationScopeFactory | None = None,
     ) -> None:
         """Initialize the client.
 
@@ -96,11 +195,15 @@ class ConversationClient(BaseClient):
         """
         super().__init__(options, api_client_settings)
         self.service_url = service_url.rstrip("/")
+        self._scope_factory = scope_factory
 
         self._activities_client = ConversationActivityClient(
             self.service_url,
             self.http,
             self._api_client_settings,
+            scope_factory=lambda service_url, agentic_identity: self._scoped_client(
+                service_url, agentic_identity
+            ).activities_client,
         )
         self._members_client = ConversationMemberClient(
             self.service_url,
@@ -117,6 +220,7 @@ class ConversationClient(BaseClient):
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
         self._activities_client.http = value
         self._members_client.http = value
@@ -164,37 +268,172 @@ class ConversationClient(BaseClient):
         """
         return MemberOperations(self, conversation_id)
 
-    async def create_activity(self, conversation_id: str, activity: ActivityParams):
+    def _scoped_client(
+        self,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+    ) -> "ConversationClient":
+        if (service_url is None and agentic_identity is None) or self._scope_factory is None:
+            return self
+        return self._scope_factory(service_url, agentic_identity)
+
+    async def create_activity(
+        self,
+        conversation_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Create an activity in a conversation."""
-        return await self._activities_client.create(conversation_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create_activity(conversation_id, activity)
+        return await self._activities_client.create(
+            conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+    async def update_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Update an activity in a conversation."""
-        return await self._activities_client.update(conversation_id, activity_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.update(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def reply_to_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+    async def reply_to_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Reply to an activity in a conversation."""
-        return await self._activities_client.reply(conversation_id, activity_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.reply_to_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.reply(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete_activity(self, conversation_id: str, activity_id: str):
+    async def delete_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
         """Delete an activity in a conversation."""
-        return await self._activities_client.delete(conversation_id, activity_id)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete_activity(conversation_id, activity_id)
+        return await self._activities_client.delete(
+            conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def get_activity_members(self, conversation_id: str, activity_id: str):
+    async def get_activity_members(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> list[TeamsChannelAccount]:
         """Get the members of an activity in a conversation."""
-        return await self._activities_client.get_members(conversation_id, activity_id)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.get_activity_members(conversation_id, activity_id)
+        return await self._activities_client.get_members(
+            conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def create_targeted_activity(self, conversation_id: str, activity: ActivityParams):
+    async def create_targeted_activity(
+        self,
+        conversation_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Create a targeted activity in a conversation."""
-        return await self._activities_client.create_targeted(conversation_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.create_targeted_activity(conversation_id, activity)
+        return await self._activities_client.create_targeted(
+            conversation_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def update_targeted_activity(self, conversation_id: str, activity_id: str, activity: ActivityParams):
+    async def update_targeted_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
         """Update a targeted activity in a conversation."""
-        return await self._activities_client.update_targeted(conversation_id, activity_id, activity)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.update_targeted_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.update_targeted(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
-    async def delete_targeted_activity(self, conversation_id: str, activity_id: str):
+    async def delete_targeted_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> None:
         """Delete a targeted activity in a conversation."""
-        return await self._activities_client.delete_targeted(conversation_id, activity_id)
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.delete_targeted_activity(conversation_id, activity_id)
+        return await self._activities_client.delete_targeted(
+            conversation_id,
+            activity_id,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
 
     async def get_members(self, conversation_id: str):
         """Get the members of a conversation."""

--- a/packages/api/src/microsoft_teams/api/clients/user/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/user/client.py
@@ -11,6 +11,7 @@ from microsoft_teams.common.http import Client, ClientOptions
 from typing_extensions import deprecated
 
 from ...auth.cloud_environment import PUBLIC, CloudEnvironment
+from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
 from ...models import TokenResponse, TokenStatus
 from ..api_client_settings import ApiClientSettings, merge_api_client_settings
 from ..base_client import BaseClient
@@ -54,6 +55,7 @@ class UserClient(BaseClient):
     @http.setter
     def http(self, value: Client) -> None:
         """Set the HTTP client instance and propagate to sub-clients."""
+        ensure_outbound_telemetry_middleware(value)
         self._http = value
         self._token.http = value
 

--- a/packages/api/src/microsoft_teams/api/diagnostics/__init__.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from ._telemetry import TEAMS_API_METER_NAME, TEAMS_API_TRACER_NAME, TeamsApiTelemetry
+
+__all__ = ["TEAMS_API_METER_NAME", "TEAMS_API_TRACER_NAME", "TeamsApiTelemetry"]

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _ApiAttributeNames:
+    activity_id: str = "activity.id"
+    activity_type: str = "activity.type"
+    auth_flow: str = "auth.flow"
+    conversation_id: str = "conversation.id"
+    operation: str = "operation"
+    service_url: str = "service.url"
+
+
+@dataclass(frozen=True)
+class _ApiAuthFlows:
+    agentic: str = "agentic"
+    app_only: str = "app_only"
+
+
+@dataclass(frozen=True)
+class _ApiMetricNames:
+    outbound_calls: str = "microsoft.teams.outbound.calls"
+    outbound_errors: str = "microsoft.teams.outbound.errors"
+
+
+@dataclass(frozen=True)
+class _ApiOutboundOperations:
+    create: str = "create"
+    create_targeted: str = "create_targeted"
+    delete: str = "delete"
+    delete_targeted: str = "delete_targeted"
+    reply: str = "reply"
+    update: str = "update"
+    update_targeted: str = "update_targeted"
+
+
+@dataclass(frozen=True)
+class _ApiSpanNames:
+    api_client: str = "microsoft.teams.api.client"
+    auth_outbound: str = "microsoft.teams.auth.outbound"
+
+
+API_ATTRIBUTE_NAMES = _ApiAttributeNames()
+API_AUTH_FLOWS = _ApiAuthFlows()
+API_METRIC_NAMES = _ApiMetricNames()
+API_OUTBOUND_OPERATIONS = _ApiOutboundOperations()
+API_SPAN_NAMES = _ApiSpanNames()

--- a/packages/api/src/microsoft_teams/api/diagnostics/_helpers.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_helpers.py
@@ -1,0 +1,46 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from opentelemetry import metrics, trace
+from opentelemetry.metrics import Counter, Meter
+from opentelemetry.trace import Span, Status, StatusCode, Tracer
+
+from ._constants import API_ATTRIBUTE_NAMES, API_METRIC_NAMES
+from ._telemetry import TeamsApiTelemetry
+
+
+def get_tracer() -> Tracer:
+    return trace.get_tracer(
+        TeamsApiTelemetry.tracer_name,
+        instrumenting_library_version=TeamsApiTelemetry.instrumentation_version,
+    )
+
+
+def get_meter() -> Meter:
+    return metrics.get_meter(
+        TeamsApiTelemetry.meter_name,
+        version=TeamsApiTelemetry.instrumentation_version,
+    )
+
+
+def get_outbound_calls_counter() -> Counter:
+    return get_meter().create_counter(API_METRIC_NAMES.outbound_calls)
+
+
+def get_outbound_errors_counter() -> Counter:
+    return get_meter().create_counter(API_METRIC_NAMES.outbound_errors)
+
+
+def record_outbound_call(operation: str) -> None:
+    get_outbound_calls_counter().add(1, {API_ATTRIBUTE_NAMES.operation: operation})
+
+
+def record_outbound_error(operation: str) -> None:
+    get_outbound_errors_counter().add(1, {API_ATTRIBUTE_NAMES.operation: operation})
+
+
+def record_exception(span: Span, exception: BaseException) -> None:
+    span.record_exception(exception)
+    span.set_status(Status(StatusCode.ERROR, str(exception)))

--- a/packages/api/src/microsoft_teams/api/diagnostics/_outbound.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_outbound.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import inspect
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 
@@ -16,6 +17,7 @@ from ._constants import API_SPAN_NAMES
 from ._helpers import get_tracer, record_exception, record_outbound_call, record_outbound_error
 
 ApiOutboundResponseHook = Callable[[Span, httpx.Response], None | Awaitable[None]]
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -51,9 +53,12 @@ class ApiOutboundTelemetryMiddleware:
                 raise
 
             if metadata.on_response is not None:
-                hook_result = metadata.on_response(span, response)
-                if inspect.isawaitable(hook_result):
-                    await hook_result
+                try:
+                    hook_result = metadata.on_response(span, response)
+                    if inspect.isawaitable(hook_result):
+                        await hook_result
+                except Exception as exception:
+                    logger.warning("API outbound telemetry response hook failed", exc_info=exception)
             return response
 
 

--- a/packages/api/src/microsoft_teams/api/diagnostics/_outbound.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_outbound.py
@@ -1,0 +1,62 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+
+import httpx
+from microsoft_teams.common import Client
+from microsoft_teams.common.http import MiddlewareContext, MiddlewareNext
+from opentelemetry.trace import Span, SpanKind
+
+from ._constants import API_SPAN_NAMES
+from ._helpers import get_tracer, record_exception, record_outbound_call, record_outbound_error
+
+ApiOutboundResponseHook = Callable[[Span, httpx.Response], None | Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ApiOutboundTelemetryMetadata:
+    operation: str
+    attributes: Mapping[str, str] = field(default_factory=dict[str, str])
+    on_response: ApiOutboundResponseHook | None = None
+
+
+class ApiOutboundTelemetryMiddleware:
+    async def send(
+        self,
+        context: MiddlewareContext,
+        next: MiddlewareNext,
+    ) -> httpx.Response:
+        metadata = context.metadata
+        if not isinstance(metadata, ApiOutboundTelemetryMetadata):
+            return await next()
+
+        record_outbound_call(metadata.operation)
+        with get_tracer().start_as_current_span(
+            API_SPAN_NAMES.api_client,
+            attributes=dict(metadata.attributes),
+            kind=SpanKind.CLIENT,
+            record_exception=False,
+            set_status_on_exception=False,
+        ) as span:
+            try:
+                response = await next()
+            except Exception as exception:
+                record_exception(span, exception)
+                record_outbound_error(metadata.operation)
+                raise
+
+            if metadata.on_response is not None:
+                hook_result = metadata.on_response(span, response)
+                if inspect.isawaitable(hook_result):
+                    await hook_result
+            return response
+
+
+def ensure_outbound_telemetry_middleware(client: Client) -> None:
+    if not any(isinstance(middleware, ApiOutboundTelemetryMiddleware) for middleware in client.middlewares):
+        client.use(ApiOutboundTelemetryMiddleware())

--- a/packages/api/src/microsoft_teams/api/diagnostics/_telemetry.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_telemetry.py
@@ -1,0 +1,18 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import importlib.metadata
+
+TEAMS_API_TRACER_NAME = "Microsoft.Teams.Api"
+TEAMS_API_METER_NAME = "Microsoft.Teams.Api"
+TEAMS_API_INSTRUMENTATION_VERSION = importlib.metadata.version("microsoft-teams-api")
+
+
+class TeamsApiTelemetry:
+    """OpenTelemetry source names for the Teams API package."""
+
+    tracer_name = TEAMS_API_TRACER_NAME
+    meter_name = TEAMS_API_METER_NAME
+    instrumentation_version = TEAMS_API_INSTRUMENTATION_VERSION

--- a/packages/api/src/microsoft_teams/api/models/account.py
+++ b/packages/api/src/microsoft_teams/api/models/account.py
@@ -46,6 +46,14 @@ class Account(CustomBaseModel):
     """
     The name of the account.
     """
+    email: Optional[str] = None
+    """
+    Email address for the account, when provided by the channel.
+    """
+    user_role: Optional[str] = None
+    """
+    Role description for the account, when provided by the channel.
+    """
     role: Optional[AccountRole | str] = None
     """The role of the account in the activity."""
     agentic_user_id: Optional[str] = None

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -2,14 +2,42 @@
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
+# pyright: basic
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import patch
 
 import httpx
 import pytest
 from microsoft_teams.api.auth.cloud_environment import US_GOV
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.base_client import BaseClient
+from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMiddleware
 from microsoft_teams.api.models import AgenticIdentity
 from microsoft_teams.common import Client, ClientOptions, Token
+from opentelemetry.trace import SpanKind
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any]):
+        self.name = name
+        self.options = options
+        self.attributes: dict[str, str] = {}
+
+    def set_attribute(self, key: str, value: str) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+        span = RecordingSpan(name, kwargs)
+        self.spans.append(span)
+        yield span
 
 
 class RequestRecorder:
@@ -38,6 +66,21 @@ class RecordingAuthProvider:
     ) -> str | None:
         self.calls.append((scope, agentic_identity))
         return self._token_value
+
+
+class RaisingAuthProvider(RecordingAuthProvider):
+    def __init__(self):
+        super().__init__()
+        self.exception = RuntimeError("token failure")
+
+    def token(
+        self,
+        *,
+        scope: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ):
+        self.calls.append((scope, agentic_identity))
+        raise self.exception
 
 
 class HarnessClient(BaseClient):
@@ -88,6 +131,17 @@ def test_api_client_uses_http_token_for_auth_provider_without_mutating_source_cl
     assert api_client.http.interceptors == http_client.interceptors
 
 
+def test_api_client_registers_outbound_telemetry_middleware_once_across_clones():
+    api_client = ApiClient("https://test.service.url")
+
+    scoped = api_client.from_service_url("https://override.service.url")
+
+    assert (
+        sum(isinstance(middleware, ApiOutboundTelemetryMiddleware) for middleware in api_client.http.middlewares) == 1
+    )
+    assert sum(isinstance(middleware, ApiOutboundTelemetryMiddleware) for middleware in scoped.http.middlewares) == 1
+
+
 def test_api_client_uses_cloud_token_service_url_for_default_settings():
     client = ApiClient("https://test.service.url", cloud=US_GOV)
 
@@ -135,6 +189,52 @@ async def test_auth_provider_token_is_used_when_request_has_no_auth():
 
     assert auth_provider.calls == [(None, None)]
     assert recorder.last_request.headers["authorization"] == "Bearer auth-provider-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agentic_identity", "expected_flow"),
+    [
+        (None, "app_only"),
+        (AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id"), "agentic"),
+    ],
+)
+async def test_auth_provider_token_records_auth_outbound_span(agentic_identity, expected_flow):
+    auth_provider = RecordingAuthProvider()
+    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_identity=agentic_identity)
+    tracer = RecordingTracer()
+
+    with patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer):
+        await client.post_resource()
+
+    assert "authorization" in recorder.last_request.headers
+    assert len(tracer.spans) == 1
+    span = tracer.spans[0]
+    assert span.name == "microsoft.teams.auth.outbound"
+    assert span.options == {
+        "kind": SpanKind.CLIENT,
+        "record_exception": False,
+        "set_status_on_exception": False,
+    }
+    assert span.attributes == {"auth.flow": expected_flow}
+
+
+@pytest.mark.asyncio
+async def test_auth_provider_token_records_exception_before_reraising():
+    auth_provider = RaisingAuthProvider()
+    client, _ = create_auth_provider_harness(auth_provider)
+    tracer = RecordingTracer()
+
+    with (
+        patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer),
+        patch("microsoft_teams.api.clients.api_client.record_exception") as record_exception,
+        pytest.raises(RuntimeError, match="token failure"),
+    ):
+        await client.post_resource()
+
+    assert auth_provider.calls == [(None, None)]
+    assert tracer.spans[0].attributes == {"auth.flow": "app_only"}
+    record_exception.assert_called_once_with(tracer.spans[0], auth_provider.exception)
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -5,7 +5,9 @@ Licensed under the MIT License.
 # pyright: basic
 
 import json
-from unittest.mock import AsyncMock, patch
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import AsyncMock, call, patch
 
 import httpx
 import pytest
@@ -13,8 +15,32 @@ from microsoft_teams.api.auth.cloud_environment import PUBLIC, with_overrides
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.conversation import ConversationClient
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
+from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMetadata
 from microsoft_teams.api.models import AgenticIdentity, ConversationResource, PagedMembersResult, TeamsChannelAccount
 from microsoft_teams.common.http import Client, ClientOptions
+from opentelemetry.trace import Span, SpanKind
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any], attributes: dict[str, str]):
+        self.name = name
+        self.options = options
+        self.attributes = attributes
+
+    def set_attribute(self, key: str, value: str) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+        attributes = kwargs.pop("attributes", {})
+        span = RecordingSpan(name, kwargs, attributes)
+        self.spans.append(span)
+        yield span
 
 
 @pytest.mark.unit
@@ -338,6 +364,171 @@ class TestConversationActivityOperations:
         last_request = request_capture._capture.last_request
         assert last_request.headers["authorization"] == "Bearer override-token"
 
+    async def test_flattened_activity_create_accepts_service_url_and_agentic_identity_kwargs(
+        self, request_capture, mock_activity
+    ):
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "override-token"
+
+        identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        client = ApiClient(
+            "https://default.service.url",
+            request_capture,
+            auth_provider=TestAuthProvider(),
+        ).conversations
+
+        await client.create_activity(
+            "test_conversation_id",
+            mock_activity,
+            service_url="https://override.service.url/",
+            agentic_identity=identity,
+        )
+
+        assert calls == [(None, identity)]
+        last_request = request_capture._capture.last_request
+        assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+        assert "authorization" in last_request.headers
+
+    async def test_direct_activities_client_methods_accept_service_url_and_agentic_identity_kwargs(
+        self, request_capture, mock_activity
+    ):
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "override-token"
+
+        identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        activities_client = ApiClient(
+            "https://default.service.url",
+            request_capture,
+            auth_provider=TestAuthProvider(),
+        ).conversations.activities_client
+        service_url = "https://override.service.url/"
+
+        await activities_client.create(
+            "test_conversation_id",
+            mock_activity,
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.update(
+            "test_conversation_id",
+            "activity-id",
+            mock_activity,
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.reply(
+            "test_conversation_id",
+            "activity-id",
+            mock_activity,
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.delete(
+            "test_conversation_id",
+            "activity-id",
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+
+        await activities_client.get_members(
+            "test_conversation_id",
+            "activity-id",
+            service_url=service_url,
+            agentic_identity=identity,
+        )
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id/members"
+        )
+        assert "authorization" in request_capture._capture.last_request.headers
+        assert calls == [(None, identity)] * 5
+
+    async def test_grouped_activity_methods_accept_service_url_kwarg(self, request_capture, mock_activity):
+        client = ConversationClient("https://default.service.url", request_capture)
+        activities = client.activities("test_conversation_id")
+        service_url = "https://override.service.url/"
+
+        await activities.create(mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+        )
+
+        await activities.update("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+
+        await activities.reply("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+
+        await activities.delete("activity-id", service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+        )
+
+        await activities.get_members("activity-id", service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id/members"
+        )
+
+        await activities.create_targeted(mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities?isTargetedActivity=true"
+        )
+
+        await activities.update_targeted("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+            "?isTargetedActivity=true"
+        )
+
+        await activities.delete_targeted("activity-id", service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+            "?isTargetedActivity=true"
+        )
+
     async def test_activity_create_agentic_identity_without_auth_provider_uses_http_client_auth(
         self, request_capture, mock_activity
     ):
@@ -349,6 +540,233 @@ class TestConversationActivityOperations:
 
         last_request = request_capture._capture.last_request
         assert "authorization" not in last_request.headers
+
+    async def test_activity_create_records_diagnostics(self, request_capture, mock_activity):
+        tracer = RecordingTracer()
+        client = ConversationClient("https://test.service.url/", request_capture)
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+        ):
+            result = await client.create_activity("conv-1", mock_activity)
+
+        assert result.id == "mock_conversation_id"
+        record_outbound_call.assert_called_once_with("create")
+        record_outbound_error.assert_not_called()
+        assert len(tracer.spans) == 1
+        span = tracer.spans[0]
+        assert span.name == "microsoft.teams.api.client"
+        assert span.options == {
+            "kind": SpanKind.CLIENT,
+            "record_exception": False,
+            "set_status_on_exception": False,
+        }
+        assert span.attributes == {
+            "operation": "create",
+            "service.url": "https://test.service.url",
+            "conversation.id": "conv-1",
+            "activity.type": "message",
+            "activity.id": "mock_conversation_id",
+        }
+
+    async def test_request_without_metadata_does_not_record_api_client_telemetry(self, request_capture):
+        tracer = RecordingTracer()
+        api_client = ApiClient("https://test.service.url", request_capture)
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+        ):
+            await api_client.http.post("https://test.service.url/v3/conversations", json={"ok": True})
+
+        assert tracer.spans == []
+        record_outbound_call.assert_not_called()
+        record_outbound_error.assert_not_called()
+
+    async def test_api_client_middleware_uses_supplied_attributes_without_deriving_semantics(self, request_capture):
+        tracer = RecordingTracer()
+        api_client = ApiClient("https://test.service.url", request_capture)
+        attributes = {
+            "operation": "create",
+            "custom.attribute": "custom-value",
+        }
+
+        with patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer):
+            await api_client.http.post(
+                "https://test.service.url/v3/conversations/conv-1/activities",
+                json={"ok": True},
+                _metadata=ApiOutboundTelemetryMetadata(operation="create", attributes=attributes),
+            )
+
+        assert len(tracer.spans) == 1
+        assert tracer.spans[0].attributes == attributes
+
+    async def test_api_client_middleware_invokes_response_hook(self):
+        tracer = RecordingTracer()
+        hook_responses: list[httpx.Response] = []
+        http_client = Client(ClientOptions(base_url="https://test.service.url"))
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"id": "response-id"}, headers={"content-type": "application/json"})
+
+        http_client.http._transport = httpx.MockTransport(handler)
+        api_client = ApiClient("https://test.service.url", http_client)
+
+        async def on_response(span: Span, response: httpx.Response) -> None:
+            hook_responses.append(response)
+            span.set_attribute("hook.attribute", str(response.json()["id"]))
+
+        with patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer):
+            await api_client.http.post(
+                "/v3/conversations/conv-1/activities",
+                json={"ok": True},
+                _metadata=ApiOutboundTelemetryMetadata(
+                    operation="create",
+                    attributes={"operation": "create"},
+                    on_response=on_response,
+                ),
+            )
+
+        assert len(hook_responses) == 1
+        assert tracer.spans[0].attributes == {
+            "operation": "create",
+            "hook.attribute": "response-id",
+        }
+
+    async def test_activity_send_paths_set_response_activity_id_from_client_owned_hooks(
+        self, request_capture, mock_activity
+    ):
+        tracer = RecordingTracer()
+        client = ConversationClient("https://test.service.url", request_capture)
+
+        with patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer):
+            await client.create_activity("conv-1", mock_activity)
+            await client.update_activity("conv-1", "act-1", mock_activity)
+            await client.reply_to_activity("conv-1", "act-1", mock_activity)
+            await client.create_targeted_activity("conv-1", mock_activity)
+            await client.update_targeted_activity("conv-1", "act-1", mock_activity)
+
+        assert [span.attributes["activity.id"] for span in tracer.spans] == [
+            "mock_conversation_id",
+            "mock_activity_id",
+            "mock_conversation_id",
+            "mock_conversation_id",
+            "mock_activity_id",
+        ]
+
+    async def test_activity_create_nests_auth_outbound_under_api_outbound_span(self, request_capture, mock_activity):
+        tracer = RecordingTracer()
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "bot-token"
+
+        client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer),
+        ):
+            await client.create_activity("conv-1", mock_activity)
+
+        assert calls == [(None, None)]
+        assert [span.name for span in tracer.spans[:2]] == [
+            "microsoft.teams.api.client",
+            "microsoft.teams.auth.outbound",
+        ]
+
+    async def test_activity_create_auth_failure_records_api_client_error(self, request_capture, mock_activity):
+        tracer = RecordingTracer()
+        error = RuntimeError("token failure")
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                raise error
+
+        client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.diagnostics._outbound.record_exception") as record_outbound_exception,
+            patch("microsoft_teams.api.clients.api_client.record_exception"),
+            pytest.raises(RuntimeError, match="token failure"),
+        ):
+            await client.create_activity("conv-1", mock_activity)
+
+        assert [span.name for span in tracer.spans[:2]] == [
+            "microsoft.teams.api.client",
+            "microsoft.teams.auth.outbound",
+        ]
+        record_outbound_call.assert_called_once_with("create")
+        record_outbound_error.assert_called_once_with("create")
+        record_outbound_exception.assert_called_once_with(tracer.spans[0], error)
+
+    async def test_request_authorization_header_bypasses_auth_provider_with_metadata(self, request_capture):
+        calls = []
+
+        class TestAuthProvider:
+            def token(self, *, scope=None, agentic_identity=None):
+                calls.append((scope, agentic_identity))
+                return "bot-token"
+
+        api_client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider())
+
+        await api_client.http.post(
+            "https://test.service.url/v3/conversations",
+            headers={"Authorization": "******"},
+            json={"ok": True},
+            _metadata=ApiOutboundTelemetryMetadata(operation="create"),
+        )
+
+        assert calls == []
+        request = request_capture._capture.last_request
+        assert request.headers["authorization"] == "******"
+
+    async def test_activity_create_records_diagnostics_on_error(self, mock_http_client, mock_activity):
+        tracer = RecordingTracer()
+        error = RuntimeError("send failed")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise error
+
+        http_client = Client(ClientOptions(base_url="https://mock.api.com"))
+        http_client.http._transport = httpx.MockTransport(handler)
+        client = ConversationClient("https://test.service.url", http_client)
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.diagnostics._outbound.record_exception") as record_exception,
+            pytest.raises(RuntimeError, match="send failed"),
+        ):
+            await client.create_activity("conv-1", mock_activity)
+
+        record_outbound_call.assert_called_once_with("create")
+        record_outbound_error.assert_called_once_with("create")
+        record_exception.assert_called_once_with(tracer.spans[0], error)
+
+    async def test_targeted_activity_operations_record_diagnostics_operations(self, mock_http_client, mock_activity):
+        client = ConversationClient("https://test.service.url", mock_http_client)
+
+        with patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call:
+            await client.create_targeted_activity("conv-1", mock_activity)
+            await client.update_targeted_activity("conv-1", "act-1", mock_activity)
+            await client.delete_targeted_activity("conv-1", "act-1")
+
+        assert record_outbound_call.call_args_list == [
+            call("create_targeted"),
+            call("update_targeted"),
+            call("delete_targeted"),
+        ]
 
     async def test_activity_update(self, request_capture, mock_activity):
         """Test updating an activity."""

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -26,6 +26,7 @@ class RecordingSpan:
         self.name = name
         self.options = options
         self.attributes = attributes
+        self.ended_count = 0
 
     def set_attribute(self, key: str, value: str) -> None:
         self.attributes[key] = value
@@ -40,7 +41,10 @@ class RecordingTracer:
         attributes = kwargs.pop("attributes", {})
         span = RecordingSpan(name, kwargs, attributes)
         self.spans.append(span)
-        yield span
+        try:
+            yield span
+        finally:
+            span.ended_count += 1
 
 
 @pytest.mark.unit
@@ -635,6 +639,45 @@ class TestConversationActivityOperations:
             "operation": "create",
             "hook.attribute": "response-id",
         }
+        assert tracer.spans[0].ended_count == 1
+
+    async def test_api_client_middleware_swallows_response_hook_failure(self):
+        tracer = RecordingTracer()
+        http_client = Client(ClientOptions(base_url="https://test.service.url"))
+        response = httpx.Response(200, json={"id": "response-id"}, headers={"content-type": "application/json"})
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return response
+
+        http_client.http._transport = httpx.MockTransport(handler)
+        api_client = ApiClient("https://test.service.url", http_client)
+
+        async def on_response(span: Span, response: httpx.Response) -> None:
+            raise RuntimeError("hook failed")
+
+        with (
+            patch("microsoft_teams.api.diagnostics._outbound.get_tracer", return_value=tracer),
+            patch("microsoft_teams.api.diagnostics._outbound.record_exception") as record_exception,
+            patch("microsoft_teams.api.diagnostics._outbound.record_outbound_error") as record_outbound_error,
+            patch("microsoft_teams.api.diagnostics._outbound.logger.warning") as warning,
+        ):
+            result = await api_client.http.post(
+                "/v3/conversations/conv-1/activities",
+                json={"ok": True},
+                _metadata=ApiOutboundTelemetryMetadata(
+                    operation="create",
+                    attributes={"operation": "create"},
+                    on_response=on_response,
+                ),
+            )
+
+        assert result is response
+        assert len(tracer.spans) == 1
+        assert tracer.spans[0].attributes == {"operation": "create"}
+        assert tracer.spans[0].ended_count == 1
+        record_exception.assert_not_called()
+        record_outbound_error.assert_not_called()
+        warning.assert_called_once()
 
     async def test_activity_send_paths_set_response_activity_id_from_client_owned_hooks(
         self, request_capture, mock_activity

--- a/packages/api/tests/unit/test_diagnostics.py
+++ b/packages/api/tests/unit/test_diagnostics.py
@@ -1,0 +1,103 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+# pyright: basic
+
+import importlib.metadata
+from unittest.mock import MagicMock, patch
+
+import microsoft_teams.api as api
+from microsoft_teams.api import TEAMS_API_METER_NAME, TEAMS_API_TRACER_NAME, TeamsApiTelemetry
+from microsoft_teams.api.diagnostics._helpers import (
+    get_meter,
+    get_tracer,
+    record_exception,
+    record_outbound_call,
+    record_outbound_error,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.trace import StatusCode
+
+
+def test_public_telemetry_names_are_exported():
+    assert TEAMS_API_TRACER_NAME == "Microsoft.Teams.Api"
+    assert TEAMS_API_METER_NAME == "Microsoft.Teams.Api"
+    assert TeamsApiTelemetry.tracer_name == "Microsoft.Teams.Api"
+    assert TeamsApiTelemetry.meter_name == "Microsoft.Teams.Api"
+    assert TeamsApiTelemetry.instrumentation_version == importlib.metadata.version("microsoft-teams-api")
+    assert "TEAMS_API_TRACER_NAME" in api.__all__
+    assert "TEAMS_API_METER_NAME" in api.__all__
+    assert "TeamsApiTelemetry" in api.__all__
+
+
+def test_runtime_instrumentation_names_stay_internal():
+    private_groups = [
+        "API_ATTRIBUTE_NAMES",
+        "API_AUTH_FLOWS",
+        "API_METRIC_NAMES",
+        "API_OUTBOUND_OPERATIONS",
+        "API_SPAN_NAMES",
+    ]
+    for group in private_groups:
+        assert group not in api.__all__
+        assert not hasattr(api, group)
+
+
+def test_helpers_use_canonical_source_names():
+    with patch("microsoft_teams.api.diagnostics._helpers.trace.get_tracer") as mock_get_tracer:
+        tracer = get_tracer()
+
+    mock_get_tracer.assert_called_once_with(
+        "Microsoft.Teams.Api",
+        instrumenting_library_version=TeamsApiTelemetry.instrumentation_version,
+    )
+    assert tracer is mock_get_tracer.return_value
+
+    with patch("microsoft_teams.api.diagnostics._helpers.metrics.get_meter") as mock_get_meter:
+        meter = get_meter()
+
+    mock_get_meter.assert_called_once_with(
+        "Microsoft.Teams.Api",
+        version=TeamsApiTelemetry.instrumentation_version,
+    )
+    assert meter is mock_get_meter.return_value
+
+
+def test_outbound_metrics_are_recorded_with_operation_attribute():
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    meter = meter_provider.get_meter("Microsoft.Teams.Api")
+
+    with patch("microsoft_teams.api.diagnostics._helpers.get_meter", return_value=meter):
+        record_outbound_call("create")
+        record_outbound_error("create")
+
+    metrics = {}
+    metrics_data = metric_reader.get_metrics_data()
+    assert metrics_data is not None
+    for resource_metric in metrics_data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                metrics[metric.name] = metric
+
+    calls_point = metrics["microsoft.teams.outbound.calls"].data.data_points[0]
+    errors_point = metrics["microsoft.teams.outbound.errors"].data.data_points[0]
+    assert calls_point.value == 1
+    assert calls_point.attributes == {"operation": "create"}
+    assert errors_point.value == 1
+    assert errors_point.attributes == {"operation": "create"}
+    meter_provider.shutdown()
+
+
+def test_record_exception_marks_span_error():
+    span = MagicMock()
+    exception = RuntimeError("boom")
+
+    record_exception(span, exception)
+
+    span.record_exception.assert_called_once_with(exception)
+    status = span.set_status.call_args.args[0]
+    assert status.status_code == StatusCode.ERROR
+    assert status.description == "boom"

--- a/packages/common/src/microsoft_teams/common/http/__init__.py
+++ b/packages/common/src/microsoft_teams/common/http/__init__.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from .client import Client, ClientOptions
+from .client import Client, ClientOptions, Middleware, MiddlewareContext, MiddlewareNext, MiddlewareResult
 from .client_token import Token, TokenFactory, resolve_token
 from .interceptor import Interceptor, InterceptorRequestContext, InterceptorResponseContext
 
@@ -13,6 +13,10 @@ __all__ = [
     "Interceptor",
     "InterceptorRequestContext",
     "InterceptorResponseContext",
+    "Middleware",
+    "MiddlewareContext",
+    "MiddlewareNext",
+    "MiddlewareResult",
     "Token",
     "TokenFactory",
     "resolve_token",

--- a/packages/common/src/microsoft_teams/common/http/client.py
+++ b/packages/common/src/microsoft_teams/common/http/client.py
@@ -7,7 +7,7 @@ import inspect
 import json
 import logging
 from dataclasses import dataclass, field, replace
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol
 
 import httpx
 from httpx._models import Request, Response
@@ -92,6 +92,43 @@ class ClientOptions:
     interceptors: Optional[List[Interceptor]] = None
 
 
+@dataclass
+class MiddlewareContext:
+    """Context passed to HTTP middleware around terminal dispatch."""
+
+    method: str
+    url: str
+    headers: Dict[str, str]
+    token: Optional[Token]
+    params: Optional[QueryParamTypes] = None
+    content: Optional[RequestContent] = None
+    data: Optional[RequestData] = None
+    files: Optional[RequestFiles] = None
+    json: object | None = None
+    kwargs: Dict[str, Any] = field(default_factory=dict[str, Any])
+    logger: logging.Logger = logger
+    metadata: object | None = None
+
+
+MiddlewareNext = Callable[[], Awaitable[httpx.Response]]
+MiddlewareResult = httpx.Response | Awaitable[httpx.Response]
+
+
+class Middleware(Protocol):
+    """Protocol for HTTP middleware.
+
+    Middleware wraps the full terminal dispatch, including token resolution,
+    existing interceptor/event-hook execution, response status handling, and
+    response JSON wrapping.
+    """
+
+    def send(
+        self,
+        context: MiddlewareContext,
+        next: MiddlewareNext,
+    ) -> MiddlewareResult: ...
+
+
 class Client:
     """
     HTTP Client abstraction for making requests with configurable options.
@@ -117,6 +154,7 @@ class Client:
 
         # Maintain interceptors as a separate instance attribute (do not mutate options)
         self._interceptors = list(options.interceptors or [])
+        self._middlewares: list[Middleware] = []
 
         self.http = _http or httpx.AsyncClient(
             base_url=httpx.URL(options.base_url) if options.base_url else "",
@@ -129,6 +167,11 @@ class Client:
     def interceptors(self) -> tuple[Interceptor, ...]:
         """Get the registered interceptors."""
         return tuple(self._interceptors)
+
+    @property
+    def middlewares(self) -> tuple[Middleware, ...]:
+        """Get the registered middleware."""
+        return tuple(self._middlewares)
 
     @property
     def token(self) -> Optional[Token]:
@@ -153,7 +196,7 @@ class Client:
             Final headers dict for the request.
         """
         req_headers = {**self._options.headers, **(headers or {})}
-        if headers and any(key.lower() == "authorization" for key in headers):
+        if any(key.lower() == "authorization" for key in req_headers):
             return req_headers
         resolved_token = await self._resolve_token(token)
         if resolved_token:
@@ -182,11 +225,7 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.get(url, headers=req_headers, params=params, **kwargs)
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
+        return await self._send("GET", url, headers=headers, token=token, params=params, **kwargs)
 
     async def post(
         self,
@@ -218,20 +257,18 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.post(
+        return await self._send(
+            "POST",
             url,
             data=data,
             files=files,
             json=json,
             content=content,
             params=params,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
 
     async def put(
         self,
@@ -263,20 +300,18 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.put(
+        return await self._send(
+            "PUT",
             url,
             data=data,
             files=files,
             json=json,
             content=content,
             params=params,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
 
     async def patch(
         self,
@@ -308,20 +343,18 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.patch(
+        return await self._send(
+            "PATCH",
             url,
             data=data,
             files=files,
             json=json,
             content=content,
             params=params,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
 
     async def delete(
         self,
@@ -345,11 +378,7 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.delete(url, headers=req_headers, params=params, **kwargs)
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
+        return await self._send("DELETE", url, headers=headers, token=token, params=params, **kwargs)
 
     async def request(
         self,
@@ -383,11 +412,11 @@ class Client:
         Returns:
             httpx.Response
         """
-        req_headers = await self._prepare_headers(headers, token)
-        response = await self.http.request(
+        return await self._send(
             method,
             url,
-            headers=req_headers,
+            headers=headers,
+            token=token,
             params=params,
             content=content,
             data=data,
@@ -395,9 +424,73 @@ class Client:
             json=json,
             **kwargs,
         )
-        response.raise_for_status()
-        _wrap_response_json(response)
-        return response
+
+    async def _send(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[QueryParamTypes] = None,
+        headers: Optional[Dict[str, str]] = None,
+        token: Optional[Token] = None,
+        content: Optional[RequestContent] = None,
+        data: Optional[RequestData] = None,
+        files: Optional[RequestFiles] = None,
+        json: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        metadata = kwargs.pop("_metadata", None)
+        context = MiddlewareContext(
+            method=method.upper(),
+            url=url,
+            headers=dict(headers or {}),
+            token=token,
+            params=params,
+            content=content,
+            data=data,
+            files=files,
+            json=json,
+            kwargs=kwargs,
+            logger=logger,
+            metadata=metadata,
+        )
+
+        async def send() -> httpx.Response:
+            req_headers = await self._prepare_headers(context.headers, context.token)
+            response = await self.http.request(
+                context.method,
+                context.url,
+                headers=req_headers,
+                params=context.params,
+                content=context.content,
+                data=context.data,
+                files=context.files,
+                json=context.json,
+                **context.kwargs,
+            )
+            response.raise_for_status()
+            _wrap_response_json(response)
+            return response
+
+        sender: MiddlewareNext = send
+        for middleware in reversed(self._middlewares):
+            sender = self._wrap_request_middleware(middleware, context, sender)
+
+        return await sender()
+
+    def _wrap_request_middleware(
+        self,
+        middleware: Middleware,
+        context: MiddlewareContext,
+        next_sender: MiddlewareNext,
+    ) -> MiddlewareNext:
+        async def sender() -> httpx.Response:
+            result = middleware.send(context, next_sender)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        return sender
 
     async def _resolve_token(self, token: Optional[Token]) -> Optional[str]:
         """
@@ -423,6 +516,15 @@ class Client:
         """
         self._interceptors.append(interceptor)
         self._update_event_hooks()
+
+    def use(self, middleware: Middleware) -> None:
+        """
+        Register middleware for terminal request dispatch.
+
+        Middleware runs in insertion order, with the first registered
+        middleware as the outermost wrapper.
+        """
+        self._middlewares.append(middleware)
 
     def _update_event_hooks(self) -> None:
         """
@@ -476,4 +578,6 @@ class Client:
             if overrides.interceptors is not None
             else list(self._interceptors),
         )
-        return Client(merged_options, _http=self.http if share_http else None)
+        cloned = Client(merged_options, _http=self.http if share_http else None)
+        cloned._middlewares = list(self._middlewares)
+        return cloned

--- a/packages/common/tests/test_client.py
+++ b/packages/common/tests/test_client.py
@@ -2,10 +2,19 @@
 Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
+# pyright: basic
 
 import httpx
 import pytest
-from microsoft_teams.common.http import Client, ClientOptions, Interceptor
+from microsoft_teams.common.http import (
+    Client,
+    ClientOptions,
+    Interceptor,
+    InterceptorRequestContext,
+    InterceptorResponseContext,
+    MiddlewareContext,
+    MiddlewareNext,
+)
 from microsoft_teams.common.http.client_token import StringLike
 
 
@@ -31,6 +40,18 @@ class DummySyncInterceptor:
 
     def response(self, ctx):
         self.response_called = True
+
+
+class RecordingMiddleware:
+    def __init__(self, name: str, events: list[str]) -> None:
+        self.name = name
+        self.events = events
+
+    async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+        self.events.append(f"{self.name}:before:{context.method}")
+        response = await next()
+        self.events.append(f"{self.name}:after:{response.status_code}")
+        return response
 
 
 class CustomStringLike(StringLike):
@@ -126,6 +147,14 @@ def test_interceptors_returns_read_only_copy():
     assert client.interceptors == (interceptor1,)
 
 
+def test_middlewares_returns_read_only_copy():
+    middleware = RecordingMiddleware("middleware", [])
+    client = Client()
+    client.use(middleware)
+
+    assert client.middlewares == (middleware,)
+
+
 def test_clone_copies_interceptor_list_independently():
     interceptor1 = DummyAsyncInterceptor()
     client = Client(ClientOptions(interceptors=[interceptor1]))
@@ -139,6 +168,31 @@ def test_clone_copies_interceptor_list_independently():
     assert client.interceptors is not clone.interceptors
 
 
+def test_clone_copies_middleware_list_independently():
+    middleware1 = RecordingMiddleware("one", [])
+    client = Client()
+    client.use(middleware1)
+
+    clone = client.clone()
+    middleware2 = RecordingMiddleware("two", [])
+    clone.use(middleware2)
+
+    assert client.middlewares == (middleware1,)
+    assert clone.middlewares == (middleware1, middleware2)
+    assert client.middlewares is not clone.middlewares
+
+
+def test_middlewares_support_deduping_by_inspection():
+    middleware = RecordingMiddleware("one", [])
+    client = Client()
+    client.use(middleware)
+
+    if not any(isinstance(existing, RecordingMiddleware) for existing in client.middlewares):
+        client.use(RecordingMiddleware("duplicate", []))
+
+    assert client.middlewares == (middleware,)
+
+
 def test_clone_reuses_underlying_http_client_when_requested():
     client = Client(ClientOptions(base_url="https://example.com"))
 
@@ -146,6 +200,156 @@ def test_clone_reuses_underlying_http_client_when_requested():
 
     assert clone is not client
     assert clone.http is client.http
+
+
+@pytest.mark.asyncio
+async def test_middleware_runs_in_insertion_order_with_first_outermost():
+    events: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        events.append("terminal")
+        return httpx.Response(200, json={"ok": True}, headers={"content-type": "application/json"})
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(RecordingMiddleware("one", events))
+    client.use(RecordingMiddleware("two", events))
+
+    await client.get("/ordered")
+
+    assert events == [
+        "one:before:GET",
+        "two:before:GET",
+        "terminal",
+        "two:after:200",
+        "one:after:200",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_middleware_can_mutate_headers_and_kwargs():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "header": request.headers["x-middleware"],
+                "extension": request.extensions["middleware"],
+            },
+            headers={"content-type": "application/json"},
+        )
+
+    class MutatingMiddleware:
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            context.headers["X-Middleware"] = "header-value"
+            context.kwargs["extensions"] = {"middleware": "extension-value"}
+            return await next()
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(MutatingMiddleware())
+
+    response = await client.get("/mutated")
+
+    assert response.json() == {"header": "header-value", "extension": "extension-value"}
+
+
+@pytest.mark.asyncio
+async def test_middleware_can_short_circuit_response():
+    class ShortCircuitMiddleware:
+        def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            return httpx.Response(204)
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(lambda request: httpx.Response(500))
+    client.use(ShortCircuitMiddleware())
+
+    response = await client.get("/short-circuit")
+
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_middleware_observes_and_propagates_terminal_errors():
+    events: list[str] = []
+    error = RuntimeError("boom")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise error
+
+    class ErrorRecordingMiddleware:
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            try:
+                return await next()
+            except Exception as exception:
+                events.append(str(exception))
+                raise
+
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(ErrorRecordingMiddleware())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await client.get("/error")
+
+    assert events == ["boom"]
+
+
+@pytest.mark.asyncio
+async def test_middleware_runs_around_existing_interceptors(mock_transport):
+    events: list[str] = []
+
+    class RecordingInterceptor(Interceptor):
+        def request(self, ctx: InterceptorRequestContext) -> None:
+            events.append("interceptor:request")
+
+        def response(self, ctx: InterceptorResponseContext) -> None:
+            events.append("interceptor:response")
+
+    class EventMiddleware:
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            events.append("middleware:before")
+            response = await next()
+            events.append("middleware:after")
+            return response
+
+    client = Client(ClientOptions(base_url="https://example.com", interceptors=[RecordingInterceptor()]))
+    client.http._transport = mock_transport
+    client.use(EventMiddleware())
+
+    await client.get("/with-interceptors")
+
+    assert events == ["middleware:before", "interceptor:request", "interceptor:response", "middleware:after"]
+
+
+@pytest.mark.asyncio
+async def test_request_metadata_is_not_sent_over_wire():
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"ok": True}, headers={"content-type": "application/json"})
+
+    class MetadataMiddleware:
+        def __init__(self) -> None:
+            self.metadata: object | None = None
+
+        async def send(self, context: MiddlewareContext, next: MiddlewareNext) -> httpx.Response:
+            self.metadata = context.metadata
+            return await next()
+
+    metadata = object()
+    middleware = MetadataMiddleware()
+    client = Client(ClientOptions(base_url="https://example.com"))
+    client.http._transport = httpx.MockTransport(handler)
+    client.use(middleware)
+
+    await client.get("/metadata", _metadata=metadata)
+
+    assert middleware.metadata is metadata
+    request = captured[0]
+    assert "_metadata" not in str(request.url)
+    assert "_metadata" not in request.headers
+    assert "_metadata" not in request.extensions
 
 
 def test_clone_uses_current_token_value():
@@ -225,6 +429,23 @@ async def test_explicit_authorization_header_wins_over_default_token(mock_transp
     client.http._transport = mock_transport
 
     resp = await client.get("/token-test", headers={"Authorization": "******"})
+    data = resp.json()
+
+    assert data["headers"]["authorization"] == "******"
+
+
+@pytest.mark.asyncio
+async def test_default_authorization_header_bypasses_token_resolution(mock_transport):
+    client = Client(
+        ClientOptions(
+            base_url="https://example.com",
+            headers={"Authorization": "******"},
+            token=failing_token_factory,
+        )
+    )
+    client.http._transport = mock_transport
+
+    resp = await client.get("/token-test")
     data = resp.json()
 
     assert data["headers"]["authorization"] == "******"

--- a/uv.lock
+++ b/uv.lock
@@ -1794,6 +1794,7 @@ source = { editable = "packages/api" }
 dependencies = [
     { name = "microsoft-teams-cards" },
     { name = "microsoft-teams-common" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
 ]
@@ -1809,6 +1810,7 @@ dev = [
 requires-dist = [
     { name = "microsoft-teams-cards", editable = "packages/cards" },
     { name = "microsoft-teams-common", editable = "packages/common" },
+    { name = "opentelemetry-api", specifier = ">=1.41.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
 ]


### PR DESCRIPTION
Adds the API-side plumbing for Teams SDK OpenTelemetry: common HTTP middleware, outbound API spans, and auth spans.

## Why

This is the foundation layer. It lets us see what the SDK is doing when it calls Teams APIs: which operation ran, which auth flow was used, whether the call failed, and how it lines up under the app’s trace.

Keeping this in the API/common layer also means Apps can stay focused on inbound activity processing instead of knowing HTTP client internals. Nice little separation of concerns, for once.

## Interesting bits

- Adds public common HTTP middleware support.
- Adds `microsoft.teams.api.client` for outbound Teams API calls.
- Adds `microsoft.teams.auth.outbound` from the API auth token callback.
- Uses `Microsoft.Teams.Api` as the instrumentation scope, with the package version attached as the scope version.
- Keeps the outbound middleware mechanics-only: start/end span, record calls/errors, record exceptions, and run the optional response hook.
- Client methods own semantic attributes and response-derived tags, including response `activity.id`.
- Preserves public compatibility for per-call service URL / agentic identity paths, including the direct conversation activity client path.

## Reviewer tips

Start with common HTTP client middleware, then the API outbound middleware, then conversation activity methods. The compatibility bits are worth a close look because they keep old scoping behavior working while routing through the new token callback path.

## Testing

CI is green for this layer. The full stack was also live-smoked against Agent365/ACF and Echo/PokemonCatcher before splitting.
