### PR TITLE
docs: note extendedmarkdown is in public preview

### DIFF
--- a/packages/api/src/microsoft_teams/api/models/text_format.py
+++ b/packages/api/src/microsoft_teams/api/models/text_format.py
@@ -5,4 +5,5 @@ Licensed under the MIT License.
 
 from typing import Literal
 
+# "extendedmarkdown" is in public preview and may be subject to change.
 TextFormat = Literal["markdown", "plain", "xml", "extendedmarkdown"]


### PR DESCRIPTION
## Summary
- add a note on the `TextFormat` literal indicating `extendedmarkdown` is still in public preview