### PR TITLE
Remove activityId from reply POST URL

### DIFF
--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -98,7 +98,7 @@ class ConversationActivityClient(BaseClient):
         activity_json = activity.model_dump(by_alias=True, exclude_none=True)
         activity_json["replyToId"] = activity_id
         response = await self.http.post(
-            f"{self.service_url}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self.service_url}/v3/conversations/{conversation_id}/activities",
             json=activity_json,
         )
         id = response.json()["id"]

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -246,7 +246,7 @@ class TestConversationActivityOperations:
         assert last_request.method == "POST"
         assert (
             str(last_request.url)
-            == f"https://test.service.url/v3/conversations/{conversation_id}/activities/{activity_id}"
+            == f"https://test.service.url/v3/conversations/{conversation_id}/activities"
         )
 
         # Validate request payload - check that replyToId was added

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -244,10 +244,7 @@ class TestConversationActivityOperations:
         # Validate request details
         last_request = request_capture._capture.last_request
         assert last_request.method == "POST"
-        assert (
-            str(last_request.url)
-            == f"https://test.service.url/v3/conversations/{conversation_id}/activities"
-        )
+        assert str(last_request.url) == f"https://test.service.url/v3/conversations/{conversation_id}/activities"
 
         # Validate request payload - check that replyToId was added
         payload = json.loads(last_request.content)
@@ -512,7 +509,7 @@ class TestConversationClientFlattened:
         assert result is not None
         last_request = request_capture._capture.last_request
         assert last_request.method == "POST"
-        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities"
         payload = json.loads(last_request.content)
         assert payload["replyToId"] == "act-1"
 


### PR DESCRIPTION
## What

Changes the connector `reply` POST to target the base activities collection instead of the activity-scoped path:

- Before: `POST /v3/conversations/{conversation_id}/activities/{activity_id}`
- After: `POST /v3/conversations/{conversation_id}/activities`

`replyToId` continues to be set in the request body, so reply semantics are unchanged. The `{activity_id}` in the path was redundant: the service uses `replyToId` (body) for encryption purposes, not routing or threading, and threading is addressed via the `;messageid=` suffix on `conversation_id`.

## Why

The only POST that included `{activity_id}` in the path was `reply`. Removing it aligns the wire shape with the other sends (`create`, `create_targeted`), which already POST to the base `.../activities`. This also matches what the .NET `core` client already does (`ActivityClient.ReplyAsync` posts to base activities with `ReplyToId` in the body).

## Scope

- `packages/api/src/microsoft_teams/api/clients/conversation/activity.py` — `reply()` URL
- Updated unit test: `packages/api/tests/unit/test_conversation_client.py`

Integration tests are behavior-based (assert the returned reply has an id) and need no change; they validate the new URL against the live service.

No observable behavior change for `app.reply` / `ctx.reply` callers.