### PR TITLE
fix(api): tolerate channel member & unknown conversationUpdate event types

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from ...models import Account, ActivityBase, ChannelData, CustomBaseModel
 
@@ -12,6 +12,10 @@ ConversationEventType = Literal[
     "channelDeleted",
     "channelRenamed",
     "channelRestored",
+    "channelShared",
+    "channelUnshared",
+    "channelMemberAdded",
+    "channelMemberRemoved",
     "teamArchived",
     "teamDeleted",
     "teamHardDeleted",
@@ -26,8 +30,13 @@ ConversationEventType = Literal[
 class ConversationChannelData(ChannelData, CustomBaseModel):
     """Extended ChannelData with event type."""
 
-    event_type: Optional[ConversationEventType] = None
-    """The type of event that occurred."""
+    event_type: Optional[Union[ConversationEventType, str]] = None
+    """The type of event that occurred.
+
+    Known values are enumerated by ``ConversationEventType``, but the field
+    accepts any string so that unrecognized or newly introduced event types
+    (e.g. from private/shared channels) do not fail validation.
+    """
 
 
 class _ConversationUpdateBase(CustomBaseModel):

--- a/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional
 
 from ...models import Account, ActivityBase, ChannelData, CustomBaseModel
 
@@ -30,7 +30,7 @@ ConversationEventType = Literal[
 class ConversationChannelData(ChannelData, CustomBaseModel):
     """Extended ChannelData with event type."""
 
-    event_type: Optional[Union[ConversationEventType, str]] = None
+    event_type: Optional[str] = None
     """The type of event that occurred.
 
     Known values are enumerated by ``ConversationEventType``, but the field

--- a/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
+++ b/packages/api/src/microsoft_teams/api/activities/conversation/conversation_update.py
@@ -3,39 +3,43 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from ...models import Account, ActivityBase, ChannelData, CustomBaseModel
 
-ConversationEventType = Literal[
-    "channelCreated",
-    "channelDeleted",
-    "channelRenamed",
-    "channelRestored",
-    "channelShared",
-    "channelUnshared",
-    "channelMemberAdded",
-    "channelMemberRemoved",
-    "teamArchived",
-    "teamDeleted",
-    "teamHardDeleted",
-    "teamRenamed",
-    "teamRestored",
-    "teamUnarchived",
-    "teamMemberRemoved",
-    "teamMemberAdded",
+ConversationEventType = Union[
+    Literal[
+        "channelCreated",
+        "channelDeleted",
+        "channelRenamed",
+        "channelRestored",
+        "channelShared",
+        "channelUnshared",
+        "channelMemberAdded",
+        "channelMemberRemoved",
+        "teamArchived",
+        "teamDeleted",
+        "teamHardDeleted",
+        "teamRenamed",
+        "teamRestored",
+        "teamUnarchived",
+        "teamMemberRemoved",
+        "teamMemberAdded",
+    ],
+    str,
 ]
 
 
 class ConversationChannelData(ChannelData, CustomBaseModel):
     """Extended ChannelData with event type."""
 
-    event_type: Optional[str] = None
+    event_type: Optional[ConversationEventType] = None
     """The type of event that occurred.
 
-    Known values are enumerated by ``ConversationEventType``, but the field
-    accepts any string so that unrecognized or newly introduced event types
-    (e.g. from private/shared channels) do not fail validation.
+    Known values are enumerated by ``ConversationEventType``, which preserves
+    IDE completion for recognized event types while still accepting any string
+    so that unrecognized or newly introduced event types (e.g. from
+    private/shared channels) do not fail validation.
     """
 
 

--- a/packages/api/tests/unit/test_activity.py
+++ b/packages/api/tests/unit/test_activity.py
@@ -160,3 +160,40 @@ class TestActivityTypeAdapter:
 
         assert isinstance(activity, ConversationUpdateActivity)
         assert activity.channel_data is None
+
+    def test_conversation_update_channel_member_added(self) -> None:
+        # Regression test for private/shared channel membership events (issue #520):
+        # Teams emits channelMemberAdded / channelMemberRemoved for private and shared
+        # channels, which previously failed strict Literal validation.
+        payload = {
+            "type": "conversationUpdate",
+            "id": "conv-update-channel-member",
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-456", "conversationType": "channel"},
+            "recipient": {"id": "bot-789", "name": "Test Bot"},
+            "channelData": {"eventType": "channelMemberAdded"},
+        }
+
+        activity = ActivityTypeAdapter.validate_python(payload)
+
+        assert isinstance(activity, ConversationUpdateActivity)
+        assert activity.channel_data is not None
+        assert activity.channel_data.event_type == "channelMemberAdded"
+
+    def test_conversation_update_unknown_event_type(self) -> None:
+        # Unknown / newly introduced event types must not fail validation; the raw
+        # value is preserved so callers can inspect it.
+        payload = {
+            "type": "conversationUpdate",
+            "id": "conv-update-unknown-event",
+            "from": {"id": "user-123", "name": "Test User"},
+            "conversation": {"id": "conv-456", "conversationType": "channel"},
+            "recipient": {"id": "bot-789", "name": "Test Bot"},
+            "channelData": {"eventType": "someFutureEventType"},
+        }
+
+        activity = ActivityTypeAdapter.validate_python(payload)
+
+        assert isinstance(activity, ConversationUpdateActivity)
+        assert activity.channel_data is not None
+        assert activity.channel_data.event_type == "someFutureEventType"


### PR DESCRIPTION
## Summary

Fixes #520.

Adding or removing the app in a **private or shared channel** caused a `ValidationError` on the incoming `conversationUpdate` activity, aborting request processing:

```
conversationUpdate.channelData.eventType
  Input should be 'channelCreated', ... 'teamMemberAdded'
  [type=literal_error, input_value='channelMemberAdded', input_type=str]
```

### Root cause

`ConversationEventType` was a strict Pydantic `Literal` that was missing the channel-scoped membership events. Private and shared channels maintain their own membership roster (separate from the team), so Teams emits `channelMemberAdded` / `channelMemberRemoved` (plus `channelShared` / `channelUnshared`) rather than the team-scoped `teamMemberAdded` / `teamMemberRemoved`. Standard channels were unaffected because they surface `teamMember*`, which were already listed.

### Fix

- Add the missing known values: `channelShared`, `channelUnshared`, `channelMemberAdded`, `channelMemberRemoved`.
- Widen the field to `Optional[Union[ConversationEventType, str]]` so unknown/newly-introduced event types are preserved instead of failing validation. This mirrors the .NET SDK, which models `eventType` as an open `StringEnum` and degrades gracefully.

The known-value list is retained for documentation/DX; the `str` fallback ensures the request pipeline can never 500 on an unrecognized `eventType`.

### Tests

Added unit tests replaying the exact failing payload from the issue (`channelMemberAdded`) and an unknown eventType, asserting both parse and preserve the raw value.

- `pytest packages/api/tests/unit/test_activity.py` — passing
- `ruff check`, `ruff format --check`, `pyright` — clean

### Validation scope

This is an **inbound** activity-parsing fix. Inbound dispatch is covered by unit tests (the integration suite is scoped to outbound API calls against the live service), so no integration tests are added.