### PR TITLE
feat(api/apps): add application/search invoke support

### DIFF
--- a/examples/cards/src/main.py
+++ b/examples/cards/src/main.py
@@ -198,7 +198,7 @@ def create_dynamic_search_card() -> AdaptiveCard:
 
     Instead of static 'choices', the ChoiceSet declares a 'choices.data' Data.Query
     with a 'dataset'. As the user types, Teams sends an 'application/search' invoke,
-    handled by @app.on_search below.
+    handled by @app.on_card_search below.
     """
     return AdaptiveCard.model_validate(
         {
@@ -335,7 +335,7 @@ async def handle_search_card(ctx: ActivityContext[MessageActivity]):
     await ctx.send(card)
 
 
-@app.on_search
+@app.on_card_search
 async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchResponse:
     """Handle the 'application/search' invoke from the dynamic typeahead ChoiceSet."""
     query = (ctx.activity.value.query_text or "").lower()

--- a/examples/cards/src/main.py
+++ b/examples/cards/src/main.py
@@ -7,11 +7,16 @@ import asyncio
 import logging
 from datetime import datetime
 
-from microsoft_teams.api import AdaptiveCardInvokeActivity, MessageActivity, MessageActivityInput
+from microsoft_teams.api import AdaptiveCardInvokeActivity, MessageActivity, MessageActivityInput, SearchInvokeActivity
 from microsoft_teams.api.models.adaptive_card import (
     AdaptiveCardActionMessageResponse,
 )
 from microsoft_teams.api.models.invoke_response import AdaptiveCardInvokeResponse
+from microsoft_teams.api.models.search import (
+    SearchInvokeResponseValue,
+    SearchInvokeResult,
+    SearchResponse,
+)
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.cards import (
     ActionSet,
@@ -188,6 +193,55 @@ def create_feedback_card() -> AdaptiveCard:
     return card
 
 
+def create_dynamic_search_card() -> AdaptiveCard:
+    """Create a card with a dynamic typeahead ChoiceSet.
+
+    Instead of static 'choices', the ChoiceSet declares a 'choices.data' Data.Query
+    with a 'dataset'. As the user types, Teams sends an 'application/search' invoke,
+    handled by @app.on_search below.
+    """
+    return AdaptiveCard.model_validate(
+        {
+            "type": "AdaptiveCard",
+            "version": "1.5",
+            "body": [
+                {
+                    "type": "TextBlock",
+                    "text": "Pick a Nintendo game (type to search):",
+                    "wrap": True,
+                    "style": "heading",
+                },
+                {
+                    "type": "Input.ChoiceSet",
+                    "id": "game",
+                    "label": "Game",
+                    "placeholder": "Search for a game",
+                    "style": "filtered",
+                    "choices": [],
+                    "choices.data": {"type": "Data.Query", "dataset": "nintendoGames"},
+                },
+            ],
+            "actions": [
+                {"type": "Action.Execute", "title": "Submit", "data": {"action": "submit_game"}},
+            ],
+        }
+    )
+
+
+# The full catalog the typeahead searches over. In a real app this would be a
+# database or API call.
+NINTENDO_GAMES = [
+    "The Legend of Zelda: Tears of the Kingdom",
+    "Super Mario Odyssey",
+    "Animal Crossing: New Horizons",
+    "Metroid Dread",
+    "Splatoon 3",
+    "Mario Kart 8 Deluxe",
+    "Super Smash Bros. Ultimate",
+    "Pikmin 4",
+]
+
+
 @app.on_message_pattern("card")
 async def handle_card_message(ctx: ActivityContext[MessageActivity]):
     """Handle card request messages - specific action routing."""
@@ -273,6 +327,23 @@ async def handle_feedback_card(ctx: ActivityContext[MessageActivity]):
     await ctx.send(card)
 
 
+@app.on_message_pattern("search")
+async def handle_search_card(ctx: ActivityContext[MessageActivity]):
+    """Handle dynamic typeahead search card request messages."""
+    logger.info(f"[SEARCH] Dynamic search card requested by: {ctx.activity.from_}")
+    card = create_dynamic_search_card()
+    await ctx.send(card)
+
+
+@app.on_search
+async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchResponse:
+    """Handle the 'application/search' invoke from the dynamic typeahead ChoiceSet."""
+    query = (ctx.activity.value.query_text or "").lower()
+    logger.info(f"[SEARCH] query='{query}'")
+    results = [SearchInvokeResult(title=game, value=game) for game in NINTENDO_GAMES if query in game.lower()]
+    return SearchResponse(value=SearchInvokeResponseValue(results=results))
+
+
 @app.on_card_action_execute
 async def handle_all_execute_actions(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -> AdaptiveCardInvokeResponse:
     """Handle all Action.Execute events without specific action routing (global handler)."""
@@ -351,6 +422,19 @@ async def handle_save_profile(ctx: ActivityContext[AdaptiveCardInvokeActivity]) 
         response_text += f"\nLocation: {location}"
 
     await ctx.send(response_text)
+    return AdaptiveCardActionMessageResponse(
+        status_code=200,
+        type="application/vnd.microsoft.activity.message",
+        value="Action processed successfully",
+    )
+
+
+@app.on_card_action_execute("submit_game")
+async def handle_submit_game(ctx: ActivityContext[AdaptiveCardInvokeActivity]) -> AdaptiveCardInvokeResponse:
+    """Handle the dynamic-search card submission."""
+    data = ctx.activity.value.action.data
+    game = data.get("game", "nothing")
+    await ctx.send(f"You picked: {game}")
     return AdaptiveCardActionMessageResponse(
         status_code=200,
         type="application/vnd.microsoft.activity.message",

--- a/packages/api/src/microsoft_teams/api/activities/invoke/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/invoke/__init__.py
@@ -23,6 +23,7 @@ from .message import (
 )
 from .message_extension import *  # noqa: F403
 from .message_extension import MessageExtensionInvokeActivity
+from .search import SearchInvokeActivity
 from .sign_in import *  # noqa: F403
 from .sign_in import SignInInvokeActivity
 from .suggested_action_submit import SuggestedActionSubmitInvokeActivity
@@ -45,6 +46,7 @@ InvokeActivity = Annotated[
         SignInInvokeActivity,
         AdaptiveCardInvokeActivity,
         SuggestedActionSubmitInvokeActivity,
+        SearchInvokeActivity,
     ],
     Field(discriminator="name"),
 ]
@@ -66,6 +68,7 @@ __all__ = [
     "SignInInvokeActivity",
     "AdaptiveCardInvokeActivity",
     "SuggestedActionSubmitInvokeActivity",
+    "SearchInvokeActivity",
 ]
 
 __all__.extend(config.__all__)

--- a/packages/api/src/microsoft_teams/api/activities/invoke/search.py
+++ b/packages/api/src/microsoft_teams/api/activities/invoke/search.py
@@ -1,0 +1,24 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Literal
+
+from ...models import SearchInvokeValue
+from ..invoke_activity import InvokeActivity
+
+
+class SearchInvokeActivity(InvokeActivity):
+    """
+    Represents an activity that is sent when an Adaptive Card dynamic typeahead
+    'Input.ChoiceSet' (via 'choices.data' / 'Data.Query') requests choices.
+    """
+
+    type: Literal["invoke"] = "invoke"  #
+
+    name: Literal["application/search"] = "application/search"  #
+    """The name of the operation associated with an invoke or event activity."""
+
+    value: SearchInvokeValue
+    """A value that is associated with the activity."""

--- a/packages/api/src/microsoft_teams/api/models/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/__init__.py
@@ -16,6 +16,7 @@ from . import (
     message,
     messaging_extension,
     o365,
+    search,
     sign_in,
     tab,
     task_module,
@@ -49,6 +50,7 @@ from .invoke_response import (
     InvokeResponseBody,
     MessagingExtensionActionInvokeResponse,
     MessagingExtensionInvokeResponse,
+    SearchInvokeResponse,
     TabInvokeResponse,
     TaskModuleInvokeResponse,
     TokenExchangeInvokeResponseType,
@@ -59,6 +61,7 @@ from .meetings import *  # noqa: F403
 from .message import *  # noqa: F403
 from .messaging_extension import *  # noqa: F403
 from .o365 import *  # noqa: F403
+from .search import *  # noqa: F403
 from .sign_in import *  # noqa: F403
 from .suggested_actions import SuggestedActions
 from .tab import *  # noqa: F403
@@ -100,6 +103,7 @@ __all__: list[str] = [
     "TaskModuleInvokeResponse",
     "TabInvokeResponse",
     "AdaptiveCardInvokeResponse",
+    "SearchInvokeResponse",
     "TokenExchangeInvokeResponseType",
     "is_invoke_response",
 ]
@@ -115,6 +119,7 @@ __all__.extend(meetings.__all__)
 __all__.extend(message.__all__)
 __all__.extend(messaging_extension.__all__)
 __all__.extend(o365.__all__)
+__all__.extend(search.__all__)
 __all__.extend(sign_in.__all__)
 __all__.extend(tab.__all__)
 __all__.extend(task_module.__all__)

--- a/packages/api/src/microsoft_teams/api/models/invoke_response.py
+++ b/packages/api/src/microsoft_teams/api/models/invoke_response.py
@@ -10,6 +10,7 @@ from .config.config_response import ConfigResponse
 from .custom_base_model import CustomBaseModel
 from .messaging_extension.messaging_extension_action_response import MessagingExtensionActionResponse
 from .messaging_extension.messaging_extension_response import MessagingExtensionResponse
+from .search.search_response import SearchResponse
 from .tab.tab_response import TabResponse
 from .task_module.task_module_response import TaskModuleResponse
 from .token_exchange.invoke_response import TokenExchangeInvokeResponse
@@ -26,6 +27,7 @@ InvokeResponseBody = Union[
     TaskModuleResponse,  # task/fetch, task/submit
     TabResponse,  # tab/fetch, tab/submit
     AdaptiveCardActionResponse,  # adaptiveCard/action
+    SearchResponse,  # application/search
     TokenExchangeInvokeResponse,  # signin/tokenExchange
 ]  # Type variable for generic invoke response
 
@@ -69,4 +71,5 @@ MessagingExtensionActionInvokeResponse = MessagingExtensionActionResponse
 TaskModuleInvokeResponse = TaskModuleResponse
 TabInvokeResponse = TabResponse
 AdaptiveCardInvokeResponse = AdaptiveCardActionResponse
+SearchInvokeResponse = SearchResponse
 TokenExchangeInvokeResponseType = Union[TokenExchangeInvokeResponse, None]

--- a/packages/api/src/microsoft_teams/api/models/search/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/search/__init__.py
@@ -1,0 +1,16 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .search_response import SearchInvokeResponseValue, SearchInvokeResult, SearchResponse
+from .search_value import SearchInvokeOptions, SearchInvokeType, SearchInvokeValue
+
+__all__ = [
+    "SearchInvokeOptions",
+    "SearchInvokeType",
+    "SearchInvokeValue",
+    "SearchInvokeResponseValue",
+    "SearchInvokeResult",
+    "SearchResponse",
+]

--- a/packages/api/src/microsoft_teams/api/models/search/search_response.py
+++ b/packages/api/src/microsoft_teams/api/models/search/search_response.py
@@ -1,0 +1,46 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import List, Literal
+
+from ..custom_base_model import CustomBaseModel
+
+
+class SearchInvokeResult(CustomBaseModel):
+    """
+    A single result returned in a SearchResponse. For Adaptive Card dynamic typeahead
+    'Input.ChoiceSet', 'title' is the display text and 'value' is the submitted value.
+    """
+
+    title: str
+    "The display text of the result."
+
+    value: str
+    "The value submitted when the result is selected."
+
+
+class SearchInvokeResponseValue(CustomBaseModel):
+    """
+    The value payload of a SearchResponse.
+    """
+
+    results: List[SearchInvokeResult]
+    "The list of search results."
+
+
+class SearchResponse(CustomBaseModel):
+    """
+    Defines the structure returned as the result of an Invoke activity with Name of
+    'application/search'.
+    """
+
+    status_code: int = 200
+    "The response status code."
+
+    type: Literal["application/vnd.microsoft.search.searchResponse"] = "application/vnd.microsoft.search.searchResponse"
+    "The type of this response."
+
+    value: SearchInvokeResponseValue
+    "The response value."

--- a/packages/api/src/microsoft_teams/api/models/search/search_value.py
+++ b/packages/api/src/microsoft_teams/api/models/search/search_value.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Any, Literal, Optional
+
+from ..custom_base_model import CustomBaseModel
+
+SearchInvokeType = Literal["search", "searchAnswer", "typeahead"]
+"""The kind of search invoke value. Must be either search, searchAnswer, or typeahead."""
+
+
+class SearchInvokeOptions(CustomBaseModel):
+    """
+    Defines the query options for an Invoke activity with Name of 'application/search'.
+    """
+
+    skip: Optional[int] = None
+    "The starting reference number from which ordered search results should be returned."
+
+    top: Optional[int] = None
+    "The number of search results that should be returned."
+
+
+class SearchInvokeValue(CustomBaseModel):
+    """
+    Defines the structure that arrives in the Activity.Value for an Invoke activity with
+    Name of 'application/search'. Sent by Adaptive Card dynamic typeahead 'Input.ChoiceSet'
+    inputs (via 'choices.data' / 'Data.Query').
+    """
+
+    kind: Optional[SearchInvokeType] = None
+    """The kind for this search invoke value (search, searchAnswer, or typeahead). Omitted by
+    Adaptive Card dynamic typeahead 'Input.ChoiceSet' inputs, so this may be None."""
+
+    query_text: str
+    "The query text of this search invoke value."
+
+    query_options: Optional[SearchInvokeOptions] = None
+    "The query options for this search invoke."
+
+    context: Optional[Any] = None
+    "Context information about the query, such as the UI control that issued the query."
+
+    dataset: Optional[str] = None
+    "The identifier of the dataset from which to fetch the choices, as authored on the Adaptive Card 'Data.Query'."

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
@@ -531,6 +531,15 @@ ACTIVITY_ROUTES: Dict[str, ActivityConfig] = {
         output_type_name="AdaptiveCardInvokeResponse",
         is_invoke=True,
     ),
+    "search": ActivityConfig(
+        name="search",
+        method_name="on_search",
+        input_model="SearchInvokeActivity",
+        selector=lambda activity: activity.type == "invoke"
+        and cast(InvokeActivity, activity).name == "application/search",
+        output_type_name="SearchInvokeResponse",
+        is_invoke=True,
+    ),
     # Generic invoke handler (fallback for any invoke not matching specific aliases)
     "invoke": ActivityConfig(
         name="invoke",

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
@@ -531,9 +531,9 @@ ACTIVITY_ROUTES: Dict[str, ActivityConfig] = {
         output_type_name="AdaptiveCardInvokeResponse",
         is_invoke=True,
     ),
-    "search": ActivityConfig(
-        name="search",
-        method_name="on_search",
+    "card.search": ActivityConfig(
+        name="card.search",
+        method_name="on_card_search",
         input_model="SearchInvokeActivity",
         selector=lambda activity: activity.type == "invoke"
         and cast(InvokeActivity, activity).name == "application/search",

--- a/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
@@ -47,6 +47,7 @@ from microsoft_teams.api.activities import (
     MessageSubmitActionInvokeActivity,
     MessageUpdateActivity,
     ReadReceiptEventActivity,
+    SearchInvokeActivity,
     SignInFailureInvokeActivity,
     SignInTokenExchangeInvokeActivity,
     SignInVerifyStateInvokeActivity,
@@ -61,6 +62,7 @@ from microsoft_teams.api.models.invoke_response import (
     ConfigInvokeResponse,
     MessagingExtensionActionInvokeResponse,
     MessagingExtensionInvokeResponse,
+    SearchInvokeResponse,
     TabInvokeResponse,
     TaskModuleInvokeResponse,
     TokenExchangeInvokeResponseType,
@@ -1385,8 +1387,7 @@ class GeneratedActivityHandlerMixin(ABC):
     def on_suggested_action_submit(
         self,
     ) -> Callable[
-        [VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]],
-        VoidInvokeHandler[SuggestedActionSubmitInvokeActivity],
+        [VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]], VoidInvokeHandler[SuggestedActionSubmitInvokeActivity]
     ]: ...
 
     def on_suggested_action_submit(
@@ -1525,6 +1526,36 @@ class GeneratedActivityHandlerMixin(ABC):
         ) -> InvokeHandler[AdaptiveCardInvokeActivity, AdaptiveCardInvokeResponse]:
             validate_handler_type(func, AdaptiveCardInvokeActivity, "on_card_action", "AdaptiveCardInvokeActivity")
             config = ACTIVITY_ROUTES["card.action"]
+            self.router.add_handler(config.selector, func)
+            return func
+
+        if handler is not None:
+            return decorator(handler)
+        return decorator
+
+    @overload
+    def on_search(
+        self, handler: InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]
+    ) -> InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]: ...
+
+    @overload
+    def on_search(
+        self,
+    ) -> Callable[
+        [InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]],
+        InvokeHandler[SearchInvokeActivity, SearchInvokeResponse],
+    ]: ...
+
+    def on_search(
+        self, handler: Optional[InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]] = None
+    ) -> InvokeHandlerUnion[SearchInvokeActivity, SearchInvokeResponse]:
+        """Register a search activity handler."""
+
+        def decorator(
+            func: InvokeHandler[SearchInvokeActivity, SearchInvokeResponse],
+        ) -> InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]:
+            validate_handler_type(func, SearchInvokeActivity, "on_search", "SearchInvokeActivity")
+            config = ACTIVITY_ROUTES["search"]
             self.router.add_handler(config.selector, func)
             return func
 

--- a/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
@@ -1534,28 +1534,28 @@ class GeneratedActivityHandlerMixin(ABC):
         return decorator
 
     @overload
-    def on_search(
+    def on_card_search(
         self, handler: InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]
     ) -> InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]: ...
 
     @overload
-    def on_search(
+    def on_card_search(
         self,
     ) -> Callable[
         [InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]],
         InvokeHandler[SearchInvokeActivity, SearchInvokeResponse],
     ]: ...
 
-    def on_search(
+    def on_card_search(
         self, handler: Optional[InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]] = None
     ) -> InvokeHandlerUnion[SearchInvokeActivity, SearchInvokeResponse]:
-        """Register a search activity handler."""
+        """Register a card.search activity handler."""
 
         def decorator(
             func: InvokeHandler[SearchInvokeActivity, SearchInvokeResponse],
         ) -> InvokeHandler[SearchInvokeActivity, SearchInvokeResponse]:
-            validate_handler_type(func, SearchInvokeActivity, "on_search", "SearchInvokeActivity")
-            config = ACTIVITY_ROUTES["search"]
+            validate_handler_type(func, SearchInvokeActivity, "on_card_search", "SearchInvokeActivity")
+            config = ACTIVITY_ROUTES["card.search"]
             self.router.add_handler(config.selector, func)
             return func
 

--- a/packages/apps/tests/test_search_routing.py
+++ b/packages/apps/tests/test_search_routing.py
@@ -1,0 +1,115 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+# pyright: basic
+
+from unittest.mock import MagicMock
+
+import pytest
+from microsoft_teams.api import (
+    Account,
+    AdaptiveCardInvokeActivity,
+    ConversationAccount,
+    SearchInvokeActivity,
+    SearchInvokeResponse,
+)
+from microsoft_teams.api.models.adaptive_card import AdaptiveCardInvokeAction, AdaptiveCardInvokeValue
+from microsoft_teams.api.models.search import (
+    SearchInvokeResponseValue,
+    SearchInvokeResult,
+    SearchInvokeValue,
+    SearchResponse,
+)
+from microsoft_teams.apps import ActivityContext, App
+
+FROM_ACCOUNT = Account(id="user-123", name="Test User")
+RECIPIENT = Account(id="bot-456", name="Test Bot")
+CONVERSATION = ConversationAccount(id="conv-789", conversation_type="personal")
+
+
+class TestSearchRouting:
+    """Test cases for application/search (dynamic typeahead) routing."""
+
+    @pytest.fixture
+    def mock_storage(self):
+        return MagicMock()
+
+    @pytest.fixture(scope="function")
+    def app_with_options(self, mock_storage):
+        return App(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+
+    def _search_activity(self) -> SearchInvokeActivity:
+        return SearchInvokeActivity(
+            id="test-activity-id",
+            type="invoke",
+            name="application/search",
+            from_=FROM_ACCOUNT,
+            recipient=RECIPIENT,
+            conversation=CONVERSATION,
+            channel_id="msteams",
+            value=SearchInvokeValue(kind="search", query_text="hello", dataset="cities"),
+        )
+
+    def test_on_search_matches_application_search(self, app_with_options: App) -> None:
+        """on_search should match an application/search invoke."""
+
+        @app_with_options.on_search
+        async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchInvokeResponse:
+            return SearchResponse(
+                value=SearchInvokeResponseValue(results=[SearchInvokeResult(title="Example", value="example")])
+            )
+
+        handlers = app_with_options.router.select_handlers(self._search_activity())
+        assert len(handlers) == 1
+        assert handlers[0] == handle_search
+
+    def test_on_search_does_not_match_other_invokes(self, app_with_options: App) -> None:
+        """on_search should not match a different invoke name."""
+
+        @app_with_options.on_search
+        async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchInvokeResponse:
+            return SearchResponse(value=SearchInvokeResponseValue(results=[]))
+
+        card_activity = AdaptiveCardInvokeActivity(
+            id="test-activity-id-2",
+            type="invoke",
+            name="adaptiveCard/action",
+            from_=FROM_ACCOUNT,
+            recipient=RECIPIENT,
+            conversation=CONVERSATION,
+            channel_id="msteams",
+            value=AdaptiveCardInvokeValue(
+                action=AdaptiveCardInvokeAction(type="Action.Execute", data={"action": "submit"})
+            ),
+        )
+
+        assert len(app_with_options.router.select_handlers(card_activity)) == 0
+
+    def test_search_value_deserializes_camel_case(self) -> None:
+        """SearchInvokeValue should accept camelCase JSON from the Teams client."""
+        value = SearchInvokeValue.model_validate(
+            {"kind": "typeahead", "queryText": "sea", "queryOptions": {"skip": 0, "top": 5}, "dataset": "cities"}
+        )
+        assert value.query_text == "sea"
+        assert value.query_options is not None
+        assert value.query_options.top == 5
+
+    def test_search_value_deserializes_without_kind(self) -> None:
+        """Adaptive Card dynamic typeahead omits 'kind'; SearchInvokeValue must still validate."""
+        value = SearchInvokeValue.model_validate(
+            {"queryText": "mario", "queryOptions": {"skip": 0, "top": 5}, "dataset": "nintendoGames"}
+        )
+        assert value.kind is None
+        assert value.query_text == "mario"
+        assert value.dataset == "nintendoGames"
+
+    def test_search_response_serializes_camel_case(self) -> None:
+        """SearchResponse should serialize to the documented camelCase shape."""
+        response = SearchResponse(
+            value=SearchInvokeResponseValue(results=[SearchInvokeResult(title="Seattle", value="seattle")])
+        )
+        dumped = response.model_dump(by_alias=True)
+        assert dumped["statusCode"] == 200
+        assert dumped["type"] == "application/vnd.microsoft.search.searchResponse"
+        assert dumped["value"]["results"][0]["title"] == "Seattle"

--- a/packages/apps/tests/test_search_routing.py
+++ b/packages/apps/tests/test_search_routing.py
@@ -51,10 +51,10 @@ class TestSearchRouting:
             value=SearchInvokeValue(kind="search", query_text="hello", dataset="cities"),
         )
 
-    def test_on_search_matches_application_search(self, app_with_options: App) -> None:
-        """on_search should match an application/search invoke."""
+    def test_on_card_search_matches_application_search(self, app_with_options: App) -> None:
+        """on_card_search should match an application/search invoke."""
 
-        @app_with_options.on_search
+        @app_with_options.on_card_search
         async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchInvokeResponse:
             return SearchResponse(
                 value=SearchInvokeResponseValue(results=[SearchInvokeResult(title="Example", value="example")])
@@ -64,10 +64,10 @@ class TestSearchRouting:
         assert len(handlers) == 1
         assert handlers[0] == handle_search
 
-    def test_on_search_does_not_match_other_invokes(self, app_with_options: App) -> None:
-        """on_search should not match a different invoke name."""
+    def test_on_card_search_does_not_match_other_invokes(self, app_with_options: App) -> None:
+        """on_card_search should not match a different invoke name."""
 
-        @app_with_options.on_search
+        @app_with_options.on_card_search
         async def handle_search(ctx: ActivityContext[SearchInvokeActivity]) -> SearchInvokeResponse:
             return SearchResponse(value=SearchInvokeResponseValue(results=[]))
 


### PR DESCRIPTION
## Summary

Adds support for the `application/search` invoke activity (Adaptive Card dynamic typeahead `Input.ChoiceSet`) to the Python SDK. Introduces the search value/response models and a declarative `@app.on_search` handler.

## Changes
- New `SearchValue` / `SearchResponse` models (`kind` optional — the real Teams payload omits it, which previously failed Pydantic validation).
- `SearchInvokeActivity` added to the invoke union; `on_search` generated handler + activity route config.
- Cards example (`examples/cards`) demonstrates a dynamic typeahead card + search handler.

## Testing
- `pytest packages/api packages/apps`
- Live e2e on Teams web.

Part of microsoft/teams.ts#252
