### PR TITLE
Rename Agent 365 identity surface to AgenticUser

### DIFF
--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -1,10 +1,10 @@
 # agent365
 
-Demonstrates scoping Teams API clients with `AgenticIdentity`.
+Demonstrates scoping Teams API clients with `AgentUser`.
 
 ## Reactive Echo
 
-`src/main.py` mimics the echo example. Incoming messages are handled normally; the inbound service URL and agentic identity are carried by the context/API layer.
+`src/main.py` mimics the echo example. Incoming messages are handled normally; the inbound service URL and agent user are carried by the context/API layer.
 
 ```bash
 export CLIENT_ID=<agent-identity-blueprint-app-id>
@@ -16,7 +16,7 @@ uv run --project examples/agent365 python src/main.py
 
 ## Proactive API Send
 
-`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. In both cases the API layer asks the auth provider for the right Agent ID token and uses it in the request header.
+`src/proactive.py` shows both `app.send(..., agent_user=...)` and a scoped lower-level conversation activity API client. In both cases the API layer asks the auth provider for the right Agent ID token and uses it in the request header.
 
 ```bash
 export CLIENT_ID=<agent-identity-blueprint-app-id>
@@ -25,6 +25,6 @@ export TENANT_ID=<tenant-id>
 
 uv run --project examples/agent365 python src/proactive.py \
   <conversation-id> \
-  <agentic-app-id> \
-  <agentic-user-id>
+  <agent-app-instance-id> \
+  <agent-user-id>
 ```

--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -7,8 +7,8 @@ Demonstrates scoping Teams API clients with `AgenticUser`.
 `src/main.py` mimics the echo example. Incoming messages are handled normally; the inbound service URL and agentic user are carried by the context/API layer.
 
 ```bash
-export CLIENT_ID=<agent-identity-blueprint-app-id>
-export CLIENT_SECRET=<agent-identity-blueprint-secret>
+export CLIENT_ID=<agentic-blueprint-app-id>
+export CLIENT_SECRET=<agentic-blueprint-secret>
 export TENANT_ID=<tenant-id>
 
 uv run --project examples/agent365 python src/main.py
@@ -19,12 +19,12 @@ uv run --project examples/agent365 python src/main.py
 `src/proactive.py` shows both `app.send(..., agentic_user=...)` and a scoped lower-level conversation activity API client. In both cases the API layer asks the auth provider for the right Agent ID token and uses it in the request header.
 
 ```bash
-export CLIENT_ID=<agent-identity-blueprint-app-id>
-export CLIENT_SECRET=<agent-identity-blueprint-secret>
+export CLIENT_ID=<agentic-blueprint-app-id>
+export CLIENT_SECRET=<agentic-blueprint-secret>
 export TENANT_ID=<tenant-id>
 
 uv run --project examples/agent365 python src/proactive.py \
   <conversation-id> \
-  <agent-app-instance-id> \
+  <agentic-app-instance-id> \
   <agentic-user-id>
 ```

--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -1,10 +1,10 @@
 # agent365
 
-Demonstrates scoping Teams API clients with `AgentUser`.
+Demonstrates scoping Teams API clients with `AgenticUser`.
 
 ## Reactive Echo
 
-`src/main.py` mimics the echo example. Incoming messages are handled normally; the inbound service URL and agent user are carried by the context/API layer.
+`src/main.py` mimics the echo example. Incoming messages are handled normally; the inbound service URL and agentic user are carried by the context/API layer.
 
 ```bash
 export CLIENT_ID=<agent-identity-blueprint-app-id>
@@ -16,7 +16,7 @@ uv run --project examples/agent365 python src/main.py
 
 ## Proactive API Send
 
-`src/proactive.py` shows both `app.send(..., agent_user=...)` and a scoped lower-level conversation activity API client. In both cases the API layer asks the auth provider for the right Agent ID token and uses it in the request header.
+`src/proactive.py` shows both `app.send(..., agentic_user=...)` and a scoped lower-level conversation activity API client. In both cases the API layer asks the auth provider for the right Agent ID token and uses it in the request header.
 
 ```bash
 export CLIENT_ID=<agent-identity-blueprint-app-id>
@@ -26,5 +26,5 @@ export TENANT_ID=<tenant-id>
 uv run --project examples/agent365 python src/proactive.py \
   <conversation-id> \
   <agent-app-instance-id> \
-  <agent-user-id>
+  <agentic-user-id>
 ```

--- a/examples/agent365/src/main.py
+++ b/examples/agent365/src/main.py
@@ -44,8 +44,8 @@ def _log_lifecycle_envelope(activity: AgentLifecycleEventActivity, handler_name:
         handler_name,
         activity.value.tenant_id,
         activity.value.agentic_user_id,
-        activity.value.agent_app_instance_id,
-        activity.value.agent_identity_blueprint_id,
+        activity.value.agentic_app_instance_id,
+        activity.value.agentic_blueprint_id,
         activity.value.version,
     )
 

--- a/examples/agent365/src/main.py
+++ b/examples/agent365/src/main.py
@@ -37,14 +37,14 @@ def _log_lifecycle_envelope(activity: AgentLifecycleEventActivity, handler_name:
         activity.value.event_type,
         activity.channel_id,
         activity.from_.id,
-        activity.recipient.agentic_identity,
+        activity.recipient.agent_user,
     )
     logger.info(
-        "[Agent365 lifecycle:%s] tenant_id=%s agentic_user_id=%s app_instance_id=%s blueprint_id=%s version=%s",
+        "[Agent365 lifecycle:%s] tenant_id=%s agent_user_id=%s app_instance_id=%s blueprint_id=%s version=%s",
         handler_name,
         activity.value.tenant_id,
-        activity.value.agentic_user_id,
-        activity.value.agentic_app_instance_id,
+        activity.value.agent_user_id,
+        activity.value.agent_app_instance_id,
         activity.value.agent_identity_blueprint_id,
         activity.value.version,
     )
@@ -57,8 +57,8 @@ async def handle_agent_lifecycle(ctx: ActivityContext[AgentLifecycleEventActivit
     await ctx.next()
 
 
-@app.on_agentic_user_identity_created
-async def handle_agentic_user_identity_created(ctx: ActivityContext[AgenticUserIdentityCreatedActivity]) -> None:
+@app.on_agent_user_identity_created
+async def handle_agent_user_identity_created(ctx: ActivityContext[AgenticUserIdentityCreatedActivity]) -> None:
     """Log an agentic user identity creation event."""
     activity = ctx.activity
     _log_lifecycle_envelope(activity, "identity_created")
@@ -69,8 +69,8 @@ async def handle_agentic_user_identity_created(ctx: ActivityContext[AgenticUserI
     )
 
 
-@app.on_agentic_user_identity_updated
-async def handle_agentic_user_identity_updated(ctx: ActivityContext[AgenticUserIdentityUpdatedActivity]) -> None:
+@app.on_agent_user_identity_updated
+async def handle_agent_user_identity_updated(ctx: ActivityContext[AgenticUserIdentityUpdatedActivity]) -> None:
     """Log an agentic user identity property update event."""
     activity = ctx.activity
     _log_lifecycle_envelope(activity, "identity_updated")
@@ -130,16 +130,16 @@ async def handle_agentic_user_workload_onboarding_updated(
 
 @app.on_message_pattern(re.compile(r"hello|hi|greetings"))
 async def handle_greeting(ctx: ActivityContext[MessageActivity]) -> None:
-    """Handle greeting messages using the inbound AgenticIdentity when present."""
+    """Handle greeting messages using the inbound AgentUser when present."""
     await ctx.reply("Hello! How can I assist you today?")
 
 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
-    """Echo incoming messages using the inbound AgenticIdentity when present."""
+    """Echo incoming messages using the inbound AgentUser when present."""
     logger.info("[Agent365 reactive] Message received: %s", ctx.activity.text)
     logger.info("[Agent365 reactive] From: %s", ctx.activity.from_)
-    logger.info("[Agent365 reactive] Agentic identity: %s", ctx.activity.recipient.agentic_identity)
+    logger.info("[Agent365 reactive] AgentUser: %s", ctx.activity.recipient.agent_user)
 
     await ctx.reply(TypingActivityInput())
 

--- a/examples/agent365/src/main.py
+++ b/examples/agent365/src/main.py
@@ -37,13 +37,13 @@ def _log_lifecycle_envelope(activity: AgentLifecycleEventActivity, handler_name:
         activity.value.event_type,
         activity.channel_id,
         activity.from_.id,
-        activity.recipient.agent_user,
+        activity.recipient.agentic_user,
     )
     logger.info(
-        "[Agent365 lifecycle:%s] tenant_id=%s agent_user_id=%s app_instance_id=%s blueprint_id=%s version=%s",
+        "[Agent365 lifecycle:%s] tenant_id=%s agentic_user_id=%s app_instance_id=%s blueprint_id=%s version=%s",
         handler_name,
         activity.value.tenant_id,
-        activity.value.agent_user_id,
+        activity.value.agentic_user_id,
         activity.value.agent_app_instance_id,
         activity.value.agent_identity_blueprint_id,
         activity.value.version,
@@ -57,8 +57,8 @@ async def handle_agent_lifecycle(ctx: ActivityContext[AgentLifecycleEventActivit
     await ctx.next()
 
 
-@app.on_agent_user_identity_created
-async def handle_agent_user_identity_created(ctx: ActivityContext[AgenticUserIdentityCreatedActivity]) -> None:
+@app.on_agentic_user_identity_created
+async def handle_agentic_user_identity_created(ctx: ActivityContext[AgenticUserIdentityCreatedActivity]) -> None:
     """Log an agentic user identity creation event."""
     activity = ctx.activity
     _log_lifecycle_envelope(activity, "identity_created")
@@ -69,8 +69,8 @@ async def handle_agent_user_identity_created(ctx: ActivityContext[AgenticUserIde
     )
 
 
-@app.on_agent_user_identity_updated
-async def handle_agent_user_identity_updated(ctx: ActivityContext[AgenticUserIdentityUpdatedActivity]) -> None:
+@app.on_agentic_user_identity_updated
+async def handle_agentic_user_identity_updated(ctx: ActivityContext[AgenticUserIdentityUpdatedActivity]) -> None:
     """Log an agentic user identity property update event."""
     activity = ctx.activity
     _log_lifecycle_envelope(activity, "identity_updated")
@@ -130,16 +130,16 @@ async def handle_agentic_user_workload_onboarding_updated(
 
 @app.on_message_pattern(re.compile(r"hello|hi|greetings"))
 async def handle_greeting(ctx: ActivityContext[MessageActivity]) -> None:
-    """Handle greeting messages using the inbound AgentUser when present."""
+    """Handle greeting messages using the inbound AgenticUser when present."""
     await ctx.reply("Hello! How can I assist you today?")
 
 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
-    """Echo incoming messages using the inbound AgentUser when present."""
+    """Echo incoming messages using the inbound AgenticUser when present."""
     logger.info("[Agent365 reactive] Message received: %s", ctx.activity.text)
     logger.info("[Agent365 reactive] From: %s", ctx.activity.from_)
-    logger.info("[Agent365 reactive] AgentUser: %s", ctx.activity.recipient.agent_user)
+    logger.info("[Agent365 reactive] AgenticUser: %s", ctx.activity.recipient.agentic_user)
 
     await ctx.reply(TypingActivityInput())
 

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -17,14 +17,14 @@ logger = logging.getLogger(__name__)
 async def main():
     parser = argparse.ArgumentParser(description="Send proactive messages using AgenticUser")
     parser.add_argument("conversation_id", help="The Teams conversation ID to send messages to")
-    parser.add_argument("agent_app_instance_id", help="The AgentAppInstance client ID")
+    parser.add_argument("agentic_app_instance_id", help="The AgenticAppInstance client ID")
     parser.add_argument("agentic_user_id", help="The agentic user object ID")
     args = parser.parse_args()
 
     app = App()
     await app.initialize()
 
-    agentic_user = app.get_agentic_user(args.agent_app_instance_id, args.agentic_user_id)
+    agentic_user = app.get_agentic_user(args.agentic_app_instance_id, args.agentic_user_id)
     sent = await app.send(
         args.conversation_id,
         "Hello from app.send with an AgenticUser.",

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -15,26 +15,26 @@ logger = logging.getLogger(__name__)
 
 
 async def main():
-    parser = argparse.ArgumentParser(description="Send proactive messages using AgenticIdentity")
+    parser = argparse.ArgumentParser(description="Send proactive messages using AgentUser")
     parser.add_argument("conversation_id", help="The Teams conversation ID to send messages to")
-    parser.add_argument("agentic_app_id", help="The concrete agent identity app/client ID")
-    parser.add_argument("agentic_user_id", help="The agent user object ID")
+    parser.add_argument("agent_app_instance_id", help="The AgentAppInstance client ID")
+    parser.add_argument("agent_user_id", help="The agent user object ID")
     args = parser.parse_args()
 
     app = App()
     await app.initialize()
 
-    agentic_identity = app.get_agentic_identity(args.agentic_app_id, args.agentic_user_id)
+    agent_user = app.get_agent_user(args.agent_app_instance_id, args.agent_user_id)
     sent = await app.send(
         args.conversation_id,
-        "Hello from app.send with an AgenticIdentity.",
-        agentic_identity=agentic_identity,
+        "Hello from app.send with an AgentUser.",
+        agent_user=agent_user,
     )
     logger.info("Sent activity through app.send. Activity ID: %s", sent.id)
 
-    api_sent = await app.api.from_agentic_identity(agentic_identity).conversations.create_activity(
+    api_sent = await app.api.from_agent_user(agent_user).conversations.create_activity(
         args.conversation_id,
-        MessageActivityInput(text="Hello from the conversation activity API with an AgenticIdentity."),
+        MessageActivityInput(text="Hello from the conversation activity API with an AgentUser."),
     )
     logger.info("Sent activity through app.api. Activity ID: %s", api_sent.id)
 

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -15,26 +15,26 @@ logger = logging.getLogger(__name__)
 
 
 async def main():
-    parser = argparse.ArgumentParser(description="Send proactive messages using AgentUser")
+    parser = argparse.ArgumentParser(description="Send proactive messages using AgenticUser")
     parser.add_argument("conversation_id", help="The Teams conversation ID to send messages to")
     parser.add_argument("agent_app_instance_id", help="The AgentAppInstance client ID")
-    parser.add_argument("agent_user_id", help="The agent user object ID")
+    parser.add_argument("agentic_user_id", help="The agentic user object ID")
     args = parser.parse_args()
 
     app = App()
     await app.initialize()
 
-    agent_user = app.get_agent_user(args.agent_app_instance_id, args.agent_user_id)
+    agentic_user = app.get_agentic_user(args.agent_app_instance_id, args.agentic_user_id)
     sent = await app.send(
         args.conversation_id,
-        "Hello from app.send with an AgentUser.",
-        agent_user=agent_user,
+        "Hello from app.send with an AgenticUser.",
+        agentic_user=agentic_user,
     )
     logger.info("Sent activity through app.send. Activity ID: %s", sent.id)
 
-    api_sent = await app.api.from_agent_user(agent_user).conversations.create_activity(
+    api_sent = await app.api.from_agentic_user(agentic_user).conversations.create_activity(
         args.conversation_id,
-        MessageActivityInput(text="Hello from the conversation activity API with an AgentUser."),
+        MessageActivityInput(text="Hello from the conversation activity API with an AgenticUser."),
     )
     logger.info("Sent activity through app.api. Activity ID: %s", api_sent.id)
 

--- a/packages/api/src/microsoft_teams/api/activities/event/agent_lifecycle/value.py
+++ b/packages/api/src/microsoft_teams/api/activities/event/agent_lifecycle/value.py
@@ -47,7 +47,7 @@ class AgentLifecycleValueBase(CustomBaseModel):
     tenant_id: Optional[str] = None
     """The tenant the agentic user belongs to."""
 
-    agent_user_id: Optional[str] = Field(
+    agentic_user_id: Optional[str] = Field(
         default=None,
         validation_alias="agenticUserId",
         serialization_alias="agenticUserId",

--- a/packages/api/src/microsoft_teams/api/activities/event/agent_lifecycle/value.py
+++ b/packages/api/src/microsoft_teams/api/activities/event/agent_lifecycle/value.py
@@ -54,15 +54,19 @@ class AgentLifecycleValueBase(CustomBaseModel):
     )
     """The Agent ID user-shaped identity object ID."""
 
-    agent_app_instance_id: Optional[str] = Field(
+    agentic_app_instance_id: Optional[str] = Field(
         default=None,
         validation_alias="agenticAppInstanceId",
         serialization_alias="agenticAppInstanceId",
     )
     """The concrete agent app instance ID."""
 
-    agent_identity_blueprint_id: Optional[str] = None
-    """The AgentIdentityBlueprint app ID."""
+    agentic_blueprint_id: Optional[str] = Field(
+        default=None,
+        validation_alias="agentIdentityBlueprintId",
+        serialization_alias="agentIdentityBlueprintId",
+    )
+    """The AgenticBlueprint app ID."""
 
     version: Optional[int] = None
     """Monotonic version of the agentic user state, when provided by the service."""

--- a/packages/api/src/microsoft_teams/api/activities/event/agent_lifecycle/value.py
+++ b/packages/api/src/microsoft_teams/api/activities/event/agent_lifecycle/value.py
@@ -6,6 +6,8 @@ Licensed under the MIT License.
 from datetime import datetime
 from typing import Literal, Optional
 
+from pydantic import Field
+
 from ....models import CustomBaseModel
 
 
@@ -45,14 +47,22 @@ class AgentLifecycleValueBase(CustomBaseModel):
     tenant_id: Optional[str] = None
     """The tenant the agentic user belongs to."""
 
-    agentic_user_id: Optional[str] = None
+    agent_user_id: Optional[str] = Field(
+        default=None,
+        validation_alias="agenticUserId",
+        serialization_alias="agenticUserId",
+    )
     """The Agent ID user-shaped identity object ID."""
 
-    agentic_app_instance_id: Optional[str] = None
+    agent_app_instance_id: Optional[str] = Field(
+        default=None,
+        validation_alias="agenticAppInstanceId",
+        serialization_alias="agenticAppInstanceId",
+    )
     """The concrete agent app instance ID."""
 
     agent_identity_blueprint_id: Optional[str] = None
-    """The agent identity blueprint app ID."""
+    """The AgentIdentityBlueprint app ID."""
 
     version: Optional[int] = None
     """Monotonic version of the agentic user state, when provided by the service."""

--- a/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
+++ b/packages/api/src/microsoft_teams/api/auth/cloud_environment.py
@@ -21,7 +21,7 @@ class CloudEnvironment:
     """The default multi-tenant login tenant (e.g. "botframework.com")."""
     bot_scope: str
     """The Bot Framework OAuth scope (e.g. "https://api.botframework.com/.default")."""
-    agentic_bot_scope: str
+    agent_bot_scope: str
     """The Teams Bot API scope for Agent ID user-token calls."""
     token_service_url: str
     """The Bot Framework token service base URL (e.g. "https://token.botframework.com")."""
@@ -37,7 +37,7 @@ PUBLIC = CloudEnvironment(
     login_endpoint="https://login.microsoftonline.com",
     login_tenant="botframework.com",
     bot_scope="https://api.botframework.com/.default",
-    agentic_bot_scope="https://botapi.skype.com/.default",
+    agent_bot_scope="https://botapi.skype.com/.default",
     token_service_url="https://token.botframework.com",
     openid_metadata_url="https://login.botframework.com/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.com",
@@ -50,7 +50,7 @@ US_GOV = CloudEnvironment(
     login_tenant="MicrosoftServices.onmicrosoft.us",
     bot_scope="https://api.botframework.us/.default",
     # TODO: confirm Agent ID Bot API scope for this cloud before enabling sovereign Agent ID scenarios.
-    agentic_bot_scope="https://botapi.skype.com/.default",
+    agent_bot_scope="https://botapi.skype.com/.default",
     token_service_url="https://tokengcch.botframework.azure.us",
     openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.us",
@@ -63,7 +63,7 @@ US_GOV_DOD = CloudEnvironment(
     login_tenant="MicrosoftServices.onmicrosoft.us",
     bot_scope="https://api.botframework.us/.default",
     # TODO: confirm Agent ID Bot API scope for this cloud before enabling sovereign Agent ID scenarios.
-    agentic_bot_scope="https://botapi.skype.com/.default",
+    agent_bot_scope="https://botapi.skype.com/.default",
     token_service_url="https://apiDoD.botframework.azure.us",
     openid_metadata_url="https://login.botframework.azure.us/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.us",
@@ -76,7 +76,7 @@ CHINA = CloudEnvironment(
     login_tenant="microsoftservices.partner.onmschina.cn",
     bot_scope="https://api.botframework.azure.cn/.default",
     # TODO: confirm Agent ID Bot API scope for this cloud before enabling China cloud Agent ID scenarios.
-    agentic_bot_scope="https://botapi.skype.com/.default",
+    agent_bot_scope="https://botapi.skype.com/.default",
     token_service_url="https://token.botframework.azure.cn",
     openid_metadata_url="https://login.botframework.azure.cn/v1/.well-known/openidconfiguration",
     token_issuer="https://api.botframework.azure.cn",

--- a/packages/api/src/microsoft_teams/api/auth/credentials.py
+++ b/packages/api/src/microsoft_teams/api/auth/credentials.py
@@ -5,29 +5,31 @@ Licensed under the MIT License.
 
 from typing import Awaitable, Callable, Literal, Optional, Protocol, TypeAlias, Union, runtime_checkable
 
-from ..models import AgentUser, CustomBaseModel
+from ..models import AgenticUser, CustomBaseModel
 
 TokenScope: TypeAlias = Union[str, list[str]]
 TokenResult: TypeAlias = Union[str, Awaitable[str]]
 BasicTokenProvider: TypeAlias = Callable[[TokenScope, Optional[str]], TokenResult]
-_PositionalAgentUserTokenProvider: TypeAlias = Callable[[TokenScope, Optional[str], Optional[AgentUser]], TokenResult]
+_PositionalAgenticUserTokenProvider: TypeAlias = Callable[
+    [TokenScope, Optional[str], Optional[AgenticUser]], TokenResult
+]
 
 
 @runtime_checkable
-class _KeywordAgentUserTokenProvider(Protocol):
+class _KeywordAgenticUserTokenProvider(Protocol):
     def __call__(
         self,
         scope: TokenScope,
         tenant_id: Optional[str],
         *,
-        agent_user: Optional[AgentUser] = None,
+        agentic_user: Optional[AgenticUser] = None,
     ) -> TokenResult: ...
 
 
 TokenProvider: TypeAlias = Union[
     BasicTokenProvider,
-    _PositionalAgentUserTokenProvider,
-    _KeywordAgentUserTokenProvider,
+    _PositionalAgenticUserTokenProvider,
+    _KeywordAgenticUserTokenProvider,
 ]
 
 
@@ -59,7 +61,7 @@ class TokenCredentials(CustomBaseModel):
     """
     The tenant ID.
     """
-    # (scope: string | string[], tenantId?: string, agentUser?: AgentUser) => string | Promise<string>
+    # (scope: string | string[], tenantId?: string, agenticUser?: AgenticUser) => string | Promise<string>
     token: TokenProvider
     """
     The token function.

--- a/packages/api/src/microsoft_teams/api/auth/credentials.py
+++ b/packages/api/src/microsoft_teams/api/auth/credentials.py
@@ -5,31 +5,29 @@ Licensed under the MIT License.
 
 from typing import Awaitable, Callable, Literal, Optional, Protocol, TypeAlias, Union, runtime_checkable
 
-from ..models import AgenticIdentity, CustomBaseModel
+from ..models import AgentUser, CustomBaseModel
 
 TokenScope: TypeAlias = Union[str, list[str]]
 TokenResult: TypeAlias = Union[str, Awaitable[str]]
 BasicTokenProvider: TypeAlias = Callable[[TokenScope, Optional[str]], TokenResult]
-_PositionalAgenticTokenProvider: TypeAlias = Callable[
-    [TokenScope, Optional[str], Optional[AgenticIdentity]], TokenResult
-]
+_PositionalAgentUserTokenProvider: TypeAlias = Callable[[TokenScope, Optional[str], Optional[AgentUser]], TokenResult]
 
 
 @runtime_checkable
-class _KeywordAgenticTokenProvider(Protocol):
+class _KeywordAgentUserTokenProvider(Protocol):
     def __call__(
         self,
         scope: TokenScope,
         tenant_id: Optional[str],
         *,
-        agentic_identity: Optional[AgenticIdentity] = None,
+        agent_user: Optional[AgentUser] = None,
     ) -> TokenResult: ...
 
 
 TokenProvider: TypeAlias = Union[
     BasicTokenProvider,
-    _PositionalAgenticTokenProvider,
-    _KeywordAgenticTokenProvider,
+    _PositionalAgentUserTokenProvider,
+    _KeywordAgentUserTokenProvider,
 ]
 
 
@@ -61,7 +59,7 @@ class TokenCredentials(CustomBaseModel):
     """
     The tenant ID.
     """
-    # (scope: string | string[], tenantId?: string, agenticIdentity?: AgenticIdentity) => string | Promise<string>
+    # (scope: string | string[], tenantId?: string, agentUser?: AgentUser) => string | Promise<string>
     token: TokenProvider
     """
     The token function.

--- a/packages/api/src/microsoft_teams/api/clients/__init__.py
+++ b/packages/api/src/microsoft_teams/api/clients/__init__.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from . import bot, conversation, meeting, reaction, team, user
 from ._auth_provider import AuthProvider
-from .api_client import AGENTIC_IDENTITY_CLEAR, AgenticIdentityClear, AgenticIdentityScope, ApiClient
+from .api_client import AGENT_USER_CLEAR, AgentUserClear, AgentUserScope, ApiClient
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
 from .bot import *  # noqa: F403
 from .conversation import *  # noqa: F403
@@ -19,9 +19,9 @@ __all__: list[str] = [
     "ApiClient",
     "ApiClientSettings",
     "AuthProvider",
-    "AGENTIC_IDENTITY_CLEAR",
-    "AgenticIdentityClear",
-    "AgenticIdentityScope",
+    "AGENT_USER_CLEAR",
+    "AgentUserClear",
+    "AgentUserScope",
     "merge_api_client_settings",
 ]
 __all__.extend(bot.__all__)

--- a/packages/api/src/microsoft_teams/api/clients/__init__.py
+++ b/packages/api/src/microsoft_teams/api/clients/__init__.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from . import bot, conversation, meeting, reaction, team, user
 from ._auth_provider import AuthProvider
-from .api_client import AGENT_USER_CLEAR, AgentUserClear, AgentUserScope, ApiClient
+from .api_client import AGENTIC_USER_CLEAR, AgenticUserClear, AgenticUserScope, ApiClient
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
 from .bot import *  # noqa: F403
 from .conversation import *  # noqa: F403
@@ -19,9 +19,9 @@ __all__: list[str] = [
     "ApiClient",
     "ApiClientSettings",
     "AuthProvider",
-    "AGENT_USER_CLEAR",
-    "AgentUserClear",
-    "AgentUserScope",
+    "AGENTIC_USER_CLEAR",
+    "AgenticUserClear",
+    "AgenticUserScope",
     "merge_api_client_settings",
 ]
 __all__.extend(bot.__all__)

--- a/packages/api/src/microsoft_teams/api/clients/_auth_provider.py
+++ b/packages/api/src/microsoft_teams/api/clients/_auth_provider.py
@@ -9,10 +9,10 @@ from typing import Awaitable, Protocol
 
 from microsoft_teams.common.http.client_token import StringLike
 
-from ..models.agent_user import AgentUser
+from ..models.agentic_user import AgenticUser
 
 
 class AuthProvider(Protocol):
     def token(
-        self, *, scope: str | None = None, agent_user: AgentUser | None = None
+        self, *, scope: str | None = None, agentic_user: AgenticUser | None = None
     ) -> str | StringLike | None | Awaitable[str | StringLike | None]: ...

--- a/packages/api/src/microsoft_teams/api/clients/_auth_provider.py
+++ b/packages/api/src/microsoft_teams/api/clients/_auth_provider.py
@@ -9,10 +9,10 @@ from typing import Awaitable, Protocol
 
 from microsoft_teams.common.http.client_token import StringLike
 
-from ..models.agentic_identity import AgenticIdentity
+from ..models.agent_user import AgentUser
 
 
 class AuthProvider(Protocol):
     def token(
-        self, *, scope: str | None = None, agentic_identity: AgenticIdentity | None = None
+        self, *, scope: str | None = None, agent_user: AgentUser | None = None
     ) -> str | StringLike | None | Awaitable[str | StringLike | None]: ...

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -18,7 +18,7 @@ from ..auth.cloud_environment import PUBLIC, CloudEnvironment
 from ..diagnostics._constants import API_ATTRIBUTE_NAMES, API_AUTH_FLOWS, API_SPAN_NAMES
 from ..diagnostics._helpers import get_tracer, record_exception
 from ..diagnostics._outbound import ensure_outbound_telemetry_middleware
-from ..models import AgentUser
+from ..models import AgenticUser
 from ._auth_provider import AuthProvider
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
 from .base_client import BaseClient
@@ -29,9 +29,9 @@ from .reaction import ReactionClient
 from .team import TeamClient
 from .user import UserClient
 
-AgentUserClear: TypeAlias = Literal["clear"]
-AGENT_USER_CLEAR: AgentUserClear = "clear"
-AgentUserScope: TypeAlias = AgentUser | None | AgentUserClear
+AgenticUserClear: TypeAlias = Literal["clear"]
+AGENTIC_USER_CLEAR: AgenticUserClear = "clear"
+AgenticUserScope: TypeAlias = AgenticUser | None | AgenticUserClear
 
 
 class ApiClient(BaseClient):
@@ -45,7 +45,7 @@ class ApiClient(BaseClient):
         cloud: Optional[CloudEnvironment] = None,
         *,
         auth_provider: Optional[AuthProvider] = None,
-        agent_user: Optional[AgentUser] = None,
+        agentic_user: Optional[AgenticUser] = None,
     ) -> None:
         """Initialize the unified Teams API client.
 
@@ -63,7 +63,7 @@ class ApiClient(BaseClient):
             raise ValueError("Cannot use both an auth provider and an HTTP client token.")
 
         self._auth_provider = auth_provider
-        self._default_agent_user = agent_user
+        self._default_agentic_user = agentic_user
         self._apply_auth_provider_token()
 
         # Initialize all client types
@@ -102,19 +102,19 @@ class ApiClient(BaseClient):
         self,
         *,
         service_url: str | None = None,
-        agent_user: AgentUserScope = None,
+        agentic_user: AgenticUserScope = None,
     ) -> "ApiClient":
         """Create a scoped API client.
 
-        Omitting agent_user, or passing None, preserves the existing scoped identity.
-        Pass AGENT_USER_CLEAR to clear it, or an AgentUser to override it.
+        Omitting agentic_user, or passing None, preserves the existing scoped identity.
+        Pass AGENTIC_USER_CLEAR to clear it, or an AgenticUser to override it.
         """
-        if agent_user is None:
-            resolved_agent_user = self._default_agent_user
-        elif agent_user == AGENT_USER_CLEAR:
-            resolved_agent_user = None
+        if agentic_user is None:
+            resolved_agentic_user = self._default_agentic_user
+        elif agentic_user == AGENTIC_USER_CLEAR:
+            resolved_agentic_user = None
         else:
-            resolved_agent_user = agent_user
+            resolved_agentic_user = agentic_user
         http = self._http.clone(share_http=True)
         if self._auth_provider is not None:
             http.token = None
@@ -125,34 +125,34 @@ class ApiClient(BaseClient):
             self._api_client_settings,
             cloud=self._cloud,
             auth_provider=self._auth_provider,
-            agent_user=resolved_agent_user,
+            agentic_user=resolved_agentic_user,
         )
 
     def from_service_url(self, service_url: str) -> "ApiClient":
         """Create a scoped API client for a different Teams service URL."""
         return self.clone(service_url=service_url)
 
-    def from_agent_user(self, agent_user: AgentUser) -> "ApiClient":
-        """Create a scoped API client for an agent user."""
-        return self.clone(agent_user=agent_user)
+    def from_agentic_user(self, agentic_user: AgenticUser) -> "ApiClient":
+        """Create a scoped API client for an agentic user."""
+        return self.clone(agentic_user=agentic_user)
 
-    def for_agent_user(self, agent_user: AgentUser) -> "ApiClient":
-        """Alias for from_agent_user."""
-        return self.from_agent_user(agent_user)
+    def for_agentic_user(self, agentic_user: AgenticUser) -> "ApiClient":
+        """Alias for from_agentic_user."""
+        return self.from_agentic_user(agentic_user)
 
     def _scope_conversations(
         self,
         service_url: str | None,
-        agent_user: AgentUser | None,
+        agentic_user: AgenticUser | None,
     ) -> ConversationClient:
-        return self.clone(service_url=service_url, agent_user=agent_user).conversations
+        return self.clone(service_url=service_url, agentic_user=agentic_user).conversations
 
-    def _get_scoped_http(self, agent_user: AgentUser | None) -> HttpClient:
+    def _get_scoped_http(self, agentic_user: AgenticUser | None) -> HttpClient:
         if self._auth_provider is None:
             return self._http.clone(share_http=True)
 
         return self._http.clone(
-            ClientOptions(token=self._create_auth_provider_token(agent_user)),
+            ClientOptions(token=self._create_auth_provider_token(agentic_user)),
             share_http=True,
         )
 
@@ -160,9 +160,9 @@ class ApiClient(BaseClient):
         if self._auth_provider is None:
             return
 
-        self._http = self._get_scoped_http(self._default_agent_user)
+        self._http = self._get_scoped_http(self._default_agentic_user)
 
-    def _create_auth_provider_token(self, agent_user: AgentUser | None) -> Token:
+    def _create_auth_provider_token(self, agentic_user: AgenticUser | None) -> Token:
         auth_provider = self._auth_provider
         if auth_provider is None:
             return None
@@ -174,10 +174,10 @@ class ApiClient(BaseClient):
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
-                flow = API_AUTH_FLOWS.agent_user if agent_user is not None else API_AUTH_FLOWS.app_only
+                flow = API_AUTH_FLOWS.agentic_user if agentic_user is not None else API_AUTH_FLOWS.app_only
                 span.set_attribute(API_ATTRIBUTE_NAMES.auth_flow, flow)
                 try:
-                    token = auth_provider.token(agent_user=agent_user)
+                    token = auth_provider.token(agentic_user=agentic_user)
                     if inspect.isawaitable(token):
                         return await token
                     return token

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -18,7 +18,7 @@ from ..auth.cloud_environment import PUBLIC, CloudEnvironment
 from ..diagnostics._constants import API_ATTRIBUTE_NAMES, API_AUTH_FLOWS, API_SPAN_NAMES
 from ..diagnostics._helpers import get_tracer, record_exception
 from ..diagnostics._outbound import ensure_outbound_telemetry_middleware
-from ..models import AgenticIdentity
+from ..models import AgentUser
 from ._auth_provider import AuthProvider
 from .api_client_settings import ApiClientSettings, merge_api_client_settings
 from .base_client import BaseClient
@@ -29,9 +29,9 @@ from .reaction import ReactionClient
 from .team import TeamClient
 from .user import UserClient
 
-AgenticIdentityClear: TypeAlias = Literal["clear"]
-AGENTIC_IDENTITY_CLEAR: AgenticIdentityClear = "clear"
-AgenticIdentityScope: TypeAlias = AgenticIdentity | None | AgenticIdentityClear
+AgentUserClear: TypeAlias = Literal["clear"]
+AGENT_USER_CLEAR: AgentUserClear = "clear"
+AgentUserScope: TypeAlias = AgentUser | None | AgentUserClear
 
 
 class ApiClient(BaseClient):
@@ -45,7 +45,7 @@ class ApiClient(BaseClient):
         cloud: Optional[CloudEnvironment] = None,
         *,
         auth_provider: Optional[AuthProvider] = None,
-        agentic_identity: Optional[AgenticIdentity] = None,
+        agent_user: Optional[AgentUser] = None,
     ) -> None:
         """Initialize the unified Teams API client.
 
@@ -63,7 +63,7 @@ class ApiClient(BaseClient):
             raise ValueError("Cannot use both an auth provider and an HTTP client token.")
 
         self._auth_provider = auth_provider
-        self._default_agentic_identity = agentic_identity
+        self._default_agent_user = agent_user
         self._apply_auth_provider_token()
 
         # Initialize all client types
@@ -102,19 +102,19 @@ class ApiClient(BaseClient):
         self,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentityScope = None,
+        agent_user: AgentUserScope = None,
     ) -> "ApiClient":
         """Create a scoped API client.
 
-        Omitting agentic_identity, or passing None, preserves the existing scoped identity.
-        Pass AGENTIC_IDENTITY_CLEAR to clear it, or an AgenticIdentity to override it.
+        Omitting agent_user, or passing None, preserves the existing scoped identity.
+        Pass AGENT_USER_CLEAR to clear it, or an AgentUser to override it.
         """
-        if agentic_identity is None:
-            resolved_agentic_identity = self._default_agentic_identity
-        elif agentic_identity == AGENTIC_IDENTITY_CLEAR:
-            resolved_agentic_identity = None
+        if agent_user is None:
+            resolved_agent_user = self._default_agent_user
+        elif agent_user == AGENT_USER_CLEAR:
+            resolved_agent_user = None
         else:
-            resolved_agentic_identity = agentic_identity
+            resolved_agent_user = agent_user
         http = self._http.clone(share_http=True)
         if self._auth_provider is not None:
             http.token = None
@@ -125,34 +125,34 @@ class ApiClient(BaseClient):
             self._api_client_settings,
             cloud=self._cloud,
             auth_provider=self._auth_provider,
-            agentic_identity=resolved_agentic_identity,
+            agent_user=resolved_agent_user,
         )
 
     def from_service_url(self, service_url: str) -> "ApiClient":
         """Create a scoped API client for a different Teams service URL."""
         return self.clone(service_url=service_url)
 
-    def from_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
-        """Create a scoped API client for an agentic identity."""
-        return self.clone(agentic_identity=agentic_identity)
+    def from_agent_user(self, agent_user: AgentUser) -> "ApiClient":
+        """Create a scoped API client for an agent user."""
+        return self.clone(agent_user=agent_user)
 
-    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
-        """Alias for from_agentic_identity."""
-        return self.from_agentic_identity(agentic_identity)
+    def for_agent_user(self, agent_user: AgentUser) -> "ApiClient":
+        """Alias for from_agent_user."""
+        return self.from_agent_user(agent_user)
 
     def _scope_conversations(
         self,
         service_url: str | None,
-        agentic_identity: AgenticIdentity | None,
+        agent_user: AgentUser | None,
     ) -> ConversationClient:
-        return self.clone(service_url=service_url, agentic_identity=agentic_identity).conversations
+        return self.clone(service_url=service_url, agent_user=agent_user).conversations
 
-    def _get_scoped_http(self, agentic_identity: AgenticIdentity | None) -> HttpClient:
+    def _get_scoped_http(self, agent_user: AgentUser | None) -> HttpClient:
         if self._auth_provider is None:
             return self._http.clone(share_http=True)
 
         return self._http.clone(
-            ClientOptions(token=self._create_auth_provider_token(agentic_identity)),
+            ClientOptions(token=self._create_auth_provider_token(agent_user)),
             share_http=True,
         )
 
@@ -160,9 +160,9 @@ class ApiClient(BaseClient):
         if self._auth_provider is None:
             return
 
-        self._http = self._get_scoped_http(self._default_agentic_identity)
+        self._http = self._get_scoped_http(self._default_agent_user)
 
-    def _create_auth_provider_token(self, agentic_identity: AgenticIdentity | None) -> Token:
+    def _create_auth_provider_token(self, agent_user: AgentUser | None) -> Token:
         auth_provider = self._auth_provider
         if auth_provider is None:
             return None
@@ -174,10 +174,10 @@ class ApiClient(BaseClient):
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
-                flow = API_AUTH_FLOWS.agentic if agentic_identity is not None else API_AUTH_FLOWS.app_only
+                flow = API_AUTH_FLOWS.agent_user if agent_user is not None else API_AUTH_FLOWS.app_only
                 span.set_attribute(API_ATTRIBUTE_NAMES.auth_flow, flow)
                 try:
-                    token = auth_provider.token(agentic_identity=agentic_identity)
+                    token = auth_provider.token(agent_user=agent_user)
                     if inspect.isawaitable(token):
                         return await token
                     return token

--- a/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
@@ -150,12 +150,12 @@ class BotTokenClient(BaseClient):
         except (TypeError, ValueError):
             return cast(str | Awaitable[str], token_provider(scope, credentials.tenant_id))
 
-        accepts_agent_user = any(
-            parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "agent_user"
+        accepts_agentic_user = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "agentic_user"
             for parameter in parameters
         )
-        if accepts_agent_user:
-            return cast(str | Awaitable[str], token_provider(scope, credentials.tenant_id, agent_user=None))
+        if accepts_agentic_user:
+            return cast(str | Awaitable[str], token_provider(scope, credentials.tenant_id, agentic_user=None))
 
         positional_parameters = [
             parameter

--- a/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/bot/token_client.py
@@ -150,12 +150,12 @@ class BotTokenClient(BaseClient):
         except (TypeError, ValueError):
             return cast(str | Awaitable[str], token_provider(scope, credentials.tenant_id))
 
-        accepts_agentic_identity = any(
-            parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "agentic_identity"
+        accepts_agent_user = any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD or parameter.name == "agent_user"
             for parameter in parameters
         )
-        if accepts_agentic_identity:
-            return cast(str | Awaitable[str], token_provider(scope, credentials.tenant_id, agentic_identity=None))
+        if accepts_agent_user:
+            return cast(str | Awaitable[str], token_provider(scope, credentials.tenant_id, agent_user=None))
 
         positional_parameters = [
             parameter

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -17,12 +17,12 @@ from ...diagnostics._constants import (
     API_OUTBOUND_OPERATIONS,
 )
 from ...diagnostics._outbound import ApiOutboundResponseHook, ApiOutboundTelemetryMetadata
-from ...models import AgenticIdentity, TeamsChannelAccount
+from ...models import AgentUser, TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 
 _PLACEHOLDER_ACTIVITY_ID = "DO_NOT_USE_PLACEHOLDER_ID"
-ActivityScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationActivityClient"]
+ActivityScopeFactory = Callable[[str | None, AgentUser | None], "ConversationActivityClient"]
 logger = logging.getLogger(__name__)
 
 
@@ -53,11 +53,11 @@ class ConversationActivityClient(BaseClient):
     def _scoped_client(
         self,
         service_url: str | None,
-        agentic_identity: AgenticIdentity | None,
+        agent_user: AgentUser | None,
     ) -> "ConversationActivityClient":
-        if (service_url is None and agentic_identity is None) or self._scope_factory is None:
+        if (service_url is None and agent_user is None) or self._scope_factory is None:
             return self
-        return self._scope_factory(service_url, agentic_identity)
+        return self._scope_factory(service_url, agent_user)
 
     async def create(
         self,
@@ -65,7 +65,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """
         Create a new activity in a conversation.
@@ -79,7 +79,7 @@ class ConversationActivityClient(BaseClient):
         """
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.create(conversation_id, activity)
 
@@ -109,7 +109,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """
         Update an existing activity in a conversation.
@@ -123,7 +123,7 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.update(conversation_id, activity_id, activity)
 
@@ -149,7 +149,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """
         Reply to an activity in a conversation.
@@ -163,7 +163,7 @@ class ConversationActivityClient(BaseClient):
             The created reply activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.reply(conversation_id, activity_id, activity)
 
@@ -190,7 +190,7 @@ class ConversationActivityClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> None:
         """
         Delete an activity from a conversation.
@@ -199,7 +199,7 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.delete(conversation_id, activity_id)
 
@@ -219,7 +219,7 @@ class ConversationActivityClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> List[TeamsChannelAccount]:
         """
         Get the members associated with an activity.
@@ -232,7 +232,7 @@ class ConversationActivityClient(BaseClient):
             List of TeamsChannelAccount objects representing the activity members
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.get_members(conversation_id, activity_id)
 
@@ -248,7 +248,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """
         Create a new targeted activity in a conversation.
@@ -267,7 +267,7 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.create_targeted(conversation_id, activity)
 
@@ -294,7 +294,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """
         Update an existing targeted activity in a conversation.
@@ -312,7 +312,7 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.update_targeted(conversation_id, activity_id, activity)
 
@@ -338,7 +338,7 @@ class ConversationActivityClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> None:
         """
         Delete a targeted activity from a conversation.
@@ -352,7 +352,7 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.delete_targeted(conversation_id, activity_id)
 

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -17,12 +17,12 @@ from ...diagnostics._constants import (
     API_OUTBOUND_OPERATIONS,
 )
 from ...diagnostics._outbound import ApiOutboundResponseHook, ApiOutboundTelemetryMetadata
-from ...models import AgentUser, TeamsChannelAccount
+from ...models import AgenticUser, TeamsChannelAccount
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
 
 _PLACEHOLDER_ACTIVITY_ID = "DO_NOT_USE_PLACEHOLDER_ID"
-ActivityScopeFactory = Callable[[str | None, AgentUser | None], "ConversationActivityClient"]
+ActivityScopeFactory = Callable[[str | None, AgenticUser | None], "ConversationActivityClient"]
 logger = logging.getLogger(__name__)
 
 
@@ -53,11 +53,11 @@ class ConversationActivityClient(BaseClient):
     def _scoped_client(
         self,
         service_url: str | None,
-        agent_user: AgentUser | None,
+        agentic_user: AgenticUser | None,
     ) -> "ConversationActivityClient":
-        if (service_url is None and agent_user is None) or self._scope_factory is None:
+        if (service_url is None and agentic_user is None) or self._scope_factory is None:
             return self
-        return self._scope_factory(service_url, agent_user)
+        return self._scope_factory(service_url, agentic_user)
 
     async def create(
         self,
@@ -65,7 +65,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """
         Create a new activity in a conversation.
@@ -79,7 +79,7 @@ class ConversationActivityClient(BaseClient):
         """
 
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.create(conversation_id, activity)
 
@@ -109,7 +109,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """
         Update an existing activity in a conversation.
@@ -123,7 +123,7 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.update(conversation_id, activity_id, activity)
 
@@ -149,7 +149,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """
         Reply to an activity in a conversation.
@@ -163,7 +163,7 @@ class ConversationActivityClient(BaseClient):
             The created reply activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.reply(conversation_id, activity_id, activity)
 
@@ -190,7 +190,7 @@ class ConversationActivityClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> None:
         """
         Delete an activity from a conversation.
@@ -199,7 +199,7 @@ class ConversationActivityClient(BaseClient):
             conversation_id: The ID of the conversation
             activity_id: The ID of the activity to delete
         """
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.delete(conversation_id, activity_id)
 
@@ -219,7 +219,7 @@ class ConversationActivityClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> List[TeamsChannelAccount]:
         """
         Get the members associated with an activity.
@@ -232,7 +232,7 @@ class ConversationActivityClient(BaseClient):
             List of TeamsChannelAccount objects representing the activity members
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.get_members(conversation_id, activity_id)
 
@@ -248,7 +248,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """
         Create a new targeted activity in a conversation.
@@ -267,7 +267,7 @@ class ConversationActivityClient(BaseClient):
             The created activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.create_targeted(conversation_id, activity)
 
@@ -294,7 +294,7 @@ class ConversationActivityClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """
         Update an existing targeted activity in a conversation.
@@ -312,7 +312,7 @@ class ConversationActivityClient(BaseClient):
             The updated activity
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.update_targeted(conversation_id, activity_id, activity)
 
@@ -338,7 +338,7 @@ class ConversationActivityClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> None:
         """
         Delete a targeted activity from a conversation.
@@ -352,7 +352,7 @@ class ConversationActivityClient(BaseClient):
             activity_id: The ID of the activity to delete
         """
         # TODO: Will be deprecated alongside accessor in ConversationClient
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.delete_targeted(conversation_id, activity_id)
 

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -10,7 +10,7 @@ from typing_extensions import deprecated
 
 from ...activities import SentActivity
 from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
-from ...models import AgentUser, ConversationResource, TeamsChannelAccount
+from ...models import AgenticUser, ConversationResource, TeamsChannelAccount
 from ...models.message import MessageReactionType
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -19,7 +19,7 @@ from .activity import ActivityParams, ConversationActivityClient
 from .member import ConversationMemberClient
 from .params import CreateConversationParams
 
-ConversationScopeFactory = Callable[[str | None, AgentUser | None], "ConversationClient"]
+ConversationScopeFactory = Callable[[str | None, AgenticUser | None], "ConversationClient"]
 
 
 class ConversationOperations:
@@ -38,13 +38,13 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         return await self._client.create_activity(
             self._conversation_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def update(
@@ -53,14 +53,14 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         return await self._client.update_activity(
             self._conversation_id,
             activity_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def reply(
@@ -69,14 +69,14 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         return await self._client.reply_to_activity(
             self._conversation_id,
             activity_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def delete(
@@ -84,13 +84,13 @@ class ActivityOperations(ConversationOperations):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> None:
         await self._client.delete_activity(
             self._conversation_id,
             activity_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def get_members(
@@ -98,13 +98,13 @@ class ActivityOperations(ConversationOperations):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> list[TeamsChannelAccount]:
         return await self._client.get_activity_members(
             self._conversation_id,
             activity_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def create_targeted(
@@ -112,14 +112,14 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Create a new targeted activity visible only to the specified recipient."""
         return await self._client.create_targeted_activity(
             self._conversation_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def update_targeted(
@@ -128,7 +128,7 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Update an existing targeted activity."""
         return await self._client.update_targeted_activity(
@@ -136,7 +136,7 @@ class ActivityOperations(ConversationOperations):
             activity_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def delete_targeted(
@@ -144,14 +144,14 @@ class ActivityOperations(ConversationOperations):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> None:
         """Delete a targeted activity."""
         await self._client.delete_targeted_activity(
             self._conversation_id,
             activity_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
 
@@ -201,8 +201,8 @@ class ConversationClient(BaseClient):
             self.service_url,
             self.http,
             self._api_client_settings,
-            scope_factory=lambda service_url, agent_user: self._scoped_client(
-                service_url, agent_user
+            scope_factory=lambda service_url, agentic_user: self._scoped_client(
+                service_url, agentic_user
             ).activities_client,
         )
         self._members_client = ConversationMemberClient(
@@ -271,11 +271,11 @@ class ConversationClient(BaseClient):
     def _scoped_client(
         self,
         service_url: str | None,
-        agent_user: AgentUser | None,
+        agentic_user: AgenticUser | None,
     ) -> "ConversationClient":
-        if (service_url is None and agent_user is None) or self._scope_factory is None:
+        if (service_url is None and agentic_user is None) or self._scope_factory is None:
             return self
-        return self._scope_factory(service_url, agent_user)
+        return self._scope_factory(service_url, agentic_user)
 
     async def create_activity(
         self,
@@ -283,17 +283,17 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Create an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.create_activity(conversation_id, activity)
         return await self._activities_client.create(
             conversation_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def update_activity(
@@ -303,10 +303,10 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Update an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.update_activity(conversation_id, activity_id, activity)
         return await self._activities_client.update(
@@ -314,7 +314,7 @@ class ConversationClient(BaseClient):
             activity_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def reply_to_activity(
@@ -324,10 +324,10 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Reply to an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.reply_to_activity(conversation_id, activity_id, activity)
         return await self._activities_client.reply(
@@ -335,7 +335,7 @@ class ConversationClient(BaseClient):
             activity_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def delete_activity(
@@ -344,17 +344,17 @@ class ConversationClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> None:
         """Delete an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.delete_activity(conversation_id, activity_id)
         return await self._activities_client.delete(
             conversation_id,
             activity_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def get_activity_members(
@@ -363,17 +363,17 @@ class ConversationClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> list[TeamsChannelAccount]:
         """Get the members of an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.get_activity_members(conversation_id, activity_id)
         return await self._activities_client.get_members(
             conversation_id,
             activity_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def create_targeted_activity(
@@ -382,17 +382,17 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Create a targeted activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.create_targeted_activity(conversation_id, activity)
         return await self._activities_client.create_targeted(
             conversation_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def update_targeted_activity(
@@ -402,10 +402,10 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> SentActivity:
         """Update a targeted activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.update_targeted_activity(conversation_id, activity_id, activity)
         return await self._activities_client.update_targeted(
@@ -413,7 +413,7 @@ class ConversationClient(BaseClient):
             activity_id,
             activity,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def delete_targeted_activity(
@@ -422,17 +422,17 @@ class ConversationClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> None:
         """Delete a targeted activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agent_user)
+        scoped_client = self._scoped_client(service_url, agentic_user)
         if scoped_client is not self:
             return await scoped_client.delete_targeted_activity(conversation_id, activity_id)
         return await self._activities_client.delete_targeted(
             conversation_id,
             activity_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     async def get_members(self, conversation_id: str):

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -10,7 +10,7 @@ from typing_extensions import deprecated
 
 from ...activities import SentActivity
 from ...diagnostics._outbound import ensure_outbound_telemetry_middleware
-from ...models import AgenticIdentity, ConversationResource, TeamsChannelAccount
+from ...models import AgentUser, ConversationResource, TeamsChannelAccount
 from ...models.message import MessageReactionType
 from ..api_client_settings import ApiClientSettings
 from ..base_client import BaseClient
@@ -19,7 +19,7 @@ from .activity import ActivityParams, ConversationActivityClient
 from .member import ConversationMemberClient
 from .params import CreateConversationParams
 
-ConversationScopeFactory = Callable[[str | None, AgenticIdentity | None], "ConversationClient"]
+ConversationScopeFactory = Callable[[str | None, AgentUser | None], "ConversationClient"]
 
 
 class ConversationOperations:
@@ -38,13 +38,13 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         return await self._client.create_activity(
             self._conversation_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def update(
@@ -53,14 +53,14 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         return await self._client.update_activity(
             self._conversation_id,
             activity_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def reply(
@@ -69,14 +69,14 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         return await self._client.reply_to_activity(
             self._conversation_id,
             activity_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def delete(
@@ -84,13 +84,13 @@ class ActivityOperations(ConversationOperations):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> None:
         await self._client.delete_activity(
             self._conversation_id,
             activity_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def get_members(
@@ -98,13 +98,13 @@ class ActivityOperations(ConversationOperations):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> list[TeamsChannelAccount]:
         return await self._client.get_activity_members(
             self._conversation_id,
             activity_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def create_targeted(
@@ -112,14 +112,14 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Create a new targeted activity visible only to the specified recipient."""
         return await self._client.create_targeted_activity(
             self._conversation_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def update_targeted(
@@ -128,7 +128,7 @@ class ActivityOperations(ConversationOperations):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Update an existing targeted activity."""
         return await self._client.update_targeted_activity(
@@ -136,7 +136,7 @@ class ActivityOperations(ConversationOperations):
             activity_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def delete_targeted(
@@ -144,14 +144,14 @@ class ActivityOperations(ConversationOperations):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> None:
         """Delete a targeted activity."""
         await self._client.delete_targeted_activity(
             self._conversation_id,
             activity_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
 
@@ -201,8 +201,8 @@ class ConversationClient(BaseClient):
             self.service_url,
             self.http,
             self._api_client_settings,
-            scope_factory=lambda service_url, agentic_identity: self._scoped_client(
-                service_url, agentic_identity
+            scope_factory=lambda service_url, agent_user: self._scoped_client(
+                service_url, agent_user
             ).activities_client,
         )
         self._members_client = ConversationMemberClient(
@@ -271,11 +271,11 @@ class ConversationClient(BaseClient):
     def _scoped_client(
         self,
         service_url: str | None,
-        agentic_identity: AgenticIdentity | None,
+        agent_user: AgentUser | None,
     ) -> "ConversationClient":
-        if (service_url is None and agentic_identity is None) or self._scope_factory is None:
+        if (service_url is None and agent_user is None) or self._scope_factory is None:
             return self
-        return self._scope_factory(service_url, agentic_identity)
+        return self._scope_factory(service_url, agent_user)
 
     async def create_activity(
         self,
@@ -283,17 +283,17 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Create an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.create_activity(conversation_id, activity)
         return await self._activities_client.create(
             conversation_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def update_activity(
@@ -303,10 +303,10 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Update an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.update_activity(conversation_id, activity_id, activity)
         return await self._activities_client.update(
@@ -314,7 +314,7 @@ class ConversationClient(BaseClient):
             activity_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def reply_to_activity(
@@ -324,10 +324,10 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Reply to an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.reply_to_activity(conversation_id, activity_id, activity)
         return await self._activities_client.reply(
@@ -335,7 +335,7 @@ class ConversationClient(BaseClient):
             activity_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def delete_activity(
@@ -344,17 +344,17 @@ class ConversationClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> None:
         """Delete an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.delete_activity(conversation_id, activity_id)
         return await self._activities_client.delete(
             conversation_id,
             activity_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def get_activity_members(
@@ -363,17 +363,17 @@ class ConversationClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> list[TeamsChannelAccount]:
         """Get the members of an activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.get_activity_members(conversation_id, activity_id)
         return await self._activities_client.get_members(
             conversation_id,
             activity_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def create_targeted_activity(
@@ -382,17 +382,17 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Create a targeted activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.create_targeted_activity(conversation_id, activity)
         return await self._activities_client.create_targeted(
             conversation_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def update_targeted_activity(
@@ -402,10 +402,10 @@ class ConversationClient(BaseClient):
         activity: ActivityParams,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> SentActivity:
         """Update a targeted activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.update_targeted_activity(conversation_id, activity_id, activity)
         return await self._activities_client.update_targeted(
@@ -413,7 +413,7 @@ class ConversationClient(BaseClient):
             activity_id,
             activity,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def delete_targeted_activity(
@@ -422,17 +422,17 @@ class ConversationClient(BaseClient):
         activity_id: str,
         *,
         service_url: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> None:
         """Delete a targeted activity in a conversation."""
-        scoped_client = self._scoped_client(service_url, agentic_identity)
+        scoped_client = self._scoped_client(service_url, agent_user)
         if scoped_client is not self:
             return await scoped_client.delete_targeted_activity(conversation_id, activity_id)
         return await self._activities_client.delete_targeted(
             conversation_id,
             activity_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     async def get_members(self, conversation_id: str):

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -18,7 +18,7 @@ class _ApiAttributeNames:
 
 @dataclass(frozen=True)
 class _ApiAuthFlows:
-    agent_user: str = "agent_user"
+    agentic_user: str = "agentic_user"
     app_only: str = "app_only"
 
 

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -18,7 +18,7 @@ class _ApiAttributeNames:
 
 @dataclass(frozen=True)
 class _ApiAuthFlows:
-    agentic: str = "agentic"
+    agent_user: str = "agent_user"
     app_only: str = "app_only"
 
 

--- a/packages/api/src/microsoft_teams/api/models/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/__init__.py
@@ -27,7 +27,7 @@ from .action import Action
 from .activity import Activity as ActivityBase
 from .activity import ActivityInput as ActivityInputBase
 from .adaptive_card import *  # noqa: F403
-from .agent_user import AgentUser
+from .agentic_user import AgenticUser
 from .app_based_link_query import AppBasedLinkQuery
 from .attachment import *  # noqa: F403
 from .cache_info import CacheInfo
@@ -76,7 +76,7 @@ __all__: list[str] = [
     "Action",
     "ActivityBase",
     "ActivityInputBase",
-    "AgentUser",
+    "AgenticUser",
     "AppBasedLinkQuery",
     "CacheInfo",
     "ChannelID",

--- a/packages/api/src/microsoft_teams/api/models/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/__init__.py
@@ -27,7 +27,7 @@ from .action import Action
 from .activity import Activity as ActivityBase
 from .activity import ActivityInput as ActivityInputBase
 from .adaptive_card import *  # noqa: F403
-from .agentic_identity import AgenticIdentity
+from .agent_user import AgentUser
 from .app_based_link_query import AppBasedLinkQuery
 from .attachment import *  # noqa: F403
 from .cache_info import CacheInfo
@@ -76,7 +76,7 @@ __all__: list[str] = [
     "Action",
     "ActivityBase",
     "ActivityInputBase",
-    "AgenticIdentity",
+    "AgentUser",
     "AppBasedLinkQuery",
     "CacheInfo",
     "ChannelID",

--- a/packages/api/src/microsoft_teams/api/models/account.py
+++ b/packages/api/src/microsoft_teams/api/models/account.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional
 
 from pydantic import AliasChoices, Field
 
-from .agentic_identity import AgenticIdentity
+from .agent_user import AgentUser
 from .custom_base_model import CustomBaseModel
 
 AccountType = Literal["person", "tag", "channel", "team", "bot"]
@@ -56,27 +56,39 @@ class Account(CustomBaseModel):
     """
     role: Optional[AccountRole | str] = None
     """The role of the account in the activity."""
-    agentic_user_id: Optional[str] = None
+    agent_user_id: Optional[str] = Field(
+        default=None,
+        validation_alias="agenticUserId",
+        serialization_alias="agenticUserId",
+    )
     """The Agent ID user-shaped identity object ID."""
-    agentic_app_id: Optional[str] = None
-    """The Agent ID app/client ID for the concrete agent identity."""
-    agentic_app_blueprint_id: Optional[str] = None
-    """The Agent ID blueprint app/client ID."""
+    agent_app_instance_id: Optional[str] = Field(
+        default=None,
+        validation_alias="agenticAppId",
+        serialization_alias="agenticAppId",
+    )
+    """The AgentAppInstance app/client ID."""
+    agent_identity_blueprint_id: Optional[str] = Field(
+        default=None,
+        validation_alias="agenticAppBlueprintId",
+        serialization_alias="agenticAppBlueprintId",
+    )
+    """The AgentIdentityBlueprint app/client ID."""
     callback_uri: Optional[str] = None
-    """The callback URI associated with the agent identity."""
+    """The callback URI associated with the agent user."""
     tenant_id: Optional[str] = None
     """The tenant ID associated with the account."""
 
     @property
-    def agentic_identity(self) -> Optional[AgenticIdentity]:
-        if self.agentic_app_id is None or self.agentic_user_id is None:
+    def agent_user(self) -> Optional[AgentUser]:
+        if self.agent_app_instance_id is None or self.agent_user_id is None:
             return None
 
-        return AgenticIdentity(
-            agentic_app_id=self.agentic_app_id,
-            agentic_user_id=self.agentic_user_id,
+        return AgentUser(
+            agent_app_instance_id=self.agent_app_instance_id,
+            agent_user_id=self.agent_user_id,
             tenant_id=self.tenant_id,
-            agentic_app_blueprint_id=self.agentic_app_blueprint_id,
+            agent_identity_blueprint_id=self.agent_identity_blueprint_id,
         )
 
 

--- a/packages/api/src/microsoft_teams/api/models/account.py
+++ b/packages/api/src/microsoft_teams/api/models/account.py
@@ -62,18 +62,18 @@ class Account(CustomBaseModel):
         serialization_alias="agenticUserId",
     )
     """The Agent ID user-shaped identity object ID."""
-    agent_app_instance_id: Optional[str] = Field(
+    agentic_app_instance_id: Optional[str] = Field(
         default=None,
         validation_alias="agenticAppId",
         serialization_alias="agenticAppId",
     )
-    """The AgentAppInstance app/client ID."""
-    agent_identity_blueprint_id: Optional[str] = Field(
+    """The AgenticAppInstance app/client ID."""
+    agentic_blueprint_id: Optional[str] = Field(
         default=None,
         validation_alias="agenticAppBlueprintId",
         serialization_alias="agenticAppBlueprintId",
     )
-    """The AgentIdentityBlueprint app/client ID."""
+    """The AgenticBlueprint app/client ID."""
     callback_uri: Optional[str] = None
     """The callback URI associated with the agentic user."""
     tenant_id: Optional[str] = None
@@ -81,14 +81,14 @@ class Account(CustomBaseModel):
 
     @property
     def agentic_user(self) -> Optional[AgenticUser]:
-        if self.agent_app_instance_id is None or self.agentic_user_id is None:
+        if self.agentic_app_instance_id is None or self.agentic_user_id is None:
             return None
 
         return AgenticUser(
-            agent_app_instance_id=self.agent_app_instance_id,
+            agentic_app_instance_id=self.agentic_app_instance_id,
             agentic_user_id=self.agentic_user_id,
             tenant_id=self.tenant_id,
-            agent_identity_blueprint_id=self.agent_identity_blueprint_id,
+            agentic_blueprint_id=self.agentic_blueprint_id,
         )
 
 

--- a/packages/api/src/microsoft_teams/api/models/account.py
+++ b/packages/api/src/microsoft_teams/api/models/account.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional
 
 from pydantic import AliasChoices, Field
 
-from .agent_user import AgentUser
+from .agentic_user import AgenticUser
 from .custom_base_model import CustomBaseModel
 
 AccountType = Literal["person", "tag", "channel", "team", "bot"]
@@ -56,7 +56,7 @@ class Account(CustomBaseModel):
     """
     role: Optional[AccountRole | str] = None
     """The role of the account in the activity."""
-    agent_user_id: Optional[str] = Field(
+    agentic_user_id: Optional[str] = Field(
         default=None,
         validation_alias="agenticUserId",
         serialization_alias="agenticUserId",
@@ -75,18 +75,18 @@ class Account(CustomBaseModel):
     )
     """The AgentIdentityBlueprint app/client ID."""
     callback_uri: Optional[str] = None
-    """The callback URI associated with the agent user."""
+    """The callback URI associated with the agentic user."""
     tenant_id: Optional[str] = None
     """The tenant ID associated with the account."""
 
     @property
-    def agent_user(self) -> Optional[AgentUser]:
-        if self.agent_app_instance_id is None or self.agent_user_id is None:
+    def agentic_user(self) -> Optional[AgenticUser]:
+        if self.agent_app_instance_id is None or self.agentic_user_id is None:
             return None
 
-        return AgentUser(
+        return AgenticUser(
             agent_app_instance_id=self.agent_app_instance_id,
-            agent_user_id=self.agent_user_id,
+            agentic_user_id=self.agentic_user_id,
             tenant_id=self.tenant_id,
             agent_identity_blueprint_id=self.agent_identity_blueprint_id,
         )

--- a/packages/api/src/microsoft_teams/api/models/agent_user.py
+++ b/packages/api/src/microsoft_teams/api/models/agent_user.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class AgenticIdentity:
+class AgentUser:
     """Identifies an Agent ID user-shaped identity and its backing agent app."""
 
-    agentic_app_id: str
-    agentic_user_id: str
+    agent_app_instance_id: str
+    agent_user_id: str
     tenant_id: str | None = None
-    agentic_app_blueprint_id: str | None = None
+    agent_identity_blueprint_id: str | None = None
 
 
-__all__ = ["AgenticIdentity"]
+__all__ = ["AgentUser"]

--- a/packages/api/src/microsoft_teams/api/models/agentic_user.py
+++ b/packages/api/src/microsoft_teams/api/models/agentic_user.py
@@ -10,10 +10,10 @@ from dataclasses import dataclass
 class AgenticUser:
     """Identifies an Agent ID user-shaped identity and its backing agent app."""
 
-    agent_app_instance_id: str
+    agentic_app_instance_id: str
     agentic_user_id: str
     tenant_id: str | None = None
-    agent_identity_blueprint_id: str | None = None
+    agentic_blueprint_id: str | None = None
 
 
 __all__ = ["AgenticUser"]

--- a/packages/api/src/microsoft_teams/api/models/agentic_user.py
+++ b/packages/api/src/microsoft_teams/api/models/agentic_user.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class AgentUser:
+class AgenticUser:
     """Identifies an Agent ID user-shaped identity and its backing agent app."""
 
     agent_app_instance_id: str
-    agent_user_id: str
+    agentic_user_id: str
     tenant_id: str | None = None
     agent_identity_blueprint_id: str | None = None
 
 
-__all__ = ["AgentUser"]
+__all__ = ["AgenticUser"]

--- a/packages/api/tests/unit/test_agent_lifecycle_event.py
+++ b/packages/api/tests/unit/test_agent_lifecycle_event.py
@@ -23,7 +23,7 @@ from microsoft_teams.api.activities.event.agent_lifecycle import (
 TENANT_ID = "00000000-0000-0000-0000-000000000001"
 AGENTIC_USER_ID = "00000000-0000-0000-0000-000000000002"
 APP_ID = "00000000-0000-0000-0000-000000000003"
-AGENTIC_APP_INSTANCE_ID = "00000000-0000-0000-0000-000000000004"
+AGENT_APP_INSTANCE_ID = "00000000-0000-0000-0000-000000000004"
 BLUEPRINT_ID = "00000000-0000-0000-0000-000000000005"
 
 
@@ -56,7 +56,7 @@ def _common(event_type: str) -> Dict[str, Any]:
     return {
         "tenantId": TENANT_ID,
         "agenticUserId": AGENTIC_USER_ID,
-        "agenticAppInstanceId": AGENTIC_APP_INSTANCE_ID,
+        "agenticAppInstanceId": AGENT_APP_INSTANCE_ID,
         "agentIdentityBlueprintId": BLUEPRINT_ID,
         "eventType": event_type,
     }
@@ -79,7 +79,7 @@ class TestAgentLifecycleEventParsing:
         assert isinstance(activity, AgenticUserIdentityCreatedActivity)
         assert activity.name == "agentLifecycle"
         assert activity.value_type == "AgenticUserIdentityCreated"
-        assert activity.value.agentic_user_id == AGENTIC_USER_ID
+        assert activity.value.agent_user_id == AGENTIC_USER_ID
         assert activity.value.manager is not None
         assert activity.value.manager.user_id == "3c22b565-74f3-48b0-aa18-1dc03b8ec270"
         assert activity.value.manager.email == "manager@example.test"
@@ -167,5 +167,5 @@ class TestAgentLifecycleEventParsing:
 
         assert dumped["name"] == "agentLifecycle"
         assert dumped["valueType"] == "AgenticUserManagerUpdated"
-        assert dumped["value"]["agenticAppInstanceId"] == AGENTIC_APP_INSTANCE_ID
+        assert dumped["value"]["agenticAppInstanceId"] == AGENT_APP_INSTANCE_ID
         assert dumped["value"]["manager"]["managerId"] == "3c22b565-74f3-48b0-aa18-1dc03b8ec270"

--- a/packages/api/tests/unit/test_agent_lifecycle_event.py
+++ b/packages/api/tests/unit/test_agent_lifecycle_event.py
@@ -23,7 +23,7 @@ from microsoft_teams.api.activities.event.agent_lifecycle import (
 TENANT_ID = "00000000-0000-0000-0000-000000000001"
 AGENTIC_USER_ID = "00000000-0000-0000-0000-000000000002"
 APP_ID = "00000000-0000-0000-0000-000000000003"
-AGENT_APP_INSTANCE_ID = "00000000-0000-0000-0000-000000000004"
+AGENTIC_APP_INSTANCE_ID = "00000000-0000-0000-0000-000000000004"
 BLUEPRINT_ID = "00000000-0000-0000-0000-000000000005"
 
 
@@ -56,7 +56,7 @@ def _common(event_type: str) -> Dict[str, Any]:
     return {
         "tenantId": TENANT_ID,
         "agenticUserId": AGENTIC_USER_ID,
-        "agenticAppInstanceId": AGENT_APP_INSTANCE_ID,
+        "agenticAppInstanceId": AGENTIC_APP_INSTANCE_ID,
         "agentIdentityBlueprintId": BLUEPRINT_ID,
         "eventType": event_type,
     }
@@ -80,6 +80,7 @@ class TestAgentLifecycleEventParsing:
         assert activity.name == "agentLifecycle"
         assert activity.value_type == "AgenticUserIdentityCreated"
         assert activity.value.agentic_user_id == AGENTIC_USER_ID
+        assert activity.value.agentic_blueprint_id == BLUEPRINT_ID
         assert activity.value.manager is not None
         assert activity.value.manager.user_id == "3c22b565-74f3-48b0-aa18-1dc03b8ec270"
         assert activity.value.manager.email == "manager@example.test"
@@ -167,5 +168,6 @@ class TestAgentLifecycleEventParsing:
 
         assert dumped["name"] == "agentLifecycle"
         assert dumped["valueType"] == "AgenticUserManagerUpdated"
-        assert dumped["value"]["agenticAppInstanceId"] == AGENT_APP_INSTANCE_ID
+        assert dumped["value"]["agenticAppInstanceId"] == AGENTIC_APP_INSTANCE_ID
+        assert dumped["value"]["agentIdentityBlueprintId"] == BLUEPRINT_ID
         assert dumped["value"]["manager"]["managerId"] == "3c22b565-74f3-48b0-aa18-1dc03b8ec270"

--- a/packages/api/tests/unit/test_agent_lifecycle_event.py
+++ b/packages/api/tests/unit/test_agent_lifecycle_event.py
@@ -79,7 +79,7 @@ class TestAgentLifecycleEventParsing:
         assert isinstance(activity, AgenticUserIdentityCreatedActivity)
         assert activity.name == "agentLifecycle"
         assert activity.value_type == "AgenticUserIdentityCreated"
-        assert activity.value.agent_user_id == AGENTIC_USER_ID
+        assert activity.value.agentic_user_id == AGENTIC_USER_ID
         assert activity.value.manager is not None
         assert activity.value.manager.user_id == "3c22b565-74f3-48b0-aa18-1dc03b8ec270"
         assert activity.value.manager.email == "manager@example.test"

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -28,7 +28,7 @@ class TestApiClientReactionsProperty:
 
     def test_reactions_inherits_agentic_user_auth_defaults(self, mock_http_client):
         """Test reactions inherits agentic user auth defaults from ApiClient."""
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
 
         class TestAuthProvider:
             def token(self, *, scope=None, agentic_user=None):
@@ -126,7 +126,7 @@ class TestApiClientDeprecatedAccessors:
 @pytest.mark.unit
 class TestApiClientScoping:
     def test_clone_preserves_defaults_when_omitted(self, mock_http_client):
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient("https://mock.service.url", mock_http_client, agentic_user=identity)
 
         clone = client.clone()
@@ -141,7 +141,7 @@ class TestApiClientScoping:
             def token(self, *, scope=None, agentic_user=None):
                 return "agentic-user-token"
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
@@ -176,7 +176,7 @@ class TestApiClientScoping:
         assert clone._default_agentic_user is override_identity
 
     def test_clone_preserves_agentic_user_with_explicit_none(self, mock_http_client):
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient("https://mock.service.url", mock_http_client, agentic_user=identity)
 
         clone = client.clone(agentic_user=None)
@@ -184,7 +184,7 @@ class TestApiClientScoping:
         assert clone._default_agentic_user is identity
 
     def test_clone_can_override_service_url_and_clear_agentic_user(self, mock_http_client):
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient("https://mock.service.url", mock_http_client, agentic_user=identity)
 
         clone = client.clone(service_url="https://override.service.url/", agentic_user=AGENTIC_USER_CLEAR)
@@ -193,7 +193,7 @@ class TestApiClientScoping:
         assert clone._default_agentic_user is None
 
     def test_scoped_helpers_create_expected_clones(self, mock_http_client):
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient("https://mock.service.url", mock_http_client)
 
         service_scoped = client.from_service_url("https://override.service.url/")
@@ -233,8 +233,8 @@ class TestApiClientScoping:
     @pytest.mark.asyncio
     async def test_clone_uses_token_for_each_scoped_agentic_user(self, request_capture, mock_activity):
         calls = []
-        identity_1 = AgenticUser("agent-app-instance-id-1", "agentic-user-id-1", tenant_id="tenant-id")
-        identity_2 = AgenticUser("agent-app-instance-id-2", "agentic-user-id-2", tenant_id="tenant-id")
+        identity_1 = AgenticUser("agentic-app-instance-id-1", "agentic-user-id-1", tenant_id="tenant-id")
+        identity_2 = AgenticUser("agentic-app-instance-id-2", "agentic-user-id-2", tenant_id="tenant-id")
 
         class TestAuthProvider:
             def token(self, *, scope=None, agentic_user=None):
@@ -263,8 +263,8 @@ class TestApiClientScoping:
     @pytest.mark.asyncio
     async def test_chained_clone_uses_token_for_new_scoped_agentic_user(self, request_capture, mock_activity):
         calls = []
-        identity_1 = AgenticUser("agent-app-instance-id-1", "agentic-user-id-1", tenant_id="tenant-id")
-        identity_2 = AgenticUser("agent-app-instance-id-2", "agentic-user-id-2", tenant_id="tenant-id")
+        identity_1 = AgenticUser("agentic-app-instance-id-1", "agentic-user-id-1", tenant_id="tenant-id")
+        identity_2 = AgenticUser("agentic-app-instance-id-2", "agentic-user-id-2", tenant_id="tenant-id")
 
         class TestAuthProvider:
             def token(self, *, scope=None, agentic_user=None):
@@ -356,5 +356,5 @@ class TestApiClientScoping:
                 "https://test.service.url",
                 request_capture_with_token,
                 auth_provider=TestAuthProvider(),
-                agentic_user=AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id"),
+                agentic_user=AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id"),
             )

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -7,8 +7,8 @@ Licensed under the MIT License.
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from microsoft_teams.api.clients import AGENT_USER_CLEAR, ApiClient, ReactionClient
-from microsoft_teams.api.models import AgentUser
+from microsoft_teams.api.clients import AGENTIC_USER_CLEAR, ApiClient, ReactionClient
+from microsoft_teams.api.models import AgenticUser
 from microsoft_teams.common.http import Client, ClientOptions
 
 
@@ -26,25 +26,25 @@ class TestApiClientReactionsProperty:
         assert reactions is not None
         assert isinstance(reactions, ReactionClient)
 
-    def test_reactions_inherits_agent_user_auth_defaults(self, mock_http_client):
-        """Test reactions inherits agent user auth defaults from ApiClient."""
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+    def test_reactions_inherits_agentic_user_auth_defaults(self, mock_http_client):
+        """Test reactions inherits agentic user auth defaults from ApiClient."""
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                return "agentic-user-token"
 
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agent_user=identity,
+            agentic_user=identity,
         )
 
         reactions = client.reactions
 
         assert not hasattr(reactions, "_auth_provider")
-        assert not hasattr(reactions, "_agent_user")
+        assert not hasattr(reactions, "_agentic_user")
         assert client.http.token is not None
         assert reactions.http is client.http
 
@@ -126,103 +126,103 @@ class TestApiClientDeprecatedAccessors:
 @pytest.mark.unit
 class TestApiClientScoping:
     def test_clone_preserves_defaults_when_omitted(self, mock_http_client):
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://mock.service.url", mock_http_client, agent_user=identity)
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://mock.service.url", mock_http_client, agentic_user=identity)
 
         clone = client.clone()
 
         assert clone.service_url == "https://mock.service.url"
-        assert clone._default_agent_user is identity
+        assert clone._default_agentic_user is identity
         assert clone._api_client_settings is client._api_client_settings
         assert clone._cloud is client._cloud
 
-    def test_clone_reuses_underlying_http_client_when_agent_user_is_unchanged(self, mock_http_client):
+    def test_clone_reuses_underlying_http_client_when_agentic_user_is_unchanged(self, mock_http_client):
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                return "agentic-user-token"
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agent_user=identity,
+            agentic_user=identity,
         )
 
         clone = client.from_service_url("https://override.service.url")
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
-        assert clone._default_agent_user is identity
+        assert clone._default_agentic_user is identity
 
-    def test_clone_replaces_http_client_when_agent_user_changes(self, mock_http_client):
+    def test_clone_replaces_http_client_when_agentic_user_changes(self, mock_http_client):
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                return "agentic-user-token"
 
-        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
-        override_identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        default_identity = AgenticUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        override_identity = AgenticUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agent_user=default_identity,
+            agentic_user=default_identity,
         )
 
-        clone = client.from_agent_user(override_identity)
+        clone = client.from_agentic_user(override_identity)
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
-        assert clone._default_agent_user is override_identity
+        assert clone._default_agentic_user is override_identity
 
-    def test_clone_preserves_agent_user_with_explicit_none(self, mock_http_client):
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://mock.service.url", mock_http_client, agent_user=identity)
+    def test_clone_preserves_agentic_user_with_explicit_none(self, mock_http_client):
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://mock.service.url", mock_http_client, agentic_user=identity)
 
-        clone = client.clone(agent_user=None)
+        clone = client.clone(agentic_user=None)
 
-        assert clone._default_agent_user is identity
+        assert clone._default_agentic_user is identity
 
-    def test_clone_can_override_service_url_and_clear_agent_user(self, mock_http_client):
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://mock.service.url", mock_http_client, agent_user=identity)
+    def test_clone_can_override_service_url_and_clear_agentic_user(self, mock_http_client):
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://mock.service.url", mock_http_client, agentic_user=identity)
 
-        clone = client.clone(service_url="https://override.service.url/", agent_user=AGENT_USER_CLEAR)
+        clone = client.clone(service_url="https://override.service.url/", agentic_user=AGENTIC_USER_CLEAR)
 
         assert clone.service_url == "https://override.service.url"
-        assert clone._default_agent_user is None
+        assert clone._default_agentic_user is None
 
     def test_scoped_helpers_create_expected_clones(self, mock_http_client):
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient("https://mock.service.url", mock_http_client)
 
         service_scoped = client.from_service_url("https://override.service.url/")
-        identity_scoped = client.from_agent_user(identity)
-        alias_scoped = client.for_agent_user(identity)
+        identity_scoped = client.from_agentic_user(identity)
+        alias_scoped = client.for_agentic_user(identity)
 
         assert service_scoped.service_url == "https://override.service.url"
-        assert identity_scoped._default_agent_user is identity
-        assert alias_scoped._default_agent_user is identity
+        assert identity_scoped._default_agentic_user is identity
+        assert alias_scoped._default_agentic_user is identity
 
     @pytest.mark.asyncio
-    async def test_clone_uses_scoped_agent_user_for_auth(self, request_capture, mock_activity):
+    async def test_clone_uses_scoped_agentic_user_for_auth(self, request_capture, mock_activity):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
-        override_identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        default_identity = AgenticUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        override_identity = AgenticUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agent_user=default_identity,
+            agentic_user=default_identity,
         )
 
-        await client.from_agent_user(override_identity).conversations.create_activity(
+        await client.from_agentic_user(override_identity).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -231,17 +231,17 @@ class TestApiClientScoping:
         assert "authorization" in request.headers
 
     @pytest.mark.asyncio
-    async def test_clone_uses_token_for_each_scoped_agent_user(self, request_capture, mock_activity):
+    async def test_clone_uses_token_for_each_scoped_agentic_user(self, request_capture, mock_activity):
         calls = []
-        identity_1 = AgentUser("agent-app-instance-id-1", "agent-user-id-1", tenant_id="tenant-id")
-        identity_2 = AgentUser("agent-app-instance-id-2", "agent-user-id-2", tenant_id="tenant-id")
+        identity_1 = AgenticUser("agent-app-instance-id-1", "agentic-user-id-1", tenant_id="tenant-id")
+        identity_2 = AgenticUser("agent-app-instance-id-2", "agentic-user-id-2", tenant_id="tenant-id")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                if agent_user is identity_1:
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                if agentic_user is identity_1:
                     return "token-1"
-                if agent_user is identity_2:
+                if agentic_user is identity_2:
                     return "token-2"
                 return "default-token"
 
@@ -251,9 +251,9 @@ class TestApiClientScoping:
             auth_provider=TestAuthProvider(),
         )
 
-        await client.from_agent_user(identity_1).conversations.create_activity("test_conversation_id", mock_activity)
+        await client.from_agentic_user(identity_1).conversations.create_activity("test_conversation_id", mock_activity)
         first_request = request_capture._capture.last_request
-        await client.from_agent_user(identity_2).conversations.create_activity("test_conversation_id", mock_activity)
+        await client.from_agentic_user(identity_2).conversations.create_activity("test_conversation_id", mock_activity)
         second_request = request_capture._capture.last_request
 
         assert calls == [(None, identity_1), (None, identity_2)]
@@ -261,17 +261,17 @@ class TestApiClientScoping:
         assert second_request.headers["authorization"] == "Bearer token-2"
 
     @pytest.mark.asyncio
-    async def test_chained_clone_uses_token_for_new_scoped_agent_user(self, request_capture, mock_activity):
+    async def test_chained_clone_uses_token_for_new_scoped_agentic_user(self, request_capture, mock_activity):
         calls = []
-        identity_1 = AgentUser("agent-app-instance-id-1", "agent-user-id-1", tenant_id="tenant-id")
-        identity_2 = AgentUser("agent-app-instance-id-2", "agent-user-id-2", tenant_id="tenant-id")
+        identity_1 = AgenticUser("agent-app-instance-id-1", "agentic-user-id-1", tenant_id="tenant-id")
+        identity_2 = AgenticUser("agent-app-instance-id-2", "agentic-user-id-2", tenant_id="tenant-id")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                if agent_user is identity_1:
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                if agentic_user is identity_1:
                     return "token-1"
-                if agent_user is identity_2:
+                if agentic_user is identity_2:
                     return "token-2"
                 return "default-token"
 
@@ -283,13 +283,13 @@ class TestApiClientScoping:
 
         await (
             client.from_service_url("https://override.service.url")
-            .from_agent_user(identity_1)
+            .from_agentic_user(identity_1)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         first_request = request_capture._capture.last_request
         await (
-            client.from_agent_user(identity_1)
-            .from_agent_user(identity_2)
+            client.from_agentic_user(identity_1)
+            .from_agentic_user(identity_2)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         second_request = request_capture._capture.last_request
@@ -301,44 +301,44 @@ class TestApiClientScoping:
         assert str(second_request.url).startswith("https://test.service.url/")
 
     @pytest.mark.asyncio
-    async def test_clone_none_preserves_scoped_agent_user(self, request_capture, mock_activity):
+    async def test_clone_none_preserves_scoped_agentic_user(self, request_capture, mock_activity):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
-        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        default_identity = AgenticUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agent_user=default_identity,
+            agentic_user=default_identity,
         )
 
-        await client.clone(agent_user=None).conversations.create_activity("test_conversation_id", mock_activity)
+        await client.clone(agentic_user=None).conversations.create_activity("test_conversation_id", mock_activity)
 
         assert calls == [(None, default_identity)]
 
     @pytest.mark.asyncio
-    async def test_clone_clear_clears_scoped_agent_user(self, request_capture, mock_activity):
+    async def test_clone_clear_clears_scoped_agentic_user(self, request_capture, mock_activity):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
-        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        default_identity = AgenticUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agent_user=default_identity,
+            agentic_user=default_identity,
         )
 
-        await client.clone(agent_user=AGENT_USER_CLEAR).conversations.create_activity(
+        await client.clone(agentic_user=AGENTIC_USER_CLEAR).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -346,8 +346,8 @@ class TestApiClientScoping:
 
     def test_http_client_token_conflicts_with_auth_provider(self, request_capture):
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                return "agentic-user-token"
 
         request_capture_with_token = request_capture.clone(ClientOptions(token="http-client-token"), share_http=True)
 
@@ -356,5 +356,5 @@ class TestApiClientScoping:
                 "https://test.service.url",
                 request_capture_with_token,
                 auth_provider=TestAuthProvider(),
-                agent_user=AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id"),
+                agentic_user=AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id"),
             )

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -7,8 +7,8 @@ Licensed under the MIT License.
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from microsoft_teams.api.clients import AGENTIC_IDENTITY_CLEAR, ApiClient, ReactionClient
-from microsoft_teams.api.models import AgenticIdentity
+from microsoft_teams.api.clients import AGENT_USER_CLEAR, ApiClient, ReactionClient
+from microsoft_teams.api.models import AgentUser
 from microsoft_teams.common.http import Client, ClientOptions
 
 
@@ -26,25 +26,25 @@ class TestApiClientReactionsProperty:
         assert reactions is not None
         assert isinstance(reactions, ReactionClient)
 
-    def test_reactions_inherits_agentic_auth_defaults(self, mock_http_client):
-        """Test reactions inherits agentic auth defaults from ApiClient."""
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+    def test_reactions_inherits_agent_user_auth_defaults(self, mock_http_client):
+        """Test reactions inherits agent user auth defaults from ApiClient."""
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                return "agent-user-token"
 
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agentic_identity=identity,
+            agent_user=identity,
         )
 
         reactions = client.reactions
 
         assert not hasattr(reactions, "_auth_provider")
-        assert not hasattr(reactions, "_agentic_identity")
+        assert not hasattr(reactions, "_agent_user")
         assert client.http.token is not None
         assert reactions.http is client.http
 
@@ -126,103 +126,103 @@ class TestApiClientDeprecatedAccessors:
 @pytest.mark.unit
 class TestApiClientScoping:
     def test_clone_preserves_defaults_when_omitted(self, mock_http_client):
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://mock.service.url", mock_http_client, agentic_identity=identity)
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://mock.service.url", mock_http_client, agent_user=identity)
 
         clone = client.clone()
 
         assert clone.service_url == "https://mock.service.url"
-        assert clone._default_agentic_identity is identity
+        assert clone._default_agent_user is identity
         assert clone._api_client_settings is client._api_client_settings
         assert clone._cloud is client._cloud
 
-    def test_clone_reuses_underlying_http_client_when_agentic_identity_is_unchanged(self, mock_http_client):
+    def test_clone_reuses_underlying_http_client_when_agent_user_is_unchanged(self, mock_http_client):
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                return "agent-user-token"
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agentic_identity=identity,
+            agent_user=identity,
         )
 
         clone = client.from_service_url("https://override.service.url")
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
-        assert clone._default_agentic_identity is identity
+        assert clone._default_agent_user is identity
 
-    def test_clone_replaces_http_client_when_agentic_identity_changes(self, mock_http_client):
+    def test_clone_replaces_http_client_when_agent_user_changes(self, mock_http_client):
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                return "agent-user-token"
 
-        default_identity = AgenticIdentity("default-app-id", "default-user-id", tenant_id="default-tenant-id")
-        override_identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        override_identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = ApiClient(
             "https://mock.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agentic_identity=default_identity,
+            agent_user=default_identity,
         )
 
-        clone = client.from_agentic_identity(override_identity)
+        clone = client.from_agent_user(override_identity)
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
-        assert clone._default_agentic_identity is override_identity
+        assert clone._default_agent_user is override_identity
 
-    def test_clone_preserves_agentic_identity_with_explicit_none(self, mock_http_client):
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://mock.service.url", mock_http_client, agentic_identity=identity)
+    def test_clone_preserves_agent_user_with_explicit_none(self, mock_http_client):
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://mock.service.url", mock_http_client, agent_user=identity)
 
-        clone = client.clone(agentic_identity=None)
+        clone = client.clone(agent_user=None)
 
-        assert clone._default_agentic_identity is identity
+        assert clone._default_agent_user is identity
 
-    def test_clone_can_override_service_url_and_clear_agentic_identity(self, mock_http_client):
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://mock.service.url", mock_http_client, agentic_identity=identity)
+    def test_clone_can_override_service_url_and_clear_agent_user(self, mock_http_client):
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://mock.service.url", mock_http_client, agent_user=identity)
 
-        clone = client.clone(service_url="https://override.service.url/", agentic_identity=AGENTIC_IDENTITY_CLEAR)
+        clone = client.clone(service_url="https://override.service.url/", agent_user=AGENT_USER_CLEAR)
 
         assert clone.service_url == "https://override.service.url"
-        assert clone._default_agentic_identity is None
+        assert clone._default_agent_user is None
 
     def test_scoped_helpers_create_expected_clones(self, mock_http_client):
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient("https://mock.service.url", mock_http_client)
 
         service_scoped = client.from_service_url("https://override.service.url/")
-        identity_scoped = client.from_agentic_identity(identity)
-        alias_scoped = client.for_agentic_identity(identity)
+        identity_scoped = client.from_agent_user(identity)
+        alias_scoped = client.for_agent_user(identity)
 
         assert service_scoped.service_url == "https://override.service.url"
-        assert identity_scoped._default_agentic_identity is identity
-        assert alias_scoped._default_agentic_identity is identity
+        assert identity_scoped._default_agent_user is identity
+        assert alias_scoped._default_agent_user is identity
 
     @pytest.mark.asyncio
-    async def test_clone_uses_scoped_agentic_identity_for_auth(self, request_capture, mock_activity):
+    async def test_clone_uses_scoped_agent_user_for_auth(self, request_capture, mock_activity):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        default_identity = AgenticIdentity("default-app-id", "default-user-id", tenant_id="default-tenant-id")
-        override_identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        override_identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agentic_identity=default_identity,
+            agent_user=default_identity,
         )
 
-        await client.from_agentic_identity(override_identity).conversations.create_activity(
+        await client.from_agent_user(override_identity).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -231,17 +231,17 @@ class TestApiClientScoping:
         assert "authorization" in request.headers
 
     @pytest.mark.asyncio
-    async def test_clone_uses_token_for_each_scoped_agentic_identity(self, request_capture, mock_activity):
+    async def test_clone_uses_token_for_each_scoped_agent_user(self, request_capture, mock_activity):
         calls = []
-        identity_1 = AgenticIdentity("agentic-app-id-1", "agentic-user-id-1", tenant_id="tenant-id")
-        identity_2 = AgenticIdentity("agentic-app-id-2", "agentic-user-id-2", tenant_id="tenant-id")
+        identity_1 = AgentUser("agent-app-instance-id-1", "agent-user-id-1", tenant_id="tenant-id")
+        identity_2 = AgentUser("agent-app-instance-id-2", "agent-user-id-2", tenant_id="tenant-id")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                if agentic_identity is identity_1:
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                if agent_user is identity_1:
                     return "token-1"
-                if agentic_identity is identity_2:
+                if agent_user is identity_2:
                     return "token-2"
                 return "default-token"
 
@@ -251,13 +251,9 @@ class TestApiClientScoping:
             auth_provider=TestAuthProvider(),
         )
 
-        await client.from_agentic_identity(identity_1).conversations.create_activity(
-            "test_conversation_id", mock_activity
-        )
+        await client.from_agent_user(identity_1).conversations.create_activity("test_conversation_id", mock_activity)
         first_request = request_capture._capture.last_request
-        await client.from_agentic_identity(identity_2).conversations.create_activity(
-            "test_conversation_id", mock_activity
-        )
+        await client.from_agent_user(identity_2).conversations.create_activity("test_conversation_id", mock_activity)
         second_request = request_capture._capture.last_request
 
         assert calls == [(None, identity_1), (None, identity_2)]
@@ -265,17 +261,17 @@ class TestApiClientScoping:
         assert second_request.headers["authorization"] == "Bearer token-2"
 
     @pytest.mark.asyncio
-    async def test_chained_clone_uses_token_for_new_scoped_agentic_identity(self, request_capture, mock_activity):
+    async def test_chained_clone_uses_token_for_new_scoped_agent_user(self, request_capture, mock_activity):
         calls = []
-        identity_1 = AgenticIdentity("agentic-app-id-1", "agentic-user-id-1", tenant_id="tenant-id")
-        identity_2 = AgenticIdentity("agentic-app-id-2", "agentic-user-id-2", tenant_id="tenant-id")
+        identity_1 = AgentUser("agent-app-instance-id-1", "agent-user-id-1", tenant_id="tenant-id")
+        identity_2 = AgentUser("agent-app-instance-id-2", "agent-user-id-2", tenant_id="tenant-id")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                if agentic_identity is identity_1:
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                if agent_user is identity_1:
                     return "token-1"
-                if agentic_identity is identity_2:
+                if agent_user is identity_2:
                     return "token-2"
                 return "default-token"
 
@@ -287,13 +283,13 @@ class TestApiClientScoping:
 
         await (
             client.from_service_url("https://override.service.url")
-            .from_agentic_identity(identity_1)
+            .from_agent_user(identity_1)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         first_request = request_capture._capture.last_request
         await (
-            client.from_agentic_identity(identity_1)
-            .from_agentic_identity(identity_2)
+            client.from_agent_user(identity_1)
+            .from_agent_user(identity_2)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         second_request = request_capture._capture.last_request
@@ -305,44 +301,44 @@ class TestApiClientScoping:
         assert str(second_request.url).startswith("https://test.service.url/")
 
     @pytest.mark.asyncio
-    async def test_clone_none_preserves_scoped_agentic_identity(self, request_capture, mock_activity):
+    async def test_clone_none_preserves_scoped_agent_user(self, request_capture, mock_activity):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
-        default_identity = AgenticIdentity("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agentic_identity=default_identity,
+            agent_user=default_identity,
         )
 
-        await client.clone(agentic_identity=None).conversations.create_activity("test_conversation_id", mock_activity)
+        await client.clone(agent_user=None).conversations.create_activity("test_conversation_id", mock_activity)
 
         assert calls == [(None, default_identity)]
 
     @pytest.mark.asyncio
-    async def test_clone_clear_clears_scoped_agentic_identity(self, request_capture, mock_activity):
+    async def test_clone_clear_clears_scoped_agent_user(self, request_capture, mock_activity):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
-        default_identity = AgenticIdentity("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agentic_identity=default_identity,
+            agent_user=default_identity,
         )
 
-        await client.clone(agentic_identity=AGENTIC_IDENTITY_CLEAR).conversations.create_activity(
+        await client.clone(agent_user=AGENT_USER_CLEAR).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -350,8 +346,8 @@ class TestApiClientScoping:
 
     def test_http_client_token_conflicts_with_auth_provider(self, request_capture):
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                return "agent-user-token"
 
         request_capture_with_token = request_capture.clone(ClientOptions(token="http-client-token"), share_http=True)
 
@@ -360,5 +356,5 @@ class TestApiClientScoping:
                 "https://test.service.url",
                 request_capture_with_token,
                 auth_provider=TestAuthProvider(),
-                agentic_identity=AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id"),
+                agent_user=AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id"),
             )

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -14,7 +14,7 @@ from microsoft_teams.api.auth.cloud_environment import US_GOV
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.base_client import BaseClient
 from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMiddleware
-from microsoft_teams.api.models import AgentUser
+from microsoft_teams.api.models import AgenticUser
 from microsoft_teams.common import Client, ClientOptions, Token
 from opentelemetry.trace import SpanKind
 
@@ -56,15 +56,15 @@ class RequestRecorder:
 class RecordingAuthProvider:
     def __init__(self, token_value: str | None = "auth-provider-token"):
         self._token_value = token_value
-        self.calls: list[tuple[str | None, AgentUser | None]] = []
+        self.calls: list[tuple[str | None, AgenticUser | None]] = []
 
     def token(
         self,
         *,
         scope: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> str | None:
-        self.calls.append((scope, agent_user))
+        self.calls.append((scope, agentic_user))
         return self._token_value
 
 
@@ -77,9 +77,9 @@ class RaisingAuthProvider(RecordingAuthProvider):
         self,
         *,
         scope: str | None = None,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ):
-        self.calls.append((scope, agent_user))
+        self.calls.append((scope, agentic_user))
         raise self.exception
 
 
@@ -107,14 +107,14 @@ def create_client(*, default_token: Token | None = None) -> tuple[Client, Reques
 
 def create_auth_provider_harness(
     auth_provider: RecordingAuthProvider,
-    default_agent_user: AgentUser | None = None,
+    default_agentic_user: AgenticUser | None = None,
 ) -> tuple[HarnessClient, RequestRecorder]:
     http_client, recorder = create_client()
     api_client = ApiClient(
         "https://test.service.url",
         http_client,
         auth_provider=auth_provider,
-        agent_user=default_agent_user,
+        agentic_user=default_agentic_user,
     )
     return HarnessClient(api_client.http), recorder
 
@@ -193,15 +193,15 @@ async def test_auth_provider_token_is_used_when_request_has_no_auth():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("agent_user", "expected_flow"),
+    ("agentic_user", "expected_flow"),
     [
         (None, "app_only"),
-        (AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id"), "agent_user"),
+        (AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id"), "agentic_user"),
     ],
 )
-async def test_auth_provider_token_records_auth_outbound_span(agent_user, expected_flow):
+async def test_auth_provider_token_records_auth_outbound_span(agentic_user, expected_flow):
     auth_provider = RecordingAuthProvider()
-    client, recorder = create_auth_provider_harness(auth_provider, default_agent_user=agent_user)
+    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_user=agentic_user)
     tracer = RecordingTracer()
 
     with patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer):
@@ -259,27 +259,27 @@ async def test_http_client_token_is_used_when_no_auth_provider():
 
 
 @pytest.mark.asyncio
-async def test_default_agent_user_is_used_without_request_metadata():
-    auth_provider = RecordingAuthProvider(token_value="agent-user-token")
-    identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-    client, recorder = create_auth_provider_harness(auth_provider, default_agent_user=identity)
+async def test_default_agentic_user_is_used_without_request_metadata():
+    auth_provider = RecordingAuthProvider(token_value="agentic-user-token")
+    identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_user=identity)
 
     await client.post_resource()
 
     assert auth_provider.calls == [(None, identity)]
-    assert recorder.last_request.headers["authorization"] == "Bearer agent-user-token"
+    assert recorder.last_request.headers["authorization"] == "Bearer agentic-user-token"
 
 
 @pytest.mark.asyncio
-async def test_default_agent_user_is_passed_to_auth_provider_token():
-    auth_provider = RecordingAuthProvider(token_value="agent-user-token")
-    identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-    client, recorder = create_auth_provider_harness(auth_provider, default_agent_user=identity)
+async def test_default_agentic_user_is_passed_to_auth_provider_token():
+    auth_provider = RecordingAuthProvider(token_value="agentic-user-token")
+    identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_user=identity)
 
     await client.post_resource()
 
     assert auth_provider.calls == [(None, identity)]
-    assert recorder.last_request.headers["authorization"] == "Bearer agent-user-token"
+    assert recorder.last_request.headers["authorization"] == "Bearer agentic-user-token"
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -196,7 +196,7 @@ async def test_auth_provider_token_is_used_when_request_has_no_auth():
     ("agentic_user", "expected_flow"),
     [
         (None, "app_only"),
-        (AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id"), "agentic_user"),
+        (AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id"), "agentic_user"),
     ],
 )
 async def test_auth_provider_token_records_auth_outbound_span(agentic_user, expected_flow):
@@ -261,7 +261,7 @@ async def test_http_client_token_is_used_when_no_auth_provider():
 @pytest.mark.asyncio
 async def test_default_agentic_user_is_used_without_request_metadata():
     auth_provider = RecordingAuthProvider(token_value="agentic-user-token")
-    identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+    identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
     client, recorder = create_auth_provider_harness(auth_provider, default_agentic_user=identity)
 
     await client.post_resource()
@@ -273,7 +273,7 @@ async def test_default_agentic_user_is_used_without_request_metadata():
 @pytest.mark.asyncio
 async def test_default_agentic_user_is_passed_to_auth_provider_token():
     auth_provider = RecordingAuthProvider(token_value="agentic-user-token")
-    identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+    identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
     client, recorder = create_auth_provider_harness(auth_provider, default_agentic_user=identity)
 
     await client.post_resource()

--- a/packages/api/tests/unit/test_base_client.py
+++ b/packages/api/tests/unit/test_base_client.py
@@ -14,7 +14,7 @@ from microsoft_teams.api.auth.cloud_environment import US_GOV
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.base_client import BaseClient
 from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMiddleware
-from microsoft_teams.api.models import AgenticIdentity
+from microsoft_teams.api.models import AgentUser
 from microsoft_teams.common import Client, ClientOptions, Token
 from opentelemetry.trace import SpanKind
 
@@ -56,15 +56,15 @@ class RequestRecorder:
 class RecordingAuthProvider:
     def __init__(self, token_value: str | None = "auth-provider-token"):
         self._token_value = token_value
-        self.calls: list[tuple[str | None, AgenticIdentity | None]] = []
+        self.calls: list[tuple[str | None, AgentUser | None]] = []
 
     def token(
         self,
         *,
         scope: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> str | None:
-        self.calls.append((scope, agentic_identity))
+        self.calls.append((scope, agent_user))
         return self._token_value
 
 
@@ -77,9 +77,9 @@ class RaisingAuthProvider(RecordingAuthProvider):
         self,
         *,
         scope: str | None = None,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ):
-        self.calls.append((scope, agentic_identity))
+        self.calls.append((scope, agent_user))
         raise self.exception
 
 
@@ -107,14 +107,14 @@ def create_client(*, default_token: Token | None = None) -> tuple[Client, Reques
 
 def create_auth_provider_harness(
     auth_provider: RecordingAuthProvider,
-    default_agentic_identity: AgenticIdentity | None = None,
+    default_agent_user: AgentUser | None = None,
 ) -> tuple[HarnessClient, RequestRecorder]:
     http_client, recorder = create_client()
     api_client = ApiClient(
         "https://test.service.url",
         http_client,
         auth_provider=auth_provider,
-        agentic_identity=default_agentic_identity,
+        agent_user=default_agent_user,
     )
     return HarnessClient(api_client.http), recorder
 
@@ -193,15 +193,15 @@ async def test_auth_provider_token_is_used_when_request_has_no_auth():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("agentic_identity", "expected_flow"),
+    ("agent_user", "expected_flow"),
     [
         (None, "app_only"),
-        (AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id"), "agentic"),
+        (AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id"), "agent_user"),
     ],
 )
-async def test_auth_provider_token_records_auth_outbound_span(agentic_identity, expected_flow):
+async def test_auth_provider_token_records_auth_outbound_span(agent_user, expected_flow):
     auth_provider = RecordingAuthProvider()
-    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_identity=agentic_identity)
+    client, recorder = create_auth_provider_harness(auth_provider, default_agent_user=agent_user)
     tracer = RecordingTracer()
 
     with patch("microsoft_teams.api.clients.api_client.get_tracer", return_value=tracer):
@@ -259,27 +259,27 @@ async def test_http_client_token_is_used_when_no_auth_provider():
 
 
 @pytest.mark.asyncio
-async def test_default_agentic_identity_is_used_without_request_metadata():
-    auth_provider = RecordingAuthProvider(token_value="agentic-token")
-    identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_identity=identity)
+async def test_default_agent_user_is_used_without_request_metadata():
+    auth_provider = RecordingAuthProvider(token_value="agent-user-token")
+    identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+    client, recorder = create_auth_provider_harness(auth_provider, default_agent_user=identity)
 
     await client.post_resource()
 
     assert auth_provider.calls == [(None, identity)]
-    assert recorder.last_request.headers["authorization"] == "Bearer agentic-token"
+    assert recorder.last_request.headers["authorization"] == "Bearer agent-user-token"
 
 
 @pytest.mark.asyncio
-async def test_default_agentic_identity_is_passed_to_auth_provider_token():
-    auth_provider = RecordingAuthProvider(token_value="agentic-token")
-    identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-    client, recorder = create_auth_provider_harness(auth_provider, default_agentic_identity=identity)
+async def test_default_agent_user_is_passed_to_auth_provider_token():
+    auth_provider = RecordingAuthProvider(token_value="agent-user-token")
+    identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+    client, recorder = create_auth_provider_harness(auth_provider, default_agent_user=identity)
 
     await client.post_resource()
 
     assert auth_provider.calls == [(None, identity)]
-    assert recorder.last_request.headers["authorization"] == "Bearer agentic-token"
+    assert recorder.last_request.headers["authorization"] == "Bearer agent-user-token"
 
 
 @pytest.mark.asyncio

--- a/packages/api/tests/unit/test_bot_client.py
+++ b/packages/api/tests/unit/test_bot_client.py
@@ -70,11 +70,11 @@ class TestBotClient:
         assert calls == [("https://api.botframework.com/.default", "tenant-id")]
 
     @pytest.mark.asyncio
-    async def test_bot_token_get_with_positional_agentic_identity_provider(self, mock_http_client):
+    async def test_bot_token_get_with_positional_agent_user_provider(self, mock_http_client):
         calls = []
 
-        def token_provider(scope, tenant_id, agentic_identity):
-            calls.append((scope, tenant_id, agentic_identity))
+        def token_provider(scope, tenant_id, agent_user):
+            calls.append((scope, tenant_id, agent_user))
             return "token"
 
         credentials = TokenCredentials(client_id="client-id", tenant_id="tenant-id", token=token_provider)
@@ -128,8 +128,8 @@ class TestBotClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider())

--- a/packages/api/tests/unit/test_bot_client.py
+++ b/packages/api/tests/unit/test_bot_client.py
@@ -70,11 +70,11 @@ class TestBotClient:
         assert calls == [("https://api.botframework.com/.default", "tenant-id")]
 
     @pytest.mark.asyncio
-    async def test_bot_token_get_with_positional_agent_user_provider(self, mock_http_client):
+    async def test_bot_token_get_with_positional_agentic_user_provider(self, mock_http_client):
         calls = []
 
-        def token_provider(scope, tenant_id, agent_user):
-            calls.append((scope, tenant_id, agent_user))
+        def token_provider(scope, tenant_id, agentic_user):
+            calls.append((scope, tenant_id, agentic_user))
             return "token"
 
         credentials = TokenCredentials(client_id="client-id", tenant_id="tenant-id", token=token_provider)
@@ -128,8 +128,8 @@ class TestBotClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider())

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -16,7 +16,7 @@ from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.conversation import ConversationClient
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
 from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMetadata
-from microsoft_teams.api.models import AgentUser, ConversationResource, PagedMembersResult, TeamsChannelAccount
+from microsoft_teams.api.models import AgenticUser, ConversationResource, PagedMembersResult, TeamsChannelAccount
 from microsoft_teams.common.http import Client, ClientOptions
 from opentelemetry.trace import Span, SpanKind
 
@@ -152,8 +152,8 @@ class TestConversationClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -166,17 +166,17 @@ class TestConversationClient:
         assert request.headers["authorization"] == "Bearer bot-token"
 
     @pytest.mark.asyncio
-    async def test_create_conversation_uses_agent_user(self, request_capture, mock_account):
+    async def test_create_conversation_uses_agentic_user(self, request_capture, mock_account):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agent_user=identity
+            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agentic_user=identity
         ).conversations
         params = CreateConversationParams(members=[mock_account], tenant_id="test_tenant_id")
 
@@ -184,7 +184,7 @@ class TestConversationClient:
 
         assert calls == [(None, identity)]
         request = request_capture._capture.last_request
-        assert request.headers["authorization"] == "Bearer agent-user-token"
+        assert request.headers["authorization"] == "Bearer agentic-user-token"
 
     def test_conversation_resource_with_all_fields(self):
         """Test that ConversationResource correctly handles all fields present."""
@@ -297,12 +297,12 @@ class TestConversationActivityOperations:
         assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
 
     async def test_activity_create_uses_auth_provider_for_bot_token(self, request_capture, mock_activity):
-        """Test creating an activity with an auth provider but no agent user."""
+        """Test creating an activity with an auth provider but no agentic user."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -313,22 +313,22 @@ class TestConversationActivityOperations:
         last_request = request_capture._capture.last_request
         assert last_request.headers["authorization"] == "Bearer bot-token"
 
-    async def test_activity_create_uses_client_agent_user(self, request_capture, mock_activity):
-        """Test creating an activity with the client's default agent user."""
+    async def test_activity_create_uses_client_agentic_user(self, request_capture, mock_activity):
+        """Test creating an activity with the client's default agentic user."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        cloud = with_overrides(PUBLIC, agent_bot_scope="agent-user-scope")
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        cloud = with_overrides(PUBLIC, agent_bot_scope="agentic-user-scope")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agent_user=identity,
+            agentic_user=identity,
             cloud=cloud,
         ).conversations
 
@@ -336,27 +336,27 @@ class TestConversationActivityOperations:
 
         assert calls == [(None, identity)]
         last_request = request_capture._capture.last_request
-        assert last_request.headers["authorization"] == "Bearer agent-user-token"
+        assert last_request.headers["authorization"] == "Bearer agentic-user-token"
 
-    async def test_activity_create_scoped_agent_user_overrides_client_default(self, request_capture, mock_activity):
-        """Test scoped agent user overrides the client's default identity."""
+    async def test_activity_create_scoped_agentic_user_overrides_client_default(self, request_capture, mock_activity):
+        """Test scoped agentic user overrides the client's default identity."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "override-token"
 
-        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
-        override_identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        default_identity = AgenticUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        override_identity = AgenticUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = (
             ApiClient(
                 "https://test.service.url",
                 request_capture,
                 auth_provider=TestAuthProvider(),
-                agent_user=default_identity,
+                agentic_user=default_identity,
             )
-            .from_agent_user(override_identity)
+            .from_agentic_user(override_identity)
             .conversations
         )
 
@@ -366,17 +366,17 @@ class TestConversationActivityOperations:
         last_request = request_capture._capture.last_request
         assert last_request.headers["authorization"] == "Bearer override-token"
 
-    async def test_flattened_activity_create_accepts_service_url_and_agent_user_kwargs(
+    async def test_flattened_activity_create_accepts_service_url_and_agentic_user_kwargs(
         self, request_capture, mock_activity
     ):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "override-token"
 
-        identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        identity = AgenticUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = ApiClient(
             "https://default.service.url",
             request_capture,
@@ -387,7 +387,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             mock_activity,
             service_url="https://override.service.url/",
-            agent_user=identity,
+            agentic_user=identity,
         )
 
         assert calls == [(None, identity)]
@@ -395,17 +395,17 @@ class TestConversationActivityOperations:
         assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
         assert "authorization" in last_request.headers
 
-    async def test_direct_activities_client_methods_accept_service_url_and_agent_user_kwargs(
+    async def test_direct_activities_client_methods_accept_service_url_and_agentic_user_kwargs(
         self, request_capture, mock_activity
     ):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "override-token"
 
-        identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        identity = AgenticUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         activities_client = ApiClient(
             "https://default.service.url",
             request_capture,
@@ -417,7 +417,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             mock_activity,
             service_url=service_url,
-            agent_user=identity,
+            agentic_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -430,7 +430,7 @@ class TestConversationActivityOperations:
             "activity-id",
             mock_activity,
             service_url=service_url,
-            agent_user=identity,
+            agentic_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -443,7 +443,7 @@ class TestConversationActivityOperations:
             "activity-id",
             mock_activity,
             service_url=service_url,
-            agent_user=identity,
+            agentic_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -455,7 +455,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             "activity-id",
             service_url=service_url,
-            agent_user=identity,
+            agentic_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -467,7 +467,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             "activity-id",
             service_url=service_url,
-            agent_user=identity,
+            agentic_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -531,12 +531,12 @@ class TestConversationActivityOperations:
             "?isTargetedActivity=true"
         )
 
-    async def test_activity_create_agent_user_without_auth_provider_uses_http_client_auth(
+    async def test_activity_create_agentic_user_without_auth_provider_uses_http_client_auth(
         self, request_capture, mock_activity
     ):
-        """Test agent user without an auth provider leaves auth resolution to the HTTP client."""
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://test.service.url", request_capture).from_agent_user(identity).conversations
+        """Test agentic user without an auth provider leaves auth resolution to the HTTP client."""
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://test.service.url", request_capture).from_agentic_user(identity).conversations
 
         await client.activities("test_conversation_id").create(mock_activity)
 
@@ -703,8 +703,8 @@ class TestConversationActivityOperations:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -726,7 +726,7 @@ class TestConversationActivityOperations:
         error = RuntimeError("token failure")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
+            def token(self, *, scope=None, agentic_user=None):
                 raise error
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -754,8 +754,8 @@ class TestConversationActivityOperations:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         api_client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider())
@@ -998,8 +998,8 @@ class TestConversationMemberOperations:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -1017,17 +1017,17 @@ class TestConversationMemberOperations:
         for request in request_capture._capture.requests[-3:]:
             assert request.headers["authorization"] == "Bearer bot-token"
 
-    async def test_member_operations_use_agent_user(self, request_capture):
+    async def test_member_operations_use_agentic_user(self, request_capture):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agent_user=identity
+            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agentic_user=identity
         ).conversations
         members = client.members("test_conversation_id")
 
@@ -1041,7 +1041,7 @@ class TestConversationMemberOperations:
             (None, identity),
         ]
         for request in request_capture._capture.requests[-3:]:
-            assert request.headers["authorization"] == "Bearer agent-user-token"
+            assert request.headers["authorization"] == "Bearer agentic-user-token"
 
     async def test_member_get_paged(self, mock_http_client):
         """Test getting a page of members returns PagedMembersResult."""

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -16,7 +16,7 @@ from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.conversation import ConversationClient
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
 from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMetadata
-from microsoft_teams.api.models import AgenticIdentity, ConversationResource, PagedMembersResult, TeamsChannelAccount
+from microsoft_teams.api.models import AgentUser, ConversationResource, PagedMembersResult, TeamsChannelAccount
 from microsoft_teams.common.http import Client, ClientOptions
 from opentelemetry.trace import Span, SpanKind
 
@@ -152,8 +152,8 @@ class TestConversationClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -166,17 +166,17 @@ class TestConversationClient:
         assert request.headers["authorization"] == "Bearer bot-token"
 
     @pytest.mark.asyncio
-    async def test_create_conversation_uses_agentic_identity(self, request_capture, mock_account):
+    async def test_create_conversation_uses_agent_user(self, request_capture, mock_account):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agentic_identity=identity
+            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agent_user=identity
         ).conversations
         params = CreateConversationParams(members=[mock_account], tenant_id="test_tenant_id")
 
@@ -184,7 +184,7 @@ class TestConversationClient:
 
         assert calls == [(None, identity)]
         request = request_capture._capture.last_request
-        assert request.headers["authorization"] == "Bearer agentic-token"
+        assert request.headers["authorization"] == "Bearer agent-user-token"
 
     def test_conversation_resource_with_all_fields(self):
         """Test that ConversationResource correctly handles all fields present."""
@@ -297,12 +297,12 @@ class TestConversationActivityOperations:
         assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
 
     async def test_activity_create_uses_auth_provider_for_bot_token(self, request_capture, mock_activity):
-        """Test creating an activity with an auth provider but no agentic identity."""
+        """Test creating an activity with an auth provider but no agent user."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -313,22 +313,22 @@ class TestConversationActivityOperations:
         last_request = request_capture._capture.last_request
         assert last_request.headers["authorization"] == "Bearer bot-token"
 
-    async def test_activity_create_uses_client_agentic_identity(self, request_capture, mock_activity):
-        """Test creating an activity with the client's default agentic identity."""
+    async def test_activity_create_uses_client_agent_user(self, request_capture, mock_activity):
+        """Test creating an activity with the client's default agent user."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        cloud = with_overrides(PUBLIC, agentic_bot_scope="agentic-scope")
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        cloud = with_overrides(PUBLIC, agent_bot_scope="agent-user-scope")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
             auth_provider=TestAuthProvider(),
-            agentic_identity=identity,
+            agent_user=identity,
             cloud=cloud,
         ).conversations
 
@@ -336,29 +336,27 @@ class TestConversationActivityOperations:
 
         assert calls == [(None, identity)]
         last_request = request_capture._capture.last_request
-        assert last_request.headers["authorization"] == "Bearer agentic-token"
+        assert last_request.headers["authorization"] == "Bearer agent-user-token"
 
-    async def test_activity_create_scoped_agentic_identity_overrides_client_default(
-        self, request_capture, mock_activity
-    ):
-        """Test scoped agentic identity overrides the client's default identity."""
+    async def test_activity_create_scoped_agent_user_overrides_client_default(self, request_capture, mock_activity):
+        """Test scoped agent user overrides the client's default identity."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "override-token"
 
-        default_identity = AgenticIdentity("default-app-id", "default-user-id", tenant_id="default-tenant-id")
-        override_identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        default_identity = AgentUser("default-app-id", "default-user-id", tenant_id="default-tenant-id")
+        override_identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = (
             ApiClient(
                 "https://test.service.url",
                 request_capture,
                 auth_provider=TestAuthProvider(),
-                agentic_identity=default_identity,
+                agent_user=default_identity,
             )
-            .from_agentic_identity(override_identity)
+            .from_agent_user(override_identity)
             .conversations
         )
 
@@ -368,17 +366,17 @@ class TestConversationActivityOperations:
         last_request = request_capture._capture.last_request
         assert last_request.headers["authorization"] == "Bearer override-token"
 
-    async def test_flattened_activity_create_accepts_service_url_and_agentic_identity_kwargs(
+    async def test_flattened_activity_create_accepts_service_url_and_agent_user_kwargs(
         self, request_capture, mock_activity
     ):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "override-token"
 
-        identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         client = ApiClient(
             "https://default.service.url",
             request_capture,
@@ -389,7 +387,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             mock_activity,
             service_url="https://override.service.url/",
-            agentic_identity=identity,
+            agent_user=identity,
         )
 
         assert calls == [(None, identity)]
@@ -397,17 +395,17 @@ class TestConversationActivityOperations:
         assert str(last_request.url) == "https://override.service.url/v3/conversations/test_conversation_id/activities"
         assert "authorization" in last_request.headers
 
-    async def test_direct_activities_client_methods_accept_service_url_and_agentic_identity_kwargs(
+    async def test_direct_activities_client_methods_accept_service_url_and_agent_user_kwargs(
         self, request_capture, mock_activity
     ):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "override-token"
 
-        identity = AgenticIdentity("override-app-id", "override-user-id", tenant_id="override-tenant-id")
+        identity = AgentUser("override-app-id", "override-user-id", tenant_id="override-tenant-id")
         activities_client = ApiClient(
             "https://default.service.url",
             request_capture,
@@ -419,7 +417,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             mock_activity,
             service_url=service_url,
-            agentic_identity=identity,
+            agent_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -432,7 +430,7 @@ class TestConversationActivityOperations:
             "activity-id",
             mock_activity,
             service_url=service_url,
-            agentic_identity=identity,
+            agent_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -445,7 +443,7 @@ class TestConversationActivityOperations:
             "activity-id",
             mock_activity,
             service_url=service_url,
-            agentic_identity=identity,
+            agent_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -457,7 +455,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             "activity-id",
             service_url=service_url,
-            agentic_identity=identity,
+            agent_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -469,7 +467,7 @@ class TestConversationActivityOperations:
             "test_conversation_id",
             "activity-id",
             service_url=service_url,
-            agentic_identity=identity,
+            agent_user=identity,
         )
         assert (
             str(request_capture._capture.last_request.url)
@@ -533,12 +531,12 @@ class TestConversationActivityOperations:
             "?isTargetedActivity=true"
         )
 
-    async def test_activity_create_agentic_identity_without_auth_provider_uses_http_client_auth(
+    async def test_activity_create_agent_user_without_auth_provider_uses_http_client_auth(
         self, request_capture, mock_activity
     ):
-        """Test agentic identity without an auth provider leaves auth resolution to the HTTP client."""
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-        client = ApiClient("https://test.service.url", request_capture).from_agentic_identity(identity).conversations
+        """Test agent user without an auth provider leaves auth resolution to the HTTP client."""
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        client = ApiClient("https://test.service.url", request_capture).from_agent_user(identity).conversations
 
         await client.activities("test_conversation_id").create(mock_activity)
 
@@ -705,8 +703,8 @@ class TestConversationActivityOperations:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -728,7 +726,7 @@ class TestConversationActivityOperations:
         error = RuntimeError("token failure")
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
+            def token(self, *, scope=None, agent_user=None):
                 raise error
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -756,8 +754,8 @@ class TestConversationActivityOperations:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         api_client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider())
@@ -1000,8 +998,8 @@ class TestConversationMemberOperations:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", request_capture, auth_provider=TestAuthProvider()).conversations
@@ -1019,17 +1017,17 @@ class TestConversationMemberOperations:
         for request in request_capture._capture.requests[-3:]:
             assert request.headers["authorization"] == "Bearer bot-token"
 
-    async def test_member_operations_use_agentic_identity(self, request_capture):
+    async def test_member_operations_use_agent_user(self, request_capture):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agentic_identity=identity
+            "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agent_user=identity
         ).conversations
         members = client.members("test_conversation_id")
 
@@ -1043,7 +1041,7 @@ class TestConversationMemberOperations:
             (None, identity),
         ]
         for request in request_capture._capture.requests[-3:]:
-            assert request.headers["authorization"] == "Bearer agentic-token"
+            assert request.headers["authorization"] == "Bearer agent-user-token"
 
     async def test_member_get_paged(self, mock_http_client):
         """Test getting a page of members returns PagedMembersResult."""

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -174,7 +174,7 @@ class TestConversationClient:
                 calls.append((scope, agentic_user))
                 return "agentic-user-token"
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agentic_user=identity
         ).conversations
@@ -323,7 +323,7 @@ class TestConversationActivityOperations:
                 return "agentic-user-token"
 
         cloud = with_overrides(PUBLIC, agent_bot_scope="agentic-user-scope")
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url",
             request_capture,
@@ -535,7 +535,7 @@ class TestConversationActivityOperations:
         self, request_capture, mock_activity
     ):
         """Test agentic user without an auth provider leaves auth resolution to the HTTP client."""
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient("https://test.service.url", request_capture).from_agentic_user(identity).conversations
 
         await client.activities("test_conversation_id").create(mock_activity)
@@ -1025,7 +1025,7 @@ class TestConversationMemberOperations:
                 calls.append((scope, agentic_user))
                 return "agentic-user-token"
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url", request_capture, auth_provider=TestAuthProvider(), agentic_user=identity
         ).conversations

--- a/packages/api/tests/unit/test_meeting_client.py
+++ b/packages/api/tests/unit/test_meeting_client.py
@@ -129,7 +129,7 @@ class TestMeetingClient:
                 calls.append((scope, agentic_user))
                 return "agentic-user-token"
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_user=identity
         ).meetings

--- a/packages/api/tests/unit/test_meeting_client.py
+++ b/packages/api/tests/unit/test_meeting_client.py
@@ -11,7 +11,7 @@ import pytest
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.meeting import MeetingClient
 from microsoft_teams.api.models import (
-    AgenticIdentity,
+    AgentUser,
     MeetingInfo,
     MeetingNotificationParams,
     MeetingNotificationResponse,
@@ -111,8 +111,8 @@ class TestMeetingClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).meetings
@@ -121,17 +121,17 @@ class TestMeetingClient:
         assert calls == [(None, None)]
 
     @pytest.mark.asyncio
-    async def test_get_participant_uses_agentic_identity(self, mock_http_client):
+    async def test_get_participant_uses_agent_user(self, mock_http_client):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_identity=identity
+            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agent_user=identity
         ).meetings
         await client.get_participant("meeting-id", "participant-id", "tenant-id")
 

--- a/packages/api/tests/unit/test_meeting_client.py
+++ b/packages/api/tests/unit/test_meeting_client.py
@@ -11,7 +11,7 @@ import pytest
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.meeting import MeetingClient
 from microsoft_teams.api.models import (
-    AgentUser,
+    AgenticUser,
     MeetingInfo,
     MeetingNotificationParams,
     MeetingNotificationResponse,
@@ -111,8 +111,8 @@ class TestMeetingClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).meetings
@@ -121,17 +121,17 @@ class TestMeetingClient:
         assert calls == [(None, None)]
 
     @pytest.mark.asyncio
-    async def test_get_participant_uses_agent_user(self, mock_http_client):
+    async def test_get_participant_uses_agentic_user(self, mock_http_client):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agent_user=identity
+            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_user=identity
         ).meetings
         await client.get_participant("meeting-id", "participant-id", "tenant-id")
 

--- a/packages/api/tests/unit/test_reaction_client.py
+++ b/packages/api/tests/unit/test_reaction_client.py
@@ -10,7 +10,7 @@ import pytest
 from microsoft_teams.api.auth.cloud_environment import PUBLIC, with_overrides
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.reaction import ReactionClient
-from microsoft_teams.api.models import AgentUser
+from microsoft_teams.api.models import AgenticUser
 
 
 @pytest.mark.unit
@@ -77,22 +77,22 @@ class TestReactionClient:
         )
 
     @pytest.mark.asyncio
-    async def test_add_reaction_uses_agent_user(self, mock_http_client):
-        """Test adding a reaction with an agent user token."""
+    async def test_add_reaction_uses_agentic_user(self, mock_http_client):
+        """Test adding a reaction with an agentic user token."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        cloud = with_overrides(PUBLIC, agent_bot_scope="agent-user-scope")
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        cloud = with_overrides(PUBLIC, agent_bot_scope="agentic-user-scope")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agent_user=identity,
+            agentic_user=identity,
             cloud=cloud,
         ).reactions
 
@@ -102,12 +102,12 @@ class TestReactionClient:
 
     @pytest.mark.asyncio
     async def test_add_reaction_uses_auth_provider_for_bot_token(self, mock_http_client):
-        """Test adding a reaction with an auth provider but no agent user."""
+        """Test adding a reaction with an auth provider but no agentic user."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).reactions
@@ -153,18 +153,18 @@ class TestReactionClient:
         mock_delete.assert_called_once_with(expected_url)
 
     @pytest.mark.asyncio
-    async def test_delete_reaction_uses_scoped_agent_user(self, mock_http_client):
-        """Test removing a reaction with a scoped agent user token."""
+    async def test_delete_reaction_uses_scoped_agentic_user(self, mock_http_client):
+        """Test removing a reaction with a scoped agentic user token."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agent_user=identity
+            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_user=identity
         ).reactions
 
         await client.delete("test_conversation_id", "test_activity_id", "like")

--- a/packages/api/tests/unit/test_reaction_client.py
+++ b/packages/api/tests/unit/test_reaction_client.py
@@ -10,7 +10,7 @@ import pytest
 from microsoft_teams.api.auth.cloud_environment import PUBLIC, with_overrides
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.reaction import ReactionClient
-from microsoft_teams.api.models import AgenticIdentity
+from microsoft_teams.api.models import AgentUser
 
 
 @pytest.mark.unit
@@ -77,22 +77,22 @@ class TestReactionClient:
         )
 
     @pytest.mark.asyncio
-    async def test_add_reaction_uses_agentic_identity(self, mock_http_client):
-        """Test adding a reaction with an agentic token."""
+    async def test_add_reaction_uses_agent_user(self, mock_http_client):
+        """Test adding a reaction with an agent user token."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        cloud = with_overrides(PUBLIC, agentic_bot_scope="agentic-scope")
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        cloud = with_overrides(PUBLIC, agent_bot_scope="agent-user-scope")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url",
             mock_http_client,
             auth_provider=TestAuthProvider(),
-            agentic_identity=identity,
+            agent_user=identity,
             cloud=cloud,
         ).reactions
 
@@ -102,12 +102,12 @@ class TestReactionClient:
 
     @pytest.mark.asyncio
     async def test_add_reaction_uses_auth_provider_for_bot_token(self, mock_http_client):
-        """Test adding a reaction with an auth provider but no agentic identity."""
+        """Test adding a reaction with an auth provider but no agent user."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).reactions
@@ -153,18 +153,18 @@ class TestReactionClient:
         mock_delete.assert_called_once_with(expected_url)
 
     @pytest.mark.asyncio
-    async def test_delete_reaction_uses_scoped_agentic_identity(self, mock_http_client):
-        """Test removing a reaction with a scoped agentic token."""
+    async def test_delete_reaction_uses_scoped_agent_user(self, mock_http_client):
+        """Test removing a reaction with a scoped agent user token."""
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_identity=identity
+            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agent_user=identity
         ).reactions
 
         await client.delete("test_conversation_id", "test_activity_id", "like")

--- a/packages/api/tests/unit/test_reaction_client.py
+++ b/packages/api/tests/unit/test_reaction_client.py
@@ -87,7 +87,7 @@ class TestReactionClient:
                 return "agentic-user-token"
 
         cloud = with_overrides(PUBLIC, agent_bot_scope="agentic-user-scope")
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url",
             mock_http_client,
@@ -162,7 +162,7 @@ class TestReactionClient:
                 calls.append((scope, agentic_user))
                 return "agentic-user-token"
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_user=identity
         ).reactions

--- a/packages/api/tests/unit/test_team_client.py
+++ b/packages/api/tests/unit/test_team_client.py
@@ -96,7 +96,7 @@ class TestTeamClient:
                 calls.append((scope, agentic_user))
                 return "agentic-user-token"
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
             "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_user=identity
         ).teams

--- a/packages/api/tests/unit/test_team_client.py
+++ b/packages/api/tests/unit/test_team_client.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.team import TeamClient
-from microsoft_teams.api.models import AgenticIdentity, ChannelInfo, TeamDetails
+from microsoft_teams.api.models import AgentUser, ChannelInfo, TeamDetails
 from microsoft_teams.common.http import Client, ClientOptions
 
 
@@ -78,8 +78,8 @@ class TestTeamClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).teams
@@ -88,17 +88,17 @@ class TestTeamClient:
         assert calls == [(None, None)]
 
     @pytest.mark.asyncio
-    async def test_get_conversations_uses_agentic_identity(self, mock_http_client):
+    async def test_get_conversations_uses_agent_user(self, mock_http_client):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
-                return "agentic-token"
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
+                return "agent-user-token"
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_identity=identity
+            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agent_user=identity
         ).teams
         await client.get_conversations("team-id")
 

--- a/packages/api/tests/unit/test_team_client.py
+++ b/packages/api/tests/unit/test_team_client.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.team import TeamClient
-from microsoft_teams.api.models import AgentUser, ChannelInfo, TeamDetails
+from microsoft_teams.api.models import AgenticUser, ChannelInfo, TeamDetails
 from microsoft_teams.common.http import Client, ClientOptions
 
 
@@ -78,8 +78,8 @@ class TestTeamClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).teams
@@ -88,17 +88,17 @@ class TestTeamClient:
         assert calls == [(None, None)]
 
     @pytest.mark.asyncio
-    async def test_get_conversations_uses_agent_user(self, mock_http_client):
+    async def test_get_conversations_uses_agentic_user(self, mock_http_client):
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
-                return "agent-user-token"
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
+                return "agentic-user-token"
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         client = ApiClient(
-            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agent_user=identity
+            "https://test.service.url", mock_http_client, auth_provider=TestAuthProvider(), agentic_user=identity
         ).teams
         await client.get_conversations("team-id")
 

--- a/packages/api/tests/unit/test_user_client.py
+++ b/packages/api/tests/unit/test_user_client.py
@@ -43,8 +43,8 @@ class TestUserClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agentic_identity=None):
-                calls.append((scope, agentic_identity))
+            def token(self, *, scope=None, agent_user=None):
+                calls.append((scope, agent_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).users

--- a/packages/api/tests/unit/test_user_client.py
+++ b/packages/api/tests/unit/test_user_client.py
@@ -43,8 +43,8 @@ class TestUserClient:
         calls = []
 
         class TestAuthProvider:
-            def token(self, *, scope=None, agent_user=None):
-                calls.append((scope, agent_user))
+            def token(self, *, scope=None, agentic_user=None):
+                calls.append((scope, agentic_user))
                 return "bot-token"
 
         client = ApiClient("https://test.service.url", mock_http_client, auth_provider=TestAuthProvider()).users

--- a/packages/apps/src/microsoft_teams/apps/activity_send.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_send.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from microsoft_teams.api import (
     ActivityParams,
-    AgenticIdentity,
+    AgentUser,
     ApiClient,
     ConversationReference,
     MessageActivityInput,
@@ -18,7 +18,7 @@ async def send_or_update_activity(
     activity: ActivityParams,
     ref: ConversationReference,
     *,
-    agentic_identity: AgenticIdentity | None = None,
+    agent_user: AgentUser | None = None,
 ) -> SentActivity:
     """Send or update an activity using the same routing rules as the removed ActivitySender."""
     is_targeted = (
@@ -34,8 +34,8 @@ async def send_or_update_activity(
     activity.conversation = ref.conversation
     scoped_api = (
         api
-        if agentic_identity is None and ref.service_url.rstrip("/") == api.service_url
-        else api.clone(service_url=ref.service_url, agentic_identity=agentic_identity)
+        if agent_user is None and ref.service_url.rstrip("/") == api.service_url
+        else api.clone(service_url=ref.service_url, agent_user=agent_user)
     )
     if activity.id:
         activity_id = activity.id

--- a/packages/apps/src/microsoft_teams/apps/activity_send.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_send.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from microsoft_teams.api import (
     ActivityParams,
-    AgentUser,
+    AgenticUser,
     ApiClient,
     ConversationReference,
     MessageActivityInput,
@@ -18,7 +18,7 @@ async def send_or_update_activity(
     activity: ActivityParams,
     ref: ConversationReference,
     *,
-    agent_user: AgentUser | None = None,
+    agentic_user: AgenticUser | None = None,
 ) -> SentActivity:
     """Send or update an activity using the same routing rules as the removed ActivitySender."""
     is_targeted = (
@@ -34,8 +34,8 @@ async def send_or_update_activity(
     activity.conversation = ref.conversation
     scoped_api = (
         api
-        if agent_user is None and ref.service_url.rstrip("/") == api.service_url
-        else api.clone(service_url=ref.service_url, agent_user=agent_user)
+        if agentic_user is None and ref.service_url.rstrip("/") == api.service_url
+        else api.clone(service_url=ref.service_url, agentic_user=agentic_user)
     )
     if activity.id:
         activity_id = activity.id

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -15,7 +15,7 @@ from microsoft_teams.api import (
     Account,
     ActivityBase,
     ActivityParams,
-    AgentUser,
+    AgenticUser,
     ApiClient,
     ClientCredentials,
     ConversationAccount,
@@ -298,7 +298,7 @@ class App(ActivityHandlerMixin):
         activity: str | ActivityParams | AdaptiveCard,
         *,
         service_url: Optional[str] = None,
-        agent_user: Optional[AgentUser] = None,
+        agentic_user: Optional[AgenticUser] = None,
     ) -> SentActivity:
         """Send an activity proactively to a conversation.
 
@@ -331,30 +331,30 @@ class App(ActivityHandlerMixin):
             self.api,
             activity,
             conversation_ref,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
-    def get_agent_user(
+    def get_agentic_user(
         self,
         agent_app_instance_id: str,
-        agent_user_id: str,
+        agentic_user_id: str,
         *,
         tenant_id: Optional[str] = None,
         agent_identity_blueprint_id: Optional[str] = None,
-    ) -> AgentUser:
-        """Get an AgentUser for API calls.
+    ) -> AgenticUser:
+        """Get an AgenticUser for API calls.
 
         When ``agent_identity_blueprint_id`` is omitted, it defaults to the app's own
         client/app id (``self.id``).
         """
         resolved_tenant_id = tenant_id or (self.credentials.tenant_id if self.credentials else None)
         if resolved_tenant_id is None:
-            raise ValueError("tenant_id is required to get an agent user")
+            raise ValueError("tenant_id is required to get an agentic user")
 
         resolved_blueprint_id = agent_identity_blueprint_id or self.id
-        return AgentUser(
+        return AgenticUser(
             agent_app_instance_id=agent_app_instance_id,
-            agent_user_id=agent_user_id,
+            agentic_user_id=agentic_user_id,
             tenant_id=resolved_tenant_id,
             agent_identity_blueprint_id=resolved_blueprint_id,
         )
@@ -367,7 +367,7 @@ class App(ActivityHandlerMixin):
         activity: str | ActivityParams | AdaptiveCard,
         *,
         service_url: Optional[str] = None,
-        agent_user: Optional[AgentUser] = None,
+        agentic_user: Optional[AgenticUser] = None,
     ) -> SentActivity: ...
 
     @overload
@@ -377,7 +377,7 @@ class App(ActivityHandlerMixin):
         message_id: str | ActivityParams | AdaptiveCard,
         *,
         service_url: Optional[str] = None,
-        agent_user: Optional[AgentUser] = None,
+        agentic_user: Optional[AgenticUser] = None,
     ) -> SentActivity: ...
 
     async def reply(  # type: ignore[reportInconsistentOverload]
@@ -387,7 +387,7 @@ class App(ActivityHandlerMixin):
         activity: str | ActivityParams | AdaptiveCard | None = None,
         *,
         service_url: Optional[str] = None,
-        agent_user: Optional[AgentUser] = None,
+        agentic_user: Optional[AgenticUser] = None,
     ) -> SentActivity:
         """Send an activity proactively to a conversation, optionally as a threaded reply.
 
@@ -412,14 +412,14 @@ class App(ActivityHandlerMixin):
                 to_threaded_conversation_id(conversation_id, message_id),
                 activity,
                 service_url=service_url,
-                agent_user=agent_user,
+                agentic_user=agentic_user,
             )
 
         return await self.send(
             conversation_id,
             message_id,
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
     def use(self, middleware: Callable[[ActivityContext[ActivityBase]], Awaitable[None]]) -> None:

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -15,7 +15,7 @@ from microsoft_teams.api import (
     Account,
     ActivityBase,
     ActivityParams,
-    AgenticIdentity,
+    AgentUser,
     ApiClient,
     ClientCredentials,
     ConversationAccount,
@@ -298,7 +298,7 @@ class App(ActivityHandlerMixin):
         activity: str | ActivityParams | AdaptiveCard,
         *,
         service_url: Optional[str] = None,
-        agentic_identity: Optional[AgenticIdentity] = None,
+        agent_user: Optional[AgentUser] = None,
     ) -> SentActivity:
         """Send an activity proactively to a conversation.
 
@@ -331,32 +331,32 @@ class App(ActivityHandlerMixin):
             self.api,
             activity,
             conversation_ref,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
-    def get_agentic_identity(
+    def get_agent_user(
         self,
-        agentic_app_id: str,
-        agentic_user_id: str,
+        agent_app_instance_id: str,
+        agent_user_id: str,
         *,
         tenant_id: Optional[str] = None,
-        agentic_app_blueprint_id: Optional[str] = None,
-    ) -> AgenticIdentity:
-        """Get an Agent ID identity for API calls.
+        agent_identity_blueprint_id: Optional[str] = None,
+    ) -> AgentUser:
+        """Get an AgentUser for API calls.
 
-        When ``agentic_app_blueprint_id`` is omitted, it defaults to the app's own
+        When ``agent_identity_blueprint_id`` is omitted, it defaults to the app's own
         client/app id (``self.id``).
         """
         resolved_tenant_id = tenant_id or (self.credentials.tenant_id if self.credentials else None)
         if resolved_tenant_id is None:
-            raise ValueError("tenant_id is required to get an agentic identity")
+            raise ValueError("tenant_id is required to get an agent user")
 
-        resolved_blueprint_id = agentic_app_blueprint_id or self.id
-        return AgenticIdentity(
-            agentic_app_id=agentic_app_id,
-            agentic_user_id=agentic_user_id,
+        resolved_blueprint_id = agent_identity_blueprint_id or self.id
+        return AgentUser(
+            agent_app_instance_id=agent_app_instance_id,
+            agent_user_id=agent_user_id,
             tenant_id=resolved_tenant_id,
-            agentic_app_blueprint_id=resolved_blueprint_id,
+            agent_identity_blueprint_id=resolved_blueprint_id,
         )
 
     @overload
@@ -367,7 +367,7 @@ class App(ActivityHandlerMixin):
         activity: str | ActivityParams | AdaptiveCard,
         *,
         service_url: Optional[str] = None,
-        agentic_identity: Optional[AgenticIdentity] = None,
+        agent_user: Optional[AgentUser] = None,
     ) -> SentActivity: ...
 
     @overload
@@ -377,7 +377,7 @@ class App(ActivityHandlerMixin):
         message_id: str | ActivityParams | AdaptiveCard,
         *,
         service_url: Optional[str] = None,
-        agentic_identity: Optional[AgenticIdentity] = None,
+        agent_user: Optional[AgentUser] = None,
     ) -> SentActivity: ...
 
     async def reply(  # type: ignore[reportInconsistentOverload]
@@ -387,7 +387,7 @@ class App(ActivityHandlerMixin):
         activity: str | ActivityParams | AdaptiveCard | None = None,
         *,
         service_url: Optional[str] = None,
-        agentic_identity: Optional[AgenticIdentity] = None,
+        agent_user: Optional[AgentUser] = None,
     ) -> SentActivity:
         """Send an activity proactively to a conversation, optionally as a threaded reply.
 
@@ -412,14 +412,14 @@ class App(ActivityHandlerMixin):
                 to_threaded_conversation_id(conversation_id, message_id),
                 activity,
                 service_url=service_url,
-                agentic_identity=agentic_identity,
+                agent_user=agent_user,
             )
 
         return await self.send(
             conversation_id,
             message_id,
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
     def use(self, middleware: Callable[[ActivityContext[ActivityBase]], Awaitable[None]]) -> None:

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -336,27 +336,27 @@ class App(ActivityHandlerMixin):
 
     def get_agentic_user(
         self,
-        agent_app_instance_id: str,
+        agentic_app_instance_id: str,
         agentic_user_id: str,
         *,
         tenant_id: Optional[str] = None,
-        agent_identity_blueprint_id: Optional[str] = None,
+        agentic_blueprint_id: Optional[str] = None,
     ) -> AgenticUser:
         """Get an AgenticUser for API calls.
 
-        When ``agent_identity_blueprint_id`` is omitted, it defaults to the app's own
+        When ``agentic_blueprint_id`` is omitted, it defaults to the app's own
         client/app id (``self.id``).
         """
         resolved_tenant_id = tenant_id or (self.credentials.tenant_id if self.credentials else None)
         if resolved_tenant_id is None:
             raise ValueError("tenant_id is required to get an agentic user")
 
-        resolved_blueprint_id = agent_identity_blueprint_id or self.id
+        resolved_blueprint_id = agentic_blueprint_id or self.id
         return AgenticUser(
-            agent_app_instance_id=agent_app_instance_id,
+            agentic_app_instance_id=agentic_app_instance_id,
             agentic_user_id=agentic_user_id,
             tenant_id=resolved_tenant_id,
-            agent_identity_blueprint_id=resolved_blueprint_id,
+            agentic_blueprint_id=resolved_blueprint_id,
         )
 
     @overload

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -111,7 +111,7 @@ class ActivityProcessor:
             self.http_client,
             self.api_client_settings,
             auth_provider=self.auth_provider,
-            agentic_identity=activity.recipient.agentic_identity,
+            agent_user=activity.recipient.agent_user,
         )
 
         # Check if user is signed in

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -111,7 +111,7 @@ class ActivityProcessor:
             self.http_client,
             self.api_client_settings,
             auth_provider=self.auth_provider,
-            agent_user=activity.recipient.agent_user,
+            agentic_user=activity.recipient.agentic_user,
         )
 
         # Check if user is signed in

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -230,7 +230,7 @@ class InboundActivityTokenValidator:
     """Validator for inbound Teams activities.
 
     Classic bot activities use Bot Framework connector tokens. Agent ID activities use
-    Entra tokens whose audience is the AgentIdentityBlueprint app ID.
+    Entra tokens whose audience is the AgenticBlueprint app ID.
     """
 
     def __init__(self, app_id: str, cloud: Optional[CloudEnvironment] = None):

--- a/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
+++ b/packages/apps/src/microsoft_teams/apps/auth/token_validator.py
@@ -230,7 +230,7 @@ class InboundActivityTokenValidator:
     """Validator for inbound Teams activities.
 
     Classic bot activities use Bot Framework connector tokens. Agent ID activities use
-    Entra tokens whose audience is the agent identity blueprint app ID.
+    Entra tokens whose audience is the AgentIdentityBlueprint app ID.
     """
 
     def __init__(self, app_id: str, cloud: Optional[CloudEnvironment] = None):

--- a/packages/apps/src/microsoft_teams/apps/auth_provider.py
+++ b/packages/apps/src/microsoft_teams/apps/auth_provider.py
@@ -3,31 +3,29 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from microsoft_teams.api import AgenticIdentity, TokenProtocol
+from microsoft_teams.api import AgentUser, TokenProtocol
 from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 
 from .token_manager import TokenManager
 
 
 class AppAuthProvider:
-    """Provides app and agentic tokens for Teams API clients."""
+    """Provides app and agent user tokens for Teams API clients."""
 
     def __init__(self, token_manager: TokenManager, cloud: CloudEnvironment):
         self._token_manager = token_manager
         self._cloud = cloud
 
-    async def token(
-        self, *, scope: str | None = None, agentic_identity: AgenticIdentity | None = None
-    ) -> TokenProtocol | None:
-        if agentic_identity is None:
+    async def token(self, *, scope: str | None = None, agent_user: AgentUser | None = None) -> TokenProtocol | None:
+        if agent_user is None:
             return await self._token_manager.get_app_token(
                 scope or self._cloud.bot_scope,
                 caller_name="token",
             )
 
-        return await self._token_manager.get_agentic_token(
-            scope or self._cloud.agentic_bot_scope,
-            agentic_identity,
+        return await self._token_manager.get_agent_user_token(
+            scope or self._cloud.agent_bot_scope,
+            agent_user,
             caller_name="token",
         )
 

--- a/packages/apps/src/microsoft_teams/apps/auth_provider.py
+++ b/packages/apps/src/microsoft_teams/apps/auth_provider.py
@@ -3,29 +3,29 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from microsoft_teams.api import AgentUser, TokenProtocol
+from microsoft_teams.api import AgenticUser, TokenProtocol
 from microsoft_teams.api.auth.cloud_environment import CloudEnvironment
 
 from .token_manager import TokenManager
 
 
 class AppAuthProvider:
-    """Provides app and agent user tokens for Teams API clients."""
+    """Provides app and agentic user tokens for Teams API clients."""
 
     def __init__(self, token_manager: TokenManager, cloud: CloudEnvironment):
         self._token_manager = token_manager
         self._cloud = cloud
 
-    async def token(self, *, scope: str | None = None, agent_user: AgentUser | None = None) -> TokenProtocol | None:
-        if agent_user is None:
+    async def token(self, *, scope: str | None = None, agentic_user: AgenticUser | None = None) -> TokenProtocol | None:
+        if agentic_user is None:
             return await self._token_manager.get_app_token(
                 scope or self._cloud.bot_scope,
                 caller_name="token",
             )
 
-        return await self._token_manager.get_agent_user_token(
+        return await self._token_manager.get_agentic_user_token(
             scope or self._cloud.agent_bot_scope,
-            agent_user,
+            agentic_user,
             caller_name="token",
         )
 

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -201,7 +201,7 @@ class ActivityContext(Generic[T]):
             self.api,
             activity,
             ref,
-            agentic_identity=self.activity.recipient.agentic_identity,
+            agent_user=self.activity.recipient.agent_user,
         )
 
     async def reply(self, input: str | ActivityParams) -> SentActivity:

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -201,7 +201,7 @@ class ActivityContext(Generic[T]):
             self.api,
             activity,
             ref,
-            agent_user=self.activity.recipient.agent_user,
+            agentic_user=self.activity.recipient.agentic_user,
         )
 
     async def reply(self, input: str | ActivityParams) -> SentActivity:

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
@@ -311,16 +311,16 @@ ACTIVITY_ROUTES: Dict[str, ActivityConfig] = {
         selector=_is_agent_lifecycle,
         output_model=None,
     ),
-    "agentic_user_identity_created": ActivityConfig(
-        name="agentic_user_identity_created",
-        method_name="on_agentic_user_identity_created",
+    "agent_user_identity_created": ActivityConfig(
+        name="agent_user_identity_created",
+        method_name="on_agent_user_identity_created",
         input_model=AgenticUserIdentityCreatedActivity,
         selector=lambda activity: _is_agent_lifecycle_variant(activity, "AgenticUserIdentityCreated"),
         output_model=None,
     ),
-    "agentic_user_identity_updated": ActivityConfig(
-        name="agentic_user_identity_updated",
-        method_name="on_agentic_user_identity_updated",
+    "agent_user_identity_updated": ActivityConfig(
+        name="agent_user_identity_updated",
+        method_name="on_agent_user_identity_updated",
         input_model=AgenticUserIdentityUpdatedActivity,
         selector=lambda activity: _is_agent_lifecycle_variant(activity, "AgenticUserIdentityUpdated"),
         output_model=None,

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_route_configs.py
@@ -311,16 +311,16 @@ ACTIVITY_ROUTES: Dict[str, ActivityConfig] = {
         selector=_is_agent_lifecycle,
         output_model=None,
     ),
-    "agent_user_identity_created": ActivityConfig(
-        name="agent_user_identity_created",
-        method_name="on_agent_user_identity_created",
+    "agentic_user_identity_created": ActivityConfig(
+        name="agentic_user_identity_created",
+        method_name="on_agentic_user_identity_created",
         input_model=AgenticUserIdentityCreatedActivity,
         selector=lambda activity: _is_agent_lifecycle_variant(activity, "AgenticUserIdentityCreated"),
         output_model=None,
     ),
-    "agent_user_identity_updated": ActivityConfig(
-        name="agent_user_identity_updated",
-        method_name="on_agent_user_identity_updated",
+    "agentic_user_identity_updated": ActivityConfig(
+        name="agentic_user_identity_updated",
+        method_name="on_agentic_user_identity_updated",
         input_model=AgenticUserIdentityUpdatedActivity,
         selector=lambda activity: _is_agent_lifecycle_variant(activity, "AgenticUserIdentityUpdated"),
         output_model=None,

--- a/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
@@ -779,21 +779,21 @@ class GeneratedActivityHandlerMixin(ABC):
         return decorator
 
     @overload
-    def on_agent_user_identity_created(
+    def on_agentic_user_identity_created(
         self, handler: BasicHandler[AgenticUserIdentityCreatedActivity]
     ) -> BasicHandler[AgenticUserIdentityCreatedActivity]: ...
 
     @overload
-    def on_agent_user_identity_created(
+    def on_agentic_user_identity_created(
         self,
     ) -> Callable[
         [BasicHandler[AgenticUserIdentityCreatedActivity]], BasicHandler[AgenticUserIdentityCreatedActivity]
     ]: ...
 
-    def on_agent_user_identity_created(
+    def on_agentic_user_identity_created(
         self, handler: Optional[BasicHandler[AgenticUserIdentityCreatedActivity]] = None
     ) -> BasicHandlerUnion[AgenticUserIdentityCreatedActivity]:
-        """Register a agent_user_identity_created activity handler."""
+        """Register a agentic_user_identity_created activity handler."""
 
         def decorator(
             func: BasicHandler[AgenticUserIdentityCreatedActivity],
@@ -801,10 +801,10 @@ class GeneratedActivityHandlerMixin(ABC):
             validate_handler_type(
                 func,
                 AgenticUserIdentityCreatedActivity,
-                "on_agent_user_identity_created",
+                "on_agentic_user_identity_created",
                 "AgenticUserIdentityCreatedActivity",
             )
-            config = ACTIVITY_ROUTES["agent_user_identity_created"]
+            config = ACTIVITY_ROUTES["agentic_user_identity_created"]
             self.router.add_handler(config.selector, func)
             return func
 
@@ -813,21 +813,21 @@ class GeneratedActivityHandlerMixin(ABC):
         return decorator
 
     @overload
-    def on_agent_user_identity_updated(
+    def on_agentic_user_identity_updated(
         self, handler: BasicHandler[AgenticUserIdentityUpdatedActivity]
     ) -> BasicHandler[AgenticUserIdentityUpdatedActivity]: ...
 
     @overload
-    def on_agent_user_identity_updated(
+    def on_agentic_user_identity_updated(
         self,
     ) -> Callable[
         [BasicHandler[AgenticUserIdentityUpdatedActivity]], BasicHandler[AgenticUserIdentityUpdatedActivity]
     ]: ...
 
-    def on_agent_user_identity_updated(
+    def on_agentic_user_identity_updated(
         self, handler: Optional[BasicHandler[AgenticUserIdentityUpdatedActivity]] = None
     ) -> BasicHandlerUnion[AgenticUserIdentityUpdatedActivity]:
-        """Register a agent_user_identity_updated activity handler."""
+        """Register a agentic_user_identity_updated activity handler."""
 
         def decorator(
             func: BasicHandler[AgenticUserIdentityUpdatedActivity],
@@ -835,10 +835,10 @@ class GeneratedActivityHandlerMixin(ABC):
             validate_handler_type(
                 func,
                 AgenticUserIdentityUpdatedActivity,
-                "on_agent_user_identity_updated",
+                "on_agentic_user_identity_updated",
                 "AgenticUserIdentityUpdatedActivity",
             )
-            config = ACTIVITY_ROUTES["agent_user_identity_updated"]
+            config = ACTIVITY_ROUTES["agentic_user_identity_updated"]
             self.router.add_handler(config.selector, func)
             return func
 

--- a/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/generated_handlers.py
@@ -779,21 +779,21 @@ class GeneratedActivityHandlerMixin(ABC):
         return decorator
 
     @overload
-    def on_agentic_user_identity_created(
+    def on_agent_user_identity_created(
         self, handler: BasicHandler[AgenticUserIdentityCreatedActivity]
     ) -> BasicHandler[AgenticUserIdentityCreatedActivity]: ...
 
     @overload
-    def on_agentic_user_identity_created(
+    def on_agent_user_identity_created(
         self,
     ) -> Callable[
         [BasicHandler[AgenticUserIdentityCreatedActivity]], BasicHandler[AgenticUserIdentityCreatedActivity]
     ]: ...
 
-    def on_agentic_user_identity_created(
+    def on_agent_user_identity_created(
         self, handler: Optional[BasicHandler[AgenticUserIdentityCreatedActivity]] = None
     ) -> BasicHandlerUnion[AgenticUserIdentityCreatedActivity]:
-        """Register a agentic_user_identity_created activity handler."""
+        """Register a agent_user_identity_created activity handler."""
 
         def decorator(
             func: BasicHandler[AgenticUserIdentityCreatedActivity],
@@ -801,10 +801,10 @@ class GeneratedActivityHandlerMixin(ABC):
             validate_handler_type(
                 func,
                 AgenticUserIdentityCreatedActivity,
-                "on_agentic_user_identity_created",
+                "on_agent_user_identity_created",
                 "AgenticUserIdentityCreatedActivity",
             )
-            config = ACTIVITY_ROUTES["agentic_user_identity_created"]
+            config = ACTIVITY_ROUTES["agent_user_identity_created"]
             self.router.add_handler(config.selector, func)
             return func
 
@@ -813,21 +813,21 @@ class GeneratedActivityHandlerMixin(ABC):
         return decorator
 
     @overload
-    def on_agentic_user_identity_updated(
+    def on_agent_user_identity_updated(
         self, handler: BasicHandler[AgenticUserIdentityUpdatedActivity]
     ) -> BasicHandler[AgenticUserIdentityUpdatedActivity]: ...
 
     @overload
-    def on_agentic_user_identity_updated(
+    def on_agent_user_identity_updated(
         self,
     ) -> Callable[
         [BasicHandler[AgenticUserIdentityUpdatedActivity]], BasicHandler[AgenticUserIdentityUpdatedActivity]
     ]: ...
 
-    def on_agentic_user_identity_updated(
+    def on_agent_user_identity_updated(
         self, handler: Optional[BasicHandler[AgenticUserIdentityUpdatedActivity]] = None
     ) -> BasicHandlerUnion[AgenticUserIdentityUpdatedActivity]:
-        """Register a agentic_user_identity_updated activity handler."""
+        """Register a agent_user_identity_updated activity handler."""
 
         def decorator(
             func: BasicHandler[AgenticUserIdentityUpdatedActivity],
@@ -835,10 +835,10 @@ class GeneratedActivityHandlerMixin(ABC):
             validate_handler_type(
                 func,
                 AgenticUserIdentityUpdatedActivity,
-                "on_agentic_user_identity_updated",
+                "on_agent_user_identity_updated",
                 "AgenticUserIdentityUpdatedActivity",
             )
-            config = ACTIVITY_ROUTES["agentic_user_identity_updated"]
+            config = ACTIVITY_ROUTES["agent_user_identity_updated"]
             self.router.add_handler(config.selector, func)
             return func
 

--- a/packages/apps/src/microsoft_teams/apps/token_manager.py
+++ b/packages/apps/src/microsoft_teams/apps/token_manager.py
@@ -10,7 +10,7 @@ from typing import Any, Awaitable, Callable, Optional, cast
 
 import requests
 from microsoft_teams.api import (
-    AgentUser,
+    AgenticUser,
     ClientCredentials,
     Credentials,
     JsonWebToken,
@@ -92,36 +92,36 @@ class TokenManager:
             default_tenant_id=DEFAULT_TENANT_FOR_GRAPH_TOKEN,
         )
 
-    async def get_agent_user_token(
+    async def get_agentic_user_token(
         self,
         scope: str,
-        agent_user: AgentUser,
+        agentic_user: AgenticUser,
         *,
         caller_name: str | None = None,
     ) -> Optional[TokenProtocol]:
-        """Get a resource token for an agent user acting through its AgentAppInstance."""
-        if not agent_user.agent_user_id:
-            raise ValueError("agent_user.agent_user_id is required to get an agent user token")
+        """Get a resource token for an agentic user acting through its AgentAppInstance."""
+        if not agentic_user.agentic_user_id:
+            raise ValueError("agentic_user.agentic_user_id is required to get an agentic user token")
         if self._credentials is None:
             if caller_name:
                 logger.debug(f"No credentials provided for {caller_name}")
             return None
 
-        tenant_id = self._resolve_tenant_id(agent_user.tenant_id, None)
+        tenant_id = self._resolve_tenant_id(agentic_user.tenant_id, None)
         if tenant_id is None:
-            raise ValueError("tenant_id is required to get an agent user token")
+            raise ValueError("tenant_id is required to get an agentic user token")
 
         credentials = self._credentials
         if isinstance(credentials, TokenCredentials):
-            return await self._get_token_with_token_provider(credentials, scope, tenant_id, agent_user)
+            return await self._get_token_with_token_provider(credentials, scope, tenant_id, agentic_user)
 
         if not isinstance(credentials, ClientCredentials):
-            raise ValueError("Agent user tokens require ClientCredentials")
+            raise ValueError("Agentic user tokens require ClientCredentials")
         confidential_client = self._get_confidential_client(credentials, tenant_id)
 
         def get_t1_assertion(_context: dict[str, Any]) -> str:
             t1_raw: dict[str, Any] = confidential_client.acquire_token_for_client(
-                [TOKEN_EXCHANGE_SCOPE], fmi_path=agent_user.agent_app_instance_id
+                [TOKEN_EXCHANGE_SCOPE], fmi_path=agentic_user.agent_app_instance_id
             )
             return self._get_access_token_or_raise(t1_raw, "Agent token exchange step 1 failed")
 
@@ -129,7 +129,7 @@ class TokenManager:
         # Identity assertion from step 1 as its client assertion for the next exchanges.
         t2_confidential_client = self._get_agent_app_instance_client(
             tenant_id,
-            agent_user.agent_app_instance_id,
+            agentic_user.agent_app_instance_id,
             get_t1_assertion,
         )
 
@@ -143,12 +143,12 @@ class TokenManager:
             lambda: t2_confidential_client.acquire_token_by_user_federated_identity_credential(
                 [scope],
                 assertion=t2,
-                user_object_id=agent_user.agent_user_id,
+                user_object_id=agentic_user.agentic_user_id,
                 username=None,
                 data={"requested_token_use": "on_behalf_of"},
             )
         )
-        return self._handle_token_response(t3_raw, caller_name or "get_agent_user_token")
+        return self._handle_token_response(t3_raw, caller_name or "get_agentic_user_token")
 
     def _get_access_token_or_raise(self, token_res: dict[str, Any], error_prefix: str) -> str:
         if token_res.get("access_token", None):
@@ -250,10 +250,10 @@ class TokenManager:
         credentials: TokenCredentials,
         scope: str,
         tenant_id: str,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> TokenProtocol:
         """Get token using custom token provider function."""
-        token = self._call_token_provider(credentials, scope, tenant_id, agent_user)
+        token = self._call_token_provider(credentials, scope, tenant_id, agentic_user)
 
         if isawaitable(token):
             access_token = await token
@@ -267,21 +267,21 @@ class TokenManager:
         credentials: TokenCredentials,
         scope: str,
         tenant_id: str,
-        agent_user: AgentUser | None = None,
+        agentic_user: AgenticUser | None = None,
     ) -> str | Awaitable[str]:
         token_provider = cast(Any, credentials.token)
         try:
             parameters = list(signature(token_provider).parameters.values())
         except (TypeError, ValueError) as error:
-            if agent_user is not None:
-                raise ValueError("Token provider must accept agent_user to mint agent user tokens") from error
+            if agentic_user is not None:
+                raise ValueError("Token provider must accept agentic_user to mint agentic user tokens") from error
             return cast(str | Awaitable[str], token_provider(scope, tenant_id))
 
-        accepts_agent_user = any(
-            parameter.kind == Parameter.VAR_KEYWORD or parameter.name == "agent_user" for parameter in parameters
+        accepts_agentic_user = any(
+            parameter.kind == Parameter.VAR_KEYWORD or parameter.name == "agentic_user" for parameter in parameters
         )
-        if accepts_agent_user:
-            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agent_user=agent_user))
+        if accepts_agentic_user:
+            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agentic_user=agentic_user))
 
         positional_parameters = [
             parameter
@@ -291,11 +291,11 @@ class TokenManager:
         required_positional_parameters = [
             parameter for parameter in positional_parameters if parameter.default is Parameter.empty
         ]
-        if len(positional_parameters) >= 3 and (agent_user is not None or len(required_positional_parameters) >= 3):
-            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agent_user))
+        if len(positional_parameters) >= 3 and (agentic_user is not None or len(required_positional_parameters) >= 3):
+            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agentic_user))
 
-        if agent_user is not None:
-            raise ValueError("Token provider must accept agent_user to mint agent user tokens")
+        if agentic_user is not None:
+            raise ValueError("Token provider must accept agentic_user to mint agentic user tokens")
 
         return cast(str | Awaitable[str], token_provider(scope, tenant_id))
 

--- a/packages/apps/src/microsoft_teams/apps/token_manager.py
+++ b/packages/apps/src/microsoft_teams/apps/token_manager.py
@@ -10,7 +10,7 @@ from typing import Any, Awaitable, Callable, Optional, cast
 
 import requests
 from microsoft_teams.api import (
-    AgenticIdentity,
+    AgentUser,
     ClientCredentials,
     Credentials,
     JsonWebToken,
@@ -48,7 +48,9 @@ class TokenManager:
         self._cloud = cloud or PUBLIC
         self._confidential_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
         self._federated_identity_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
-        self._agent_identity_clients_by_tenant_and_app_id: dict[tuple[str, str], ConfidentialClientApplication] = {}
+        self._agent_app_instance_clients_by_tenant_and_app_instance_id: dict[
+            tuple[str, str], ConfidentialClientApplication
+        ] = {}
         self._managed_identity_client: Optional[ManagedIdentityClient] = None
 
     async def get_bot_token(self) -> Optional[TokenProtocol]:
@@ -90,28 +92,28 @@ class TokenManager:
             default_tenant_id=DEFAULT_TENANT_FOR_GRAPH_TOKEN,
         )
 
-    async def get_agentic_token(
+    async def get_agent_user_token(
         self,
         scope: str,
-        agentic_identity: AgenticIdentity,
+        agent_user: AgentUser,
         *,
         caller_name: str | None = None,
     ) -> Optional[TokenProtocol]:
-        """Get a resource token for an agentic identity acting through its agentic user."""
-        if not agentic_identity.agentic_user_id:
-            raise ValueError("agentic_identity.agentic_user_id is required to get an agentic token")
+        """Get a resource token for an agent user acting through its AgentAppInstance."""
+        if not agent_user.agent_user_id:
+            raise ValueError("agent_user.agent_user_id is required to get an agent user token")
         if self._credentials is None:
             if caller_name:
                 logger.debug(f"No credentials provided for {caller_name}")
             return None
 
-        tenant_id = self._resolve_tenant_id(agentic_identity.tenant_id, None)
+        tenant_id = self._resolve_tenant_id(agent_user.tenant_id, None)
         if tenant_id is None:
-            raise ValueError("tenant_id is required to get an agentic token")
+            raise ValueError("tenant_id is required to get an agent user token")
 
         credentials = self._credentials
         if isinstance(credentials, TokenCredentials):
-            return await self._get_token_with_token_provider(credentials, scope, tenant_id, agentic_identity)
+            return await self._get_token_with_token_provider(credentials, scope, tenant_id, agent_user)
 
         if not isinstance(credentials, ClientCredentials):
             raise ValueError("Agent user tokens require ClientCredentials")
@@ -119,15 +121,15 @@ class TokenManager:
 
         def get_t1_assertion(_context: dict[str, Any]) -> str:
             t1_raw: dict[str, Any] = confidential_client.acquire_token_for_client(
-                [TOKEN_EXCHANGE_SCOPE], fmi_path=agentic_identity.agentic_app_id
+                [TOKEN_EXCHANGE_SCOPE], fmi_path=agent_user.agent_app_instance_id
             )
             return self._get_access_token_or_raise(t1_raw, "Agent token exchange step 1 failed")
 
-        # The agent identity app needs its own MSAL client. It uses the Federated Managed
+        # The AgentAppInstance needs its own MSAL client. It uses the Federated Managed
         # Identity assertion from step 1 as its client assertion for the next exchanges.
-        t2_confidential_client = self._get_agent_identity_client(
+        t2_confidential_client = self._get_agent_app_instance_client(
             tenant_id,
-            agentic_identity.agentic_app_id,
+            agent_user.agent_app_instance_id,
             get_t1_assertion,
         )
 
@@ -141,12 +143,12 @@ class TokenManager:
             lambda: t2_confidential_client.acquire_token_by_user_federated_identity_credential(
                 [scope],
                 assertion=t2,
-                user_object_id=agentic_identity.agentic_user_id,
+                user_object_id=agent_user.agent_user_id,
                 username=None,
                 data={"requested_token_use": "on_behalf_of"},
             )
         )
-        return self._handle_token_response(t3_raw, caller_name or "get_agentic_token")
+        return self._handle_token_response(t3_raw, caller_name or "get_agent_user_token")
 
     def _get_access_token_or_raise(self, token_res: dict[str, Any], error_prefix: str) -> str:
         if token_res.get("access_token", None):
@@ -248,10 +250,10 @@ class TokenManager:
         credentials: TokenCredentials,
         scope: str,
         tenant_id: str,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> TokenProtocol:
         """Get token using custom token provider function."""
-        token = self._call_token_provider(credentials, scope, tenant_id, agentic_identity)
+        token = self._call_token_provider(credentials, scope, tenant_id, agent_user)
 
         if isawaitable(token):
             access_token = await token
@@ -265,21 +267,21 @@ class TokenManager:
         credentials: TokenCredentials,
         scope: str,
         tenant_id: str,
-        agentic_identity: AgenticIdentity | None = None,
+        agent_user: AgentUser | None = None,
     ) -> str | Awaitable[str]:
         token_provider = cast(Any, credentials.token)
         try:
             parameters = list(signature(token_provider).parameters.values())
         except (TypeError, ValueError) as error:
-            if agentic_identity is not None:
-                raise ValueError("Token provider must accept agentic_identity to mint agentic tokens") from error
+            if agent_user is not None:
+                raise ValueError("Token provider must accept agent_user to mint agent user tokens") from error
             return cast(str | Awaitable[str], token_provider(scope, tenant_id))
 
-        accepts_agentic_identity = any(
-            parameter.kind == Parameter.VAR_KEYWORD or parameter.name == "agentic_identity" for parameter in parameters
+        accepts_agent_user = any(
+            parameter.kind == Parameter.VAR_KEYWORD or parameter.name == "agent_user" for parameter in parameters
         )
-        if accepts_agentic_identity:
-            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agentic_identity=agentic_identity))
+        if accepts_agent_user:
+            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agent_user=agent_user))
 
         positional_parameters = [
             parameter
@@ -289,13 +291,11 @@ class TokenManager:
         required_positional_parameters = [
             parameter for parameter in positional_parameters if parameter.default is Parameter.empty
         ]
-        if len(positional_parameters) >= 3 and (
-            agentic_identity is not None or len(required_positional_parameters) >= 3
-        ):
-            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agentic_identity))
+        if len(positional_parameters) >= 3 and (agent_user is not None or len(required_positional_parameters) >= 3):
+            return cast(str | Awaitable[str], token_provider(scope, tenant_id, agent_user))
 
-        if agentic_identity is not None:
-            raise ValueError("Token provider must accept agentic_identity to mint agentic tokens")
+        if agent_user is not None:
+            raise ValueError("Token provider must accept agent_user to mint agent user tokens")
 
         return cast(str | Awaitable[str], token_provider(scope, tenant_id))
 
@@ -348,22 +348,24 @@ class TokenManager:
         self._federated_identity_clients_by_tenant[tenant_id] = client
         return client
 
-    def _get_agent_identity_client(
+    def _get_agent_app_instance_client(
         self,
         tenant_id: str,
-        agentic_app_id: str,
+        agent_app_instance_id: str,
         client_assertion: Callable[[dict[str, Any]], str],
     ) -> ConfidentialClientApplication:
-        cached_client = self._agent_identity_clients_by_tenant_and_app_id.get((tenant_id, agentic_app_id))
+        cached_client = self._agent_app_instance_clients_by_tenant_and_app_instance_id.get(
+            (tenant_id, agent_app_instance_id)
+        )
         if cached_client:
             return cached_client
 
         client: ConfidentialClientApplication = ConfidentialClientApplication(
-            agentic_app_id,
+            agent_app_instance_id,
             client_credential={"client_assertion": client_assertion},
             authority=f"{self._cloud.login_endpoint}/{tenant_id}",
         )
-        self._agent_identity_clients_by_tenant_and_app_id[(tenant_id, agentic_app_id)] = client
+        self._agent_app_instance_clients_by_tenant_and_app_instance_id[(tenant_id, agent_app_instance_id)] = client
         return client
 
     def _get_managed_identity_client(

--- a/packages/apps/src/microsoft_teams/apps/token_manager.py
+++ b/packages/apps/src/microsoft_teams/apps/token_manager.py
@@ -48,7 +48,7 @@ class TokenManager:
         self._cloud = cloud or PUBLIC
         self._confidential_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
         self._federated_identity_clients_by_tenant: dict[str, ConfidentialClientApplication] = {}
-        self._agent_app_instance_clients_by_tenant_and_app_instance_id: dict[
+        self._agentic_app_instance_clients_by_tenant_and_app_instance_id: dict[
             tuple[str, str], ConfidentialClientApplication
         ] = {}
         self._managed_identity_client: Optional[ManagedIdentityClient] = None
@@ -99,7 +99,7 @@ class TokenManager:
         *,
         caller_name: str | None = None,
     ) -> Optional[TokenProtocol]:
-        """Get a resource token for an agentic user acting through its AgentAppInstance."""
+        """Get a resource token for an agentic user acting through its AgenticAppInstance."""
         if not agentic_user.agentic_user_id:
             raise ValueError("agentic_user.agentic_user_id is required to get an agentic user token")
         if self._credentials is None:
@@ -121,15 +121,15 @@ class TokenManager:
 
         def get_t1_assertion(_context: dict[str, Any]) -> str:
             t1_raw: dict[str, Any] = confidential_client.acquire_token_for_client(
-                [TOKEN_EXCHANGE_SCOPE], fmi_path=agentic_user.agent_app_instance_id
+                [TOKEN_EXCHANGE_SCOPE], fmi_path=agentic_user.agentic_app_instance_id
             )
             return self._get_access_token_or_raise(t1_raw, "Agent token exchange step 1 failed")
 
-        # The AgentAppInstance needs its own MSAL client. It uses the Federated Managed
+        # The AgenticAppInstance needs its own MSAL client. It uses the Federated Managed
         # Identity assertion from step 1 as its client assertion for the next exchanges.
-        t2_confidential_client = self._get_agent_app_instance_client(
+        t2_confidential_client = self._get_agentic_app_instance_client(
             tenant_id,
-            agentic_user.agent_app_instance_id,
+            agentic_user.agentic_app_instance_id,
             get_t1_assertion,
         )
 
@@ -348,24 +348,24 @@ class TokenManager:
         self._federated_identity_clients_by_tenant[tenant_id] = client
         return client
 
-    def _get_agent_app_instance_client(
+    def _get_agentic_app_instance_client(
         self,
         tenant_id: str,
-        agent_app_instance_id: str,
+        agentic_app_instance_id: str,
         client_assertion: Callable[[dict[str, Any]], str],
     ) -> ConfidentialClientApplication:
-        cached_client = self._agent_app_instance_clients_by_tenant_and_app_instance_id.get(
-            (tenant_id, agent_app_instance_id)
+        cached_client = self._agentic_app_instance_clients_by_tenant_and_app_instance_id.get(
+            (tenant_id, agentic_app_instance_id)
         )
         if cached_client:
             return cached_client
 
         client: ConfidentialClientApplication = ConfidentialClientApplication(
-            agent_app_instance_id,
+            agentic_app_instance_id,
             client_credential={"client_assertion": client_assertion},
             authority=f"{self._cloud.login_endpoint}/{tenant_id}",
         )
-        self._agent_app_instance_clients_by_tenant_and_app_instance_id[(tenant_id, agent_app_instance_id)] = client
+        self._agentic_app_instance_clients_by_tenant_and_app_instance_id[(tenant_id, agentic_app_instance_id)] = client
         return client
 
     def _get_managed_identity_client(

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -400,13 +400,13 @@ class TestActivityContextSend:
         assert isinstance(result, SentActivity)
 
     @pytest.mark.asyncio
-    async def test_send_passes_inbound_agentic_identity(self) -> None:
-        """Sending from an Agent ID activity uses the inbound agentic identity."""
+    async def test_send_passes_inbound_agent_user(self) -> None:
+        """Sending from an Agent ID activity uses the inbound agent user."""
         recipient = Account(
             id="bot-id",
             name="Test Bot",
-            agentic_app_id="agentic-app-id",
-            agentic_user_id="agentic-user-id",
+            agent_app_instance_id="agent-app-instance-id",
+            agent_user_id="agent-user-id",
             tenant_id="tenant-id",
         )
         activity = MessageActivity(
@@ -423,7 +423,7 @@ class TestActivityContextSend:
         mock_sender.send.assert_called_once()
         ctx.api.clone.assert_called_once_with(
             service_url=ctx.conversation_ref.service_url,
-            agentic_identity=recipient.agentic_identity,
+            agent_user=recipient.agent_user,
         )
 
 
@@ -471,13 +471,13 @@ class TestActivityContextReply:
         assert sent_activity.entities[0].quoted_reply.message_id == "evt-id-999"
 
     @pytest.mark.asyncio
-    async def test_reply_passes_inbound_agentic_identity(self) -> None:
-        """Replying to an Agent ID activity uses the inbound agentic identity."""
+    async def test_reply_passes_inbound_agent_user(self) -> None:
+        """Replying to an Agent ID activity uses the inbound agent user."""
         recipient = Account(
             id="bot-id",
             name="Test Bot",
-            agentic_app_id="agentic-app-id",
-            agentic_user_id="agentic-user-id",
+            agent_app_instance_id="agent-app-instance-id",
+            agent_user_id="agent-user-id",
             tenant_id="tenant-id",
         )
         activity = MessageActivity(
@@ -494,7 +494,7 @@ class TestActivityContextReply:
         mock_sender.send.assert_called_once()
         ctx.api.clone.assert_called_once_with(
             service_url=ctx.conversation_ref.service_url,
-            agentic_identity=recipient.agentic_identity,
+            agent_user=recipient.agent_user,
         )
 
 

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -400,13 +400,13 @@ class TestActivityContextSend:
         assert isinstance(result, SentActivity)
 
     @pytest.mark.asyncio
-    async def test_send_passes_inbound_agent_user(self) -> None:
-        """Sending from an Agent ID activity uses the inbound agent user."""
+    async def test_send_passes_inbound_agentic_user(self) -> None:
+        """Sending from an Agent ID activity uses the inbound agentic user."""
         recipient = Account(
             id="bot-id",
             name="Test Bot",
             agent_app_instance_id="agent-app-instance-id",
-            agent_user_id="agent-user-id",
+            agentic_user_id="agentic-user-id",
             tenant_id="tenant-id",
         )
         activity = MessageActivity(
@@ -423,7 +423,7 @@ class TestActivityContextSend:
         mock_sender.send.assert_called_once()
         ctx.api.clone.assert_called_once_with(
             service_url=ctx.conversation_ref.service_url,
-            agent_user=recipient.agent_user,
+            agentic_user=recipient.agentic_user,
         )
 
 
@@ -471,13 +471,13 @@ class TestActivityContextReply:
         assert sent_activity.entities[0].quoted_reply.message_id == "evt-id-999"
 
     @pytest.mark.asyncio
-    async def test_reply_passes_inbound_agent_user(self) -> None:
-        """Replying to an Agent ID activity uses the inbound agent user."""
+    async def test_reply_passes_inbound_agentic_user(self) -> None:
+        """Replying to an Agent ID activity uses the inbound agentic user."""
         recipient = Account(
             id="bot-id",
             name="Test Bot",
             agent_app_instance_id="agent-app-instance-id",
-            agent_user_id="agent-user-id",
+            agentic_user_id="agentic-user-id",
             tenant_id="tenant-id",
         )
         activity = MessageActivity(
@@ -494,7 +494,7 @@ class TestActivityContextReply:
         mock_sender.send.assert_called_once()
         ctx.api.clone.assert_called_once_with(
             service_url=ctx.conversation_ref.service_url,
-            agent_user=recipient.agent_user,
+            agentic_user=recipient.agentic_user,
         )
 
 

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -405,7 +405,7 @@ class TestActivityContextSend:
         recipient = Account(
             id="bot-id",
             name="Test Bot",
-            agent_app_instance_id="agent-app-instance-id",
+            agentic_app_instance_id="agentic-app-instance-id",
             agentic_user_id="agentic-user-id",
             tenant_id="tenant-id",
         )
@@ -476,7 +476,7 @@ class TestActivityContextReply:
         recipient = Account(
             id="bot-id",
             name="Test Bot",
-            agent_app_instance_id="agent-app-instance-id",
+            agentic_app_instance_id="agentic-app-instance-id",
             agentic_user_id="agentic-user-id",
             tenant_id="tenant-id",
         )

--- a/packages/apps/tests/test_agent_lifecycle_routes.py
+++ b/packages/apps/tests/test_agent_lifecycle_routes.py
@@ -23,8 +23,8 @@ def _identity_created() -> AgenticUserIdentityCreatedActivity:
         channel_id="agents",
         from_=Account(id="system", name="System"),
         conversation=ConversationAccount(id="conversation-1"),
-        recipient=Account(id="agentic-user-1"),
-        value=AgenticUserIdentityCreatedValue(agentic_user_id="agentic-user-1"),
+        recipient=Account(id="agent-user-1"),
+        value=AgenticUserIdentityCreatedValue(agent_user_id="agent-user-1"),
     )
 
 
@@ -34,8 +34,8 @@ def _enabled() -> AgenticUserEnabledActivity:
         channel_id="agents",
         from_=Account(id="system", name="System"),
         conversation=ConversationAccount(id="conversation-1"),
-        recipient=Account(id="agentic-user-1"),
-        value=AgenticUserEnabledValue(agentic_user_id="agentic-user-1", version=6),
+        recipient=Account(id="agent-user-1"),
+        value=AgenticUserEnabledValue(agent_user_id="agent-user-1", version=6),
     )
 
 
@@ -45,9 +45,9 @@ def _manager_updated() -> AgenticUserManagerUpdatedActivity:
         channel_id="agents",
         from_=Account(id="system", name="System"),
         conversation=ConversationAccount(id="conversation-1"),
-        recipient=Account(id="agentic-user-1"),
+        recipient=Account(id="agent-user-1"),
         value=AgenticUserManagerUpdatedValue(
-            agentic_user_id="agentic-user-1", manager=AgentLifecycleManagerRef(manager_id="manager-1")
+            agent_user_id="agent-user-1", manager=AgentLifecycleManagerRef(manager_id="manager-1")
         ),
     )
 
@@ -63,7 +63,7 @@ def test_general_agent_lifecycle_route_matches_every_variant() -> None:
 @pytest.mark.parametrize(
     "route_key,activity_factory",
     [
-        ("agentic_user_identity_created", _identity_created),
+        ("agent_user_identity_created", _identity_created),
         ("agentic_user_enabled", _enabled),
         ("agentic_user_manager_updated", _manager_updated),
     ],
@@ -76,7 +76,7 @@ def test_variant_route_matches_only_its_own_variant(route_key, activity_factory)
     other_keys = [
         key
         for key in (
-            "agentic_user_identity_created",
+            "agent_user_identity_created",
             "agentic_user_enabled",
             "agentic_user_manager_updated",
         )

--- a/packages/apps/tests/test_agent_lifecycle_routes.py
+++ b/packages/apps/tests/test_agent_lifecycle_routes.py
@@ -23,8 +23,8 @@ def _identity_created() -> AgenticUserIdentityCreatedActivity:
         channel_id="agents",
         from_=Account(id="system", name="System"),
         conversation=ConversationAccount(id="conversation-1"),
-        recipient=Account(id="agent-user-1"),
-        value=AgenticUserIdentityCreatedValue(agent_user_id="agent-user-1"),
+        recipient=Account(id="agentic-user-1"),
+        value=AgenticUserIdentityCreatedValue(agentic_user_id="agentic-user-1"),
     )
 
 
@@ -34,8 +34,8 @@ def _enabled() -> AgenticUserEnabledActivity:
         channel_id="agents",
         from_=Account(id="system", name="System"),
         conversation=ConversationAccount(id="conversation-1"),
-        recipient=Account(id="agent-user-1"),
-        value=AgenticUserEnabledValue(agent_user_id="agent-user-1", version=6),
+        recipient=Account(id="agentic-user-1"),
+        value=AgenticUserEnabledValue(agentic_user_id="agentic-user-1", version=6),
     )
 
 
@@ -45,9 +45,9 @@ def _manager_updated() -> AgenticUserManagerUpdatedActivity:
         channel_id="agents",
         from_=Account(id="system", name="System"),
         conversation=ConversationAccount(id="conversation-1"),
-        recipient=Account(id="agent-user-1"),
+        recipient=Account(id="agentic-user-1"),
         value=AgenticUserManagerUpdatedValue(
-            agent_user_id="agent-user-1", manager=AgentLifecycleManagerRef(manager_id="manager-1")
+            agentic_user_id="agentic-user-1", manager=AgentLifecycleManagerRef(manager_id="manager-1")
         ),
     )
 
@@ -63,7 +63,7 @@ def test_general_agent_lifecycle_route_matches_every_variant() -> None:
 @pytest.mark.parametrize(
     "route_key,activity_factory",
     [
-        ("agent_user_identity_created", _identity_created),
+        ("agentic_user_identity_created", _identity_created),
         ("agentic_user_enabled", _enabled),
         ("agentic_user_manager_updated", _manager_updated),
     ],
@@ -76,7 +76,7 @@ def test_variant_route_matches_only_its_own_variant(route_key, activity_factory)
     other_keys = [
         key
         for key in (
-            "agent_user_identity_created",
+            "agentic_user_identity_created",
             "agentic_user_enabled",
             "agentic_user_manager_updated",
         )

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -15,7 +15,7 @@ import httpx
 import pytest
 from microsoft_teams.api import (
     Account,
-    AgentUser,
+    AgenticUser,
     ConversationAccount,
     FederatedIdentityCredentials,
     InvokeActivity,
@@ -882,7 +882,7 @@ class TestApp:
         assert sent_activity.conversation.id == "conv-123"
 
     @pytest.mark.asyncio
-    async def test_send_passes_service_url_and_agent_user_to_scoped_api(self, mock_storage) -> None:
+    async def test_send_passes_service_url_and_agentic_user_to_scoped_api(self, mock_storage) -> None:
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
         app._initialized = True
@@ -894,20 +894,20 @@ class TestApp:
         app.api.conversations.activities = MagicMock(return_value=activities)
         _wire_flat_activity_methods(app.api, activities)
         app.api.clone = MagicMock(return_value=app.api)
-        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         result = await app.send(
             "conv-123",
             "Hello",
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
         app.api.conversations.activities.assert_called_once_with("conv-123")
         app.api.clone.assert_called_once_with(
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
         create.assert_called_once()
         activity = create.call_args.args[0]
@@ -917,7 +917,7 @@ class TestApp:
         assert result.id == "sent-activity-id"
 
     @pytest.mark.asyncio
-    async def test_send_uses_existing_api_when_agent_user_is_none(self, mock_storage) -> None:
+    async def test_send_uses_existing_api_when_agentic_user_is_none(self, mock_storage) -> None:
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
         app._initialized = True
@@ -929,32 +929,32 @@ class TestApp:
         _wire_flat_activity_methods(app.api, activities)
         app.api.clone = MagicMock(return_value=app.api)
 
-        await app.send("conv-123", "Hello", agent_user=None)
+        await app.send("conv-123", "Hello", agentic_user=None)
 
         app.api.clone.assert_not_called()
 
-    def test_get_agent_user_preserves_explicit_blueprint_id(self, mock_storage) -> None:
+    def test_get_agentic_user_preserves_explicit_blueprint_id(self, mock_storage) -> None:
         """An explicitly provided agent_identity_blueprint_id should be preserved."""
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
-        identity = app.get_agent_user(
+        identity = app.get_agentic_user(
             "agent-app-instance-id",
-            "agent-user-id",
+            "agentic-user-id",
             tenant_id="tenant-id",
             agent_identity_blueprint_id="explicit-blueprint-id",
         )
 
         assert identity.agent_identity_blueprint_id == "explicit-blueprint-id"
 
-    def test_get_agent_user_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
+    def test_get_agentic_user_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
         """When agent_identity_blueprint_id is omitted, it should default to the app's client id."""
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
-        identity = app.get_agent_user(
+        identity = app.get_agentic_user(
             "agent-app-instance-id",
-            "agent-user-id",
+            "agentic-user-id",
             tenant_id="tenant-id",
         )
 
@@ -1052,8 +1052,8 @@ class TestAppReply:
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
 
     @pytest.mark.asyncio
-    async def test_reply_with_three_args_passes_service_url_and_agent_user_to_scoped_api(self, started_app):
-        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+    async def test_reply_with_three_args_passes_service_url_and_agentic_user_to_scoped_api(self, started_app):
+        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         await started_app.reply(
@@ -1061,13 +1061,13 @@ class TestAppReply:
             "1680000000000",
             "Hello thread",
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
         started_app.api.clone.assert_called_once_with(
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
         create = started_app.api.conversations.activities.return_value.create
         activity = create.call_args.args[0]
@@ -1082,21 +1082,21 @@ class TestAppReply:
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
 
     @pytest.mark.asyncio
-    async def test_reply_with_two_args_passes_service_url_and_agent_user_to_scoped_api(self, started_app):
-        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+    async def test_reply_with_two_args_passes_service_url_and_agentic_user_to_scoped_api(self, started_app):
+        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         await started_app.reply(
             "19:abc@thread.skype",
             "Hello flat",
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
         started_app.api.clone.assert_called_once_with(
             service_url=service_url,
-            agent_user=agent_user,
+            agentic_user=agentic_user,
         )
         create = started_app.api.conversations.activities.return_value.create
         activity = create.call_args.args[0]

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -15,7 +15,7 @@ import httpx
 import pytest
 from microsoft_teams.api import (
     Account,
-    AgenticIdentity,
+    AgentUser,
     ConversationAccount,
     FederatedIdentityCredentials,
     InvokeActivity,
@@ -882,7 +882,7 @@ class TestApp:
         assert sent_activity.conversation.id == "conv-123"
 
     @pytest.mark.asyncio
-    async def test_send_passes_service_url_and_agentic_identity_to_scoped_api(self, mock_storage) -> None:
+    async def test_send_passes_service_url_and_agent_user_to_scoped_api(self, mock_storage) -> None:
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
         app._initialized = True
@@ -894,20 +894,20 @@ class TestApp:
         app.api.conversations.activities = MagicMock(return_value=activities)
         _wire_flat_activity_methods(app.api, activities)
         app.api.clone = MagicMock(return_value=app.api)
-        agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         result = await app.send(
             "conv-123",
             "Hello",
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
         app.api.conversations.activities.assert_called_once_with("conv-123")
         app.api.clone.assert_called_once_with(
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
         create.assert_called_once()
         activity = create.call_args.args[0]
@@ -917,7 +917,7 @@ class TestApp:
         assert result.id == "sent-activity-id"
 
     @pytest.mark.asyncio
-    async def test_send_uses_existing_api_when_agentic_identity_is_none(self, mock_storage) -> None:
+    async def test_send_uses_existing_api_when_agent_user_is_none(self, mock_storage) -> None:
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
         app._initialized = True
@@ -929,37 +929,37 @@ class TestApp:
         _wire_flat_activity_methods(app.api, activities)
         app.api.clone = MagicMock(return_value=app.api)
 
-        await app.send("conv-123", "Hello", agentic_identity=None)
+        await app.send("conv-123", "Hello", agent_user=None)
 
         app.api.clone.assert_not_called()
 
-    def test_get_agentic_identity_preserves_explicit_blueprint_id(self, mock_storage) -> None:
-        """An explicitly provided agentic_app_blueprint_id should be preserved."""
+    def test_get_agent_user_preserves_explicit_blueprint_id(self, mock_storage) -> None:
+        """An explicitly provided agent_identity_blueprint_id should be preserved."""
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
-        identity = app.get_agentic_identity(
-            "agentic-app-id",
-            "agentic-user-id",
+        identity = app.get_agent_user(
+            "agent-app-instance-id",
+            "agent-user-id",
             tenant_id="tenant-id",
-            agentic_app_blueprint_id="explicit-blueprint-id",
+            agent_identity_blueprint_id="explicit-blueprint-id",
         )
 
-        assert identity.agentic_app_blueprint_id == "explicit-blueprint-id"
+        assert identity.agent_identity_blueprint_id == "explicit-blueprint-id"
 
-    def test_get_agentic_identity_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
-        """When agentic_app_blueprint_id is omitted, it should default to the app's client id."""
+    def test_get_agent_user_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
+        """When agent_identity_blueprint_id is omitted, it should default to the app's client id."""
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
-        identity = app.get_agentic_identity(
-            "agentic-app-id",
-            "agentic-user-id",
+        identity = app.get_agent_user(
+            "agent-app-instance-id",
+            "agent-user-id",
             tenant_id="tenant-id",
         )
 
-        assert identity.agentic_app_blueprint_id == app.id
-        assert identity.agentic_app_blueprint_id == "test-client-id"
+        assert identity.agent_identity_blueprint_id == app.id
+        assert identity.agent_identity_blueprint_id == "test-client-id"
 
 
 class TestAppInitialize:
@@ -1052,8 +1052,8 @@ class TestAppReply:
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
 
     @pytest.mark.asyncio
-    async def test_reply_with_three_args_passes_service_url_and_agentic_identity_to_scoped_api(self, started_app):
-        agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+    async def test_reply_with_three_args_passes_service_url_and_agent_user_to_scoped_api(self, started_app):
+        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         await started_app.reply(
@@ -1061,13 +1061,13 @@ class TestAppReply:
             "1680000000000",
             "Hello thread",
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
         started_app.api.clone.assert_called_once_with(
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
         create = started_app.api.conversations.activities.return_value.create
         activity = create.call_args.args[0]
@@ -1082,21 +1082,21 @@ class TestAppReply:
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
 
     @pytest.mark.asyncio
-    async def test_reply_with_two_args_passes_service_url_and_agentic_identity_to_scoped_api(self, started_app):
-        agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+    async def test_reply_with_two_args_passes_service_url_and_agent_user_to_scoped_api(self, started_app):
+        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         await started_app.reply(
             "19:abc@thread.skype",
             "Hello flat",
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
         started_app.api.clone.assert_called_once_with(
             service_url=service_url,
-            agentic_identity=agentic_identity,
+            agent_user=agent_user,
         )
         create = started_app.api.conversations.activities.return_value.create
         activity = create.call_args.args[0]

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -894,7 +894,7 @@ class TestApp:
         app.api.conversations.activities = MagicMock(return_value=activities)
         _wire_flat_activity_methods(app.api, activities)
         app.api.clone = MagicMock(return_value=app.api)
-        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         result = await app.send(
@@ -934,32 +934,32 @@ class TestApp:
         app.api.clone.assert_not_called()
 
     def test_get_agentic_user_preserves_explicit_blueprint_id(self, mock_storage) -> None:
-        """An explicitly provided agent_identity_blueprint_id should be preserved."""
+        """An explicitly provided agentic_blueprint_id should be preserved."""
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
         identity = app.get_agentic_user(
-            "agent-app-instance-id",
+            "agentic-app-instance-id",
             "agentic-user-id",
             tenant_id="tenant-id",
-            agent_identity_blueprint_id="explicit-blueprint-id",
+            agentic_blueprint_id="explicit-blueprint-id",
         )
 
-        assert identity.agent_identity_blueprint_id == "explicit-blueprint-id"
+        assert identity.agentic_blueprint_id == "explicit-blueprint-id"
 
     def test_get_agentic_user_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
-        """When agent_identity_blueprint_id is omitted, it should default to the app's client id."""
+        """When agentic_blueprint_id is omitted, it should default to the app's client id."""
         options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
         identity = app.get_agentic_user(
-            "agent-app-instance-id",
+            "agentic-app-instance-id",
             "agentic-user-id",
             tenant_id="tenant-id",
         )
 
-        assert identity.agent_identity_blueprint_id == app.id
-        assert identity.agent_identity_blueprint_id == "test-client-id"
+        assert identity.agentic_blueprint_id == app.id
+        assert identity.agentic_blueprint_id == "test-client-id"
 
 
 class TestAppInitialize:
@@ -1053,7 +1053,7 @@ class TestAppReply:
 
     @pytest.mark.asyncio
     async def test_reply_with_three_args_passes_service_url_and_agentic_user_to_scoped_api(self, started_app):
-        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         await started_app.reply(
@@ -1083,7 +1083,7 @@ class TestAppReply:
 
     @pytest.mark.asyncio
     async def test_reply_with_two_args_passes_service_url_and_agentic_user_to_scoped_api(self, started_app):
-        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         service_url = "https://override.service.url"
 
         await started_app.reply(

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -236,7 +236,7 @@ class TestActivityProcessor:
                     "agenticAppId": "agent-app-1",
                     "agenticUserId": "agent-user-1",
                     "agenticAppBlueprintId": "blueprint-1",
-                    "email": "agentic-user@example.com",
+                    "email": "agent-user@example.com",
                     "userRole": "assistant",
                 },
                 "channelId": "msteams",
@@ -587,11 +587,11 @@ class TestActivityProcessor:
         mock_api_client.users.get_token.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_build_context_scopes_api_to_inbound_agentic_identity(self, activity_processor):
-        """Inbound Agent ID activities scope ctx.api with the inbound agentic identity."""
+    async def test_build_context_scopes_api_to_inbound_agent_user(self, activity_processor):
+        """Inbound Agent ID activities scope ctx.api with the inbound agent user."""
         core_activity = CoreActivity(
             type="message",
-            id="activity-agentic",
+            id="activity-agent-user",
             service_url="https://service.url",
             **{
                 "from": {"id": "user-1", "name": "Test User"},
@@ -599,8 +599,8 @@ class TestActivityProcessor:
                 "recipient": {
                     "id": "bot-1",
                     "name": "Test Bot",
-                    "agenticAppId": "agentic-app-id",
-                    "agenticUserId": "agentic-user-id",
+                    "agenticAppId": "agent-app-instance-id",
+                    "agenticUserId": "agent-user-id",
                     "tenantId": "tenant-id",
                 },
                 "channelId": "msteams",
@@ -621,10 +621,10 @@ class TestActivityProcessor:
             await activity_processor.process_activity([], mock_activity_event)
 
         assert mock_api_client_type.call_args.kwargs["auth_provider"] is activity_processor.auth_provider
-        agentic_identity = mock_api_client_type.call_args.kwargs["agentic_identity"]
-        assert agentic_identity.agentic_app_id == "agentic-app-id"
-        assert agentic_identity.agentic_user_id == "agentic-user-id"
-        assert agentic_identity.tenant_id == "tenant-id"
+        agent_user = mock_api_client_type.call_args.kwargs["agent_user"]
+        assert agent_user.agent_app_instance_id == "agent-app-instance-id"
+        assert agent_user.agent_user_id == "agent-user-id"
+        assert agent_user.tenant_id == "tenant-id"
 
     @pytest.mark.asyncio
     async def test_process_activity_raises_when_event_manager_missing(self, activity_processor):

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -234,9 +234,9 @@ class TestActivityProcessor:
                     "name": "Agent",
                     "tenantId": "tenant-1",
                     "agenticAppId": "agent-app-1",
-                    "agenticUserId": "agent-user-1",
+                    "agenticUserId": "agentic-user-1",
                     "agenticAppBlueprintId": "blueprint-1",
-                    "email": "agent-user@example.com",
+                    "email": "agentic-user@example.com",
                     "userRole": "assistant",
                 },
                 "channelId": "msteams",
@@ -587,11 +587,11 @@ class TestActivityProcessor:
         mock_api_client.users.get_token.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_build_context_scopes_api_to_inbound_agent_user(self, activity_processor):
-        """Inbound Agent ID activities scope ctx.api with the inbound agent user."""
+    async def test_build_context_scopes_api_to_inbound_agentic_user(self, activity_processor):
+        """Inbound Agent ID activities scope ctx.api with the inbound agentic user."""
         core_activity = CoreActivity(
             type="message",
-            id="activity-agent-user",
+            id="activity-agentic-user",
             service_url="https://service.url",
             **{
                 "from": {"id": "user-1", "name": "Test User"},
@@ -600,7 +600,7 @@ class TestActivityProcessor:
                     "id": "bot-1",
                     "name": "Test Bot",
                     "agenticAppId": "agent-app-instance-id",
-                    "agenticUserId": "agent-user-id",
+                    "agenticUserId": "agentic-user-id",
                     "tenantId": "tenant-id",
                 },
                 "channelId": "msteams",
@@ -621,10 +621,10 @@ class TestActivityProcessor:
             await activity_processor.process_activity([], mock_activity_event)
 
         assert mock_api_client_type.call_args.kwargs["auth_provider"] is activity_processor.auth_provider
-        agent_user = mock_api_client_type.call_args.kwargs["agent_user"]
-        assert agent_user.agent_app_instance_id == "agent-app-instance-id"
-        assert agent_user.agent_user_id == "agent-user-id"
-        assert agent_user.tenant_id == "tenant-id"
+        agentic_user = mock_api_client_type.call_args.kwargs["agentic_user"]
+        assert agentic_user.agent_app_instance_id == "agent-app-instance-id"
+        assert agentic_user.agentic_user_id == "agentic-user-id"
+        assert agentic_user.tenant_id == "tenant-id"
 
     @pytest.mark.asyncio
     async def test_process_activity_raises_when_event_manager_missing(self, activity_processor):

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -599,7 +599,7 @@ class TestActivityProcessor:
                 "recipient": {
                     "id": "bot-1",
                     "name": "Test Bot",
-                    "agenticAppId": "agent-app-instance-id",
+                    "agenticAppId": "agentic-app-instance-id",
                     "agenticUserId": "agentic-user-id",
                     "tenantId": "tenant-id",
                 },
@@ -622,7 +622,7 @@ class TestActivityProcessor:
 
         assert mock_api_client_type.call_args.kwargs["auth_provider"] is activity_processor.auth_provider
         agentic_user = mock_api_client_type.call_args.kwargs["agentic_user"]
-        assert agentic_user.agent_app_instance_id == "agent-app-instance-id"
+        assert agentic_user.agentic_app_instance_id == "agentic-app-instance-id"
         assert agentic_user.agentic_user_id == "agentic-user-id"
         assert agentic_user.tenant_id == "tenant-id"
 

--- a/packages/apps/tests/test_token_manager.py
+++ b/packages/apps/tests/test_token_manager.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 from microsoft_teams.api import (
-    AgentUser,
+    AgenticUser,
     ClientCredentials,
     FederatedIdentityCredentials,
     JsonWebToken,
@@ -34,7 +34,7 @@ class TestTokenManager:
     """Test TokenManager functionality."""
 
     @pytest.mark.asyncio
-    async def test_get_agent_user_token_uses_agent_identity_flow(self):
+    async def test_get_agentic_user_token_uses_agent_identity_flow(self):
         mock_credentials = ClientCredentials(
             client_id="blueprint-client-id",
             client_secret="blueprint-client-secret",
@@ -55,9 +55,9 @@ class TestTokenManager:
             mock_confidential_app.side_effect = [blueprint_app, agent_app]
 
             manager = TokenManager(credentials=mock_credentials)
-            token = await manager.get_agent_user_token(
+            token = await manager.get_agentic_user_token(
                 AGENT_BOT_API_SCOPE,
-                AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id"),
+                AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id"),
             )
 
         assert token is not None
@@ -70,7 +70,7 @@ class TestTokenManager:
         agent_app.acquire_token_by_user_federated_identity_credential.assert_called_once_with(
             [AGENT_BOT_API_SCOPE],
             assertion="t2-token",
-            user_object_id="agent-user-id",
+            user_object_id="agentic-user-id",
             username=None,
             data={"requested_token_use": "on_behalf_of"},
         )
@@ -86,7 +86,7 @@ class TestTokenManager:
         assert callable(second_call.kwargs["client_credential"]["client_assertion"])
 
     @pytest.mark.asyncio
-    async def test_get_agent_user_token_caches_agent_identity_client(self):
+    async def test_get_agentic_user_token_caches_agent_identity_client(self):
         mock_credentials = ClientCredentials(
             client_id="blueprint-client-id",
             client_secret="blueprint-client-secret",
@@ -104,56 +104,56 @@ class TestTokenManager:
             mock_confidential_app.side_effect = [blueprint_app, agent_app]
 
             manager = TokenManager(credentials=mock_credentials)
-            await manager.get_agent_user_token(
-                AGENT_BOT_API_SCOPE, AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+            await manager.get_agentic_user_token(
+                AGENT_BOT_API_SCOPE, AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
             )
-            await manager.get_agent_user_token(
-                AGENT_BOT_API_SCOPE, AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+            await manager.get_agentic_user_token(
+                AGENT_BOT_API_SCOPE, AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
             )
 
         assert mock_confidential_app.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_get_agent_user_token_with_token_credentials_passes_agent_user(self):
+    async def test_get_agentic_user_token_with_token_credentials_passes_agentic_user(self):
         calls = []
 
-        async def token_provider(scope: str, tenant_id: str | None, *, agent_user: AgentUser | None):
-            calls.append((scope, tenant_id, agent_user))
+        async def token_provider(scope: str, tenant_id: str | None, *, agentic_user: AgenticUser | None):
+            calls.append((scope, tenant_id, agentic_user))
             return VALID_TEST_TOKEN
 
         credentials = TokenCredentials(client_id="blueprint-client-id", token=token_provider, tenant_id="tenant-id")
         manager = TokenManager(credentials=credentials)
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-        token = await manager.get_agent_user_token(AGENT_BOT_API_SCOPE, identity)
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        token = await manager.get_agentic_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
         assert str(token) == VALID_TEST_TOKEN
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", identity)]
 
     @pytest.mark.asyncio
-    async def test_get_agent_user_token_with_token_credentials_accepts_positional_identity(self):
+    async def test_get_agentic_user_token_with_token_credentials_accepts_positional_identity(self):
         calls = []
 
-        def token_provider(scope: str, tenant_id: str | None, identity: AgentUser | None):
+        def token_provider(scope: str, tenant_id: str | None, identity: AgenticUser | None):
             calls.append((scope, tenant_id, identity))
             return VALID_TEST_TOKEN
 
         credentials = TokenCredentials(client_id="blueprint-client-id", token=token_provider, tenant_id="tenant-id")
         manager = TokenManager(credentials=credentials)
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
-        token = await manager.get_agent_user_token(AGENT_BOT_API_SCOPE, identity)
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        token = await manager.get_agentic_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
         assert str(token) == VALID_TEST_TOKEN
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", identity)]
 
     @pytest.mark.asyncio
-    async def test_get_token_with_required_third_argument_passes_none_for_non_agent_user_token(self):
+    async def test_get_token_with_required_third_argument_passes_none_for_non_agentic_user_token(self):
         calls = []
 
-        def token_provider(scope: str, tenant_id: str | None, identity: AgentUser | None):
+        def token_provider(scope: str, tenant_id: str | None, identity: AgenticUser | None):
             calls.append((scope, tenant_id, identity))
             return VALID_TEST_TOKEN
 
@@ -166,7 +166,7 @@ class TestTokenManager:
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", None)]
 
     @pytest.mark.asyncio
-    async def test_get_token_with_optional_third_argument_uses_default_for_non_agent_user_token(self):
+    async def test_get_token_with_optional_third_argument_uses_default_for_non_agentic_user_token(self):
         calls = []
 
         def token_provider(scope: str, tenant_id: str | None, timeout: int = 30):
@@ -182,7 +182,7 @@ class TestTokenManager:
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", 30)]
 
     @pytest.mark.asyncio
-    async def test_token_provider_uninspectable_signature_uses_legacy_args_without_agent_user(self):
+    async def test_token_provider_uninspectable_signature_uses_legacy_args_without_agentic_user(self):
         calls = []
 
         def token_provider(scope: str, tenant_id: str | None):
@@ -199,21 +199,23 @@ class TestTokenManager:
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id")]
 
     @pytest.mark.asyncio
-    async def test_token_provider_uninspectable_signature_rejects_agent_user(self):
+    async def test_token_provider_uninspectable_signature_rejects_agentic_user(self):
         credentials = TokenCredentials(
             client_id="test-client-id",
             token=lambda _scope, _tenant_id: VALID_TEST_TOKEN,
             tenant_id="tenant-id",
         )
         manager = TokenManager(credentials=credentials)
-        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
 
         with patch("microsoft_teams.apps.token_manager.signature", side_effect=ValueError("no signature")):
-            with pytest.raises(ValueError, match="Token provider must accept agent_user"):
-                await manager._get_token_with_token_provider(credentials, AGENT_BOT_API_SCOPE, "tenant-id", agent_user)
+            with pytest.raises(ValueError, match="Token provider must accept agentic_user"):
+                await manager._get_token_with_token_provider(
+                    credentials, AGENT_BOT_API_SCOPE, "tenant-id", agentic_user
+                )
 
     @pytest.mark.asyncio
-    async def test_app_auth_provider_uses_app_token_without_agent_user(self):
+    async def test_app_auth_provider_uses_app_token_without_agentic_user(self):
         token_manager = MagicMock(spec=TokenManager)
         token_manager.get_app_token = AsyncMock(return_value="app-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
@@ -222,48 +224,48 @@ class TestTokenManager:
 
         assert token == "app-token"
         token_manager.get_app_token.assert_awaited_once_with(PUBLIC.bot_scope, caller_name="token")
-        token_manager.get_agent_user_token.assert_not_called()
+        token_manager.get_agentic_user_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_app_auth_provider_uses_agent_user_token_with_agent_user(self):
+    async def test_app_auth_provider_uses_agentic_user_token_with_agentic_user(self):
         token_manager = MagicMock(spec=TokenManager)
-        token_manager.get_agent_user_token = AsyncMock(return_value="agent-user-token")
+        token_manager.get_agentic_user_token = AsyncMock(return_value="agentic-user-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
-        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
 
-        token = await auth_provider.token(agent_user=agent_user)
+        token = await auth_provider.token(agentic_user=agentic_user)
 
-        assert token == "agent-user-token"
-        token_manager.get_agent_user_token.assert_awaited_once_with(
+        assert token == "agentic-user-token"
+        token_manager.get_agentic_user_token.assert_awaited_once_with(
             AGENT_BOT_API_SCOPE,
-            agent_user,
+            agentic_user,
             caller_name="token",
         )
         token_manager.get_app_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_app_auth_provider_passes_missing_agent_user_tenant_to_token_manager(self):
+    async def test_app_auth_provider_passes_missing_agentic_user_tenant_to_token_manager(self):
         token_manager = MagicMock(spec=TokenManager)
-        token_manager.get_agent_user_token = AsyncMock(return_value="agent-user-token")
+        token_manager.get_agentic_user_token = AsyncMock(return_value="agentic-user-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
-        agent_user = AgentUser("agent-app-instance-id", "agent-user-id")
+        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id")
 
-        token = await auth_provider.token(agent_user=agent_user)
+        token = await auth_provider.token(agentic_user=agentic_user)
 
-        assert token == "agent-user-token"
-        token_manager.get_agent_user_token.assert_awaited_once_with(
+        assert token == "agentic-user-token"
+        token_manager.get_agentic_user_token.assert_awaited_once_with(
             AGENT_BOT_API_SCOPE,
-            agent_user,
+            agentic_user,
             caller_name="token",
         )
         token_manager.get_app_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_get_agent_user_token_uses_credentials_tenant_when_missing(self):
+    async def test_get_agentic_user_token_uses_credentials_tenant_when_missing(self):
         calls = []
 
-        async def token_provider(scope: str, tenant_id: str | None, *, agent_user: AgentUser | None):
-            calls.append((scope, tenant_id, agent_user))
+        async def token_provider(scope: str, tenant_id: str | None, *, agentic_user: AgenticUser | None):
+            calls.append((scope, tenant_id, agentic_user))
             return VALID_TEST_TOKEN
 
         credentials = TokenCredentials(
@@ -271,24 +273,24 @@ class TestTokenManager:
         )
         manager = TokenManager(credentials=credentials)
 
-        identity = AgentUser("agent-app-instance-id", "agent-user-id")
-        token = await manager.get_agent_user_token(AGENT_BOT_API_SCOPE, identity)
+        identity = AgenticUser("agent-app-instance-id", "agentic-user-id")
+        token = await manager.get_agentic_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
         assert calls == [(AGENT_BOT_API_SCOPE, "credential-tenant-id", identity)]
 
     @pytest.mark.asyncio
-    async def test_get_agent_user_token_requires_tenant_when_missing_from_request_and_credentials(self):
+    async def test_get_agentic_user_token_requires_tenant_when_missing_from_request_and_credentials(self):
         credentials = TokenCredentials(
             client_id="blueprint-client-id",
             token=lambda _scope, _tenant_id: VALID_TEST_TOKEN,
         )
         manager = TokenManager(credentials=credentials)
 
-        with pytest.raises(ValueError, match="tenant_id is required to get an agent user token"):
-            await manager.get_agent_user_token(
+        with pytest.raises(ValueError, match="tenant_id is required to get an agentic user token"):
+            await manager.get_agentic_user_token(
                 AGENT_BOT_API_SCOPE,
-                AgentUser("agent-app-instance-id", "agent-user-id"),
+                AgenticUser("agent-app-instance-id", "agentic-user-id"),
             )
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_token_manager.py
+++ b/packages/apps/tests/test_token_manager.py
@@ -57,14 +57,14 @@ class TestTokenManager:
             manager = TokenManager(credentials=mock_credentials)
             token = await manager.get_agentic_user_token(
                 AGENT_BOT_API_SCOPE,
-                AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id"),
+                AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id"),
             )
 
         assert token is not None
         assert str(token) == VALID_TEST_TOKEN
 
         blueprint_app.acquire_token_for_client.assert_called_once_with(
-            [TOKEN_EXCHANGE_SCOPE], fmi_path="agent-app-instance-id"
+            [TOKEN_EXCHANGE_SCOPE], fmi_path="agentic-app-instance-id"
         )
         agent_app.acquire_token_for_client.assert_called_once_with([TOKEN_EXCHANGE_SCOPE])
         agent_app.acquire_token_by_user_federated_identity_credential.assert_called_once_with(
@@ -81,7 +81,7 @@ class TestTokenManager:
             "client_credential": "blueprint-client-secret",
             "authority": "https://login.microsoftonline.com/tenant-id",
         }
-        assert second_call.args == ("agent-app-instance-id",)
+        assert second_call.args == ("agentic-app-instance-id",)
         assert second_call.kwargs["authority"] == "https://login.microsoftonline.com/tenant-id"
         assert callable(second_call.kwargs["client_credential"]["client_assertion"])
 
@@ -105,10 +105,10 @@ class TestTokenManager:
 
             manager = TokenManager(credentials=mock_credentials)
             await manager.get_agentic_user_token(
-                AGENT_BOT_API_SCOPE, AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+                AGENT_BOT_API_SCOPE, AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
             )
             await manager.get_agentic_user_token(
-                AGENT_BOT_API_SCOPE, AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+                AGENT_BOT_API_SCOPE, AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
             )
 
         assert mock_confidential_app.call_count == 2
@@ -124,7 +124,7 @@ class TestTokenManager:
         credentials = TokenCredentials(client_id="blueprint-client-id", token=token_provider, tenant_id="tenant-id")
         manager = TokenManager(credentials=credentials)
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         token = await manager.get_agentic_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
@@ -142,7 +142,7 @@ class TestTokenManager:
         credentials = TokenCredentials(client_id="blueprint-client-id", token=token_provider, tenant_id="tenant-id")
         manager = TokenManager(credentials=credentials)
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
         token = await manager.get_agentic_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
@@ -206,7 +206,7 @@ class TestTokenManager:
             tenant_id="tenant-id",
         )
         manager = TokenManager(credentials=credentials)
-        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
 
         with patch("microsoft_teams.apps.token_manager.signature", side_effect=ValueError("no signature")):
             with pytest.raises(ValueError, match="Token provider must accept agentic_user"):
@@ -231,7 +231,7 @@ class TestTokenManager:
         token_manager = MagicMock(spec=TokenManager)
         token_manager.get_agentic_user_token = AsyncMock(return_value="agentic-user-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
-        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
+        agentic_user = AgenticUser("agentic-app-instance-id", "agentic-user-id", tenant_id="tenant-id")
 
         token = await auth_provider.token(agentic_user=agentic_user)
 
@@ -248,7 +248,7 @@ class TestTokenManager:
         token_manager = MagicMock(spec=TokenManager)
         token_manager.get_agentic_user_token = AsyncMock(return_value="agentic-user-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
-        agentic_user = AgenticUser("agent-app-instance-id", "agentic-user-id")
+        agentic_user = AgenticUser("agentic-app-instance-id", "agentic-user-id")
 
         token = await auth_provider.token(agentic_user=agentic_user)
 
@@ -273,7 +273,7 @@ class TestTokenManager:
         )
         manager = TokenManager(credentials=credentials)
 
-        identity = AgenticUser("agent-app-instance-id", "agentic-user-id")
+        identity = AgenticUser("agentic-app-instance-id", "agentic-user-id")
         token = await manager.get_agentic_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
@@ -290,7 +290,7 @@ class TestTokenManager:
         with pytest.raises(ValueError, match="tenant_id is required to get an agentic user token"):
             await manager.get_agentic_user_token(
                 AGENT_BOT_API_SCOPE,
-                AgenticUser("agent-app-instance-id", "agentic-user-id"),
+                AgenticUser("agentic-app-instance-id", "agentic-user-id"),
             )
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_token_manager.py
+++ b/packages/apps/tests/test_token_manager.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 from microsoft_teams.api import (
-    AgenticIdentity,
+    AgentUser,
     ClientCredentials,
     FederatedIdentityCredentials,
     JsonWebToken,
@@ -34,7 +34,7 @@ class TestTokenManager:
     """Test TokenManager functionality."""
 
     @pytest.mark.asyncio
-    async def test_get_agentic_token_uses_agent_identity_flow(self):
+    async def test_get_agent_user_token_uses_agent_identity_flow(self):
         mock_credentials = ClientCredentials(
             client_id="blueprint-client-id",
             client_secret="blueprint-client-secret",
@@ -55,22 +55,22 @@ class TestTokenManager:
             mock_confidential_app.side_effect = [blueprint_app, agent_app]
 
             manager = TokenManager(credentials=mock_credentials)
-            token = await manager.get_agentic_token(
+            token = await manager.get_agent_user_token(
                 AGENT_BOT_API_SCOPE,
-                AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id"),
+                AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id"),
             )
 
         assert token is not None
         assert str(token) == VALID_TEST_TOKEN
 
         blueprint_app.acquire_token_for_client.assert_called_once_with(
-            [TOKEN_EXCHANGE_SCOPE], fmi_path="agentic-app-id"
+            [TOKEN_EXCHANGE_SCOPE], fmi_path="agent-app-instance-id"
         )
         agent_app.acquire_token_for_client.assert_called_once_with([TOKEN_EXCHANGE_SCOPE])
         agent_app.acquire_token_by_user_federated_identity_credential.assert_called_once_with(
             [AGENT_BOT_API_SCOPE],
             assertion="t2-token",
-            user_object_id="agentic-user-id",
+            user_object_id="agent-user-id",
             username=None,
             data={"requested_token_use": "on_behalf_of"},
         )
@@ -81,12 +81,12 @@ class TestTokenManager:
             "client_credential": "blueprint-client-secret",
             "authority": "https://login.microsoftonline.com/tenant-id",
         }
-        assert second_call.args == ("agentic-app-id",)
+        assert second_call.args == ("agent-app-instance-id",)
         assert second_call.kwargs["authority"] == "https://login.microsoftonline.com/tenant-id"
         assert callable(second_call.kwargs["client_credential"]["client_assertion"])
 
     @pytest.mark.asyncio
-    async def test_get_agentic_token_caches_agent_identity_client(self):
+    async def test_get_agent_user_token_caches_agent_identity_client(self):
         mock_credentials = ClientCredentials(
             client_id="blueprint-client-id",
             client_secret="blueprint-client-secret",
@@ -104,56 +104,56 @@ class TestTokenManager:
             mock_confidential_app.side_effect = [blueprint_app, agent_app]
 
             manager = TokenManager(credentials=mock_credentials)
-            await manager.get_agentic_token(
-                AGENT_BOT_API_SCOPE, AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+            await manager.get_agent_user_token(
+                AGENT_BOT_API_SCOPE, AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
             )
-            await manager.get_agentic_token(
-                AGENT_BOT_API_SCOPE, AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+            await manager.get_agent_user_token(
+                AGENT_BOT_API_SCOPE, AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
             )
 
         assert mock_confidential_app.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_get_agentic_token_with_token_credentials_passes_agentic_identity(self):
+    async def test_get_agent_user_token_with_token_credentials_passes_agent_user(self):
         calls = []
 
-        async def token_provider(scope: str, tenant_id: str | None, *, agentic_identity: AgenticIdentity | None):
-            calls.append((scope, tenant_id, agentic_identity))
+        async def token_provider(scope: str, tenant_id: str | None, *, agent_user: AgentUser | None):
+            calls.append((scope, tenant_id, agent_user))
             return VALID_TEST_TOKEN
 
         credentials = TokenCredentials(client_id="blueprint-client-id", token=token_provider, tenant_id="tenant-id")
         manager = TokenManager(credentials=credentials)
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-        token = await manager.get_agentic_token(AGENT_BOT_API_SCOPE, identity)
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        token = await manager.get_agent_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
         assert str(token) == VALID_TEST_TOKEN
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", identity)]
 
     @pytest.mark.asyncio
-    async def test_get_agentic_token_with_token_credentials_accepts_positional_identity(self):
+    async def test_get_agent_user_token_with_token_credentials_accepts_positional_identity(self):
         calls = []
 
-        def token_provider(scope: str, tenant_id: str | None, identity: AgenticIdentity | None):
+        def token_provider(scope: str, tenant_id: str | None, identity: AgentUser | None):
             calls.append((scope, tenant_id, identity))
             return VALID_TEST_TOKEN
 
         credentials = TokenCredentials(client_id="blueprint-client-id", token=token_provider, tenant_id="tenant-id")
         manager = TokenManager(credentials=credentials)
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
-        token = await manager.get_agentic_token(AGENT_BOT_API_SCOPE, identity)
+        identity = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
+        token = await manager.get_agent_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
         assert str(token) == VALID_TEST_TOKEN
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", identity)]
 
     @pytest.mark.asyncio
-    async def test_get_token_with_required_third_argument_passes_none_for_non_agentic_token(self):
+    async def test_get_token_with_required_third_argument_passes_none_for_non_agent_user_token(self):
         calls = []
 
-        def token_provider(scope: str, tenant_id: str | None, identity: AgenticIdentity | None):
+        def token_provider(scope: str, tenant_id: str | None, identity: AgentUser | None):
             calls.append((scope, tenant_id, identity))
             return VALID_TEST_TOKEN
 
@@ -166,7 +166,7 @@ class TestTokenManager:
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", None)]
 
     @pytest.mark.asyncio
-    async def test_get_token_with_optional_third_argument_uses_default_for_non_agentic_token(self):
+    async def test_get_token_with_optional_third_argument_uses_default_for_non_agent_user_token(self):
         calls = []
 
         def token_provider(scope: str, tenant_id: str | None, timeout: int = 30):
@@ -182,7 +182,7 @@ class TestTokenManager:
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id", 30)]
 
     @pytest.mark.asyncio
-    async def test_token_provider_uninspectable_signature_uses_legacy_args_without_agentic_identity(self):
+    async def test_token_provider_uninspectable_signature_uses_legacy_args_without_agent_user(self):
         calls = []
 
         def token_provider(scope: str, tenant_id: str | None):
@@ -199,23 +199,21 @@ class TestTokenManager:
         assert calls == [(AGENT_BOT_API_SCOPE, "tenant-id")]
 
     @pytest.mark.asyncio
-    async def test_token_provider_uninspectable_signature_rejects_agentic_identity(self):
+    async def test_token_provider_uninspectable_signature_rejects_agent_user(self):
         credentials = TokenCredentials(
             client_id="test-client-id",
             token=lambda _scope, _tenant_id: VALID_TEST_TOKEN,
             tenant_id="tenant-id",
         )
         manager = TokenManager(credentials=credentials)
-        agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
 
         with patch("microsoft_teams.apps.token_manager.signature", side_effect=ValueError("no signature")):
-            with pytest.raises(ValueError, match="Token provider must accept agentic_identity"):
-                await manager._get_token_with_token_provider(
-                    credentials, AGENT_BOT_API_SCOPE, "tenant-id", agentic_identity
-                )
+            with pytest.raises(ValueError, match="Token provider must accept agent_user"):
+                await manager._get_token_with_token_provider(credentials, AGENT_BOT_API_SCOPE, "tenant-id", agent_user)
 
     @pytest.mark.asyncio
-    async def test_app_auth_provider_uses_app_token_without_agentic_identity(self):
+    async def test_app_auth_provider_uses_app_token_without_agent_user(self):
         token_manager = MagicMock(spec=TokenManager)
         token_manager.get_app_token = AsyncMock(return_value="app-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
@@ -224,48 +222,48 @@ class TestTokenManager:
 
         assert token == "app-token"
         token_manager.get_app_token.assert_awaited_once_with(PUBLIC.bot_scope, caller_name="token")
-        token_manager.get_agentic_token.assert_not_called()
+        token_manager.get_agent_user_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_app_auth_provider_uses_agentic_token_with_agentic_identity(self):
+    async def test_app_auth_provider_uses_agent_user_token_with_agent_user(self):
         token_manager = MagicMock(spec=TokenManager)
-        token_manager.get_agentic_token = AsyncMock(return_value="agentic-token")
+        token_manager.get_agent_user_token = AsyncMock(return_value="agent-user-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
-        agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id", tenant_id="tenant-id")
+        agent_user = AgentUser("agent-app-instance-id", "agent-user-id", tenant_id="tenant-id")
 
-        token = await auth_provider.token(agentic_identity=agentic_identity)
+        token = await auth_provider.token(agent_user=agent_user)
 
-        assert token == "agentic-token"
-        token_manager.get_agentic_token.assert_awaited_once_with(
+        assert token == "agent-user-token"
+        token_manager.get_agent_user_token.assert_awaited_once_with(
             AGENT_BOT_API_SCOPE,
-            agentic_identity,
+            agent_user,
             caller_name="token",
         )
         token_manager.get_app_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_app_auth_provider_passes_missing_agentic_tenant_to_token_manager(self):
+    async def test_app_auth_provider_passes_missing_agent_user_tenant_to_token_manager(self):
         token_manager = MagicMock(spec=TokenManager)
-        token_manager.get_agentic_token = AsyncMock(return_value="agentic-token")
+        token_manager.get_agent_user_token = AsyncMock(return_value="agent-user-token")
         auth_provider = AppAuthProvider(token_manager, PUBLIC)
-        agentic_identity = AgenticIdentity("agentic-app-id", "agentic-user-id")
+        agent_user = AgentUser("agent-app-instance-id", "agent-user-id")
 
-        token = await auth_provider.token(agentic_identity=agentic_identity)
+        token = await auth_provider.token(agent_user=agent_user)
 
-        assert token == "agentic-token"
-        token_manager.get_agentic_token.assert_awaited_once_with(
+        assert token == "agent-user-token"
+        token_manager.get_agent_user_token.assert_awaited_once_with(
             AGENT_BOT_API_SCOPE,
-            agentic_identity,
+            agent_user,
             caller_name="token",
         )
         token_manager.get_app_token.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_get_agentic_token_uses_credentials_tenant_when_missing(self):
+    async def test_get_agent_user_token_uses_credentials_tenant_when_missing(self):
         calls = []
 
-        async def token_provider(scope: str, tenant_id: str | None, *, agentic_identity: AgenticIdentity | None):
-            calls.append((scope, tenant_id, agentic_identity))
+        async def token_provider(scope: str, tenant_id: str | None, *, agent_user: AgentUser | None):
+            calls.append((scope, tenant_id, agent_user))
             return VALID_TEST_TOKEN
 
         credentials = TokenCredentials(
@@ -273,24 +271,24 @@ class TestTokenManager:
         )
         manager = TokenManager(credentials=credentials)
 
-        identity = AgenticIdentity("agentic-app-id", "agentic-user-id")
-        token = await manager.get_agentic_token(AGENT_BOT_API_SCOPE, identity)
+        identity = AgentUser("agent-app-instance-id", "agent-user-id")
+        token = await manager.get_agent_user_token(AGENT_BOT_API_SCOPE, identity)
 
         assert token is not None
         assert calls == [(AGENT_BOT_API_SCOPE, "credential-tenant-id", identity)]
 
     @pytest.mark.asyncio
-    async def test_get_agentic_token_requires_tenant_when_missing_from_request_and_credentials(self):
+    async def test_get_agent_user_token_requires_tenant_when_missing_from_request_and_credentials(self):
         credentials = TokenCredentials(
             client_id="blueprint-client-id",
             token=lambda _scope, _tenant_id: VALID_TEST_TOKEN,
         )
         manager = TokenManager(credentials=credentials)
 
-        with pytest.raises(ValueError, match="tenant_id is required to get an agentic token"):
-            await manager.get_agentic_token(
+        with pytest.raises(ValueError, match="tenant_id is required to get an agent user token"):
+            await manager.get_agent_user_token(
                 AGENT_BOT_API_SCOPE,
-                AgenticIdentity("agentic-app-id", "agentic-user-id"),
+                AgentUser("agent-app-instance-id", "agent-user-id"),
             )
 
     @pytest.mark.asyncio

--- a/tests/integration/.env.example
+++ b/tests/integration/.env.example
@@ -15,6 +15,6 @@ TEST_CHANNEL_ID=19:...@thread.tacv2
 TEST_MEETING_ID=MCM...
 
 # Optional — for AgenticUser tests
-# TEST_AGENT_APP_INSTANCE_ID=<agent-app-instance-id>
+# TEST_AGENTIC_APP_INSTANCE_ID=<agentic-app-instance-id>
 # TEST_AGENTIC_USER_ID=<agentic-user-id>
 # AZURE_SCOPE=https://botapi.skype.com/.default

--- a/tests/integration/.env.example
+++ b/tests/integration/.env.example
@@ -14,7 +14,7 @@ TEST_TEAM_ID=19:...@thread.tacv2
 TEST_CHANNEL_ID=19:...@thread.tacv2
 TEST_MEETING_ID=MCM...
 
-# Optional — for AgentUser tests
+# Optional — for AgenticUser tests
 # TEST_AGENT_APP_INSTANCE_ID=<agent-app-instance-id>
-# TEST_AGENT_USER_ID=<agent-user-id>
+# TEST_AGENTIC_USER_ID=<agentic-user-id>
 # AZURE_SCOPE=https://botapi.skype.com/.default

--- a/tests/integration/.env.example
+++ b/tests/integration/.env.example
@@ -14,7 +14,7 @@ TEST_TEAM_ID=19:...@thread.tacv2
 TEST_CHANNEL_ID=19:...@thread.tacv2
 TEST_MEETING_ID=MCM...
 
-# Optional — for agentic identity tests
-# TEST_AGENTIC_APP_ID=<agentic-app-id>
-# TEST_AGENTIC_USER_ID=<agentic-user-id>
+# Optional — for AgentUser tests
+# TEST_AGENT_APP_INSTANCE_ID=<agent-app-instance-id>
+# TEST_AGENT_USER_ID=<agent-user-id>
 # AZURE_SCOPE=https://botapi.skype.com/.default

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -36,7 +36,7 @@ pytest tests/integration -k "test_create_activity" -v
 
 ## Known Limitations
 
-- **AgentUser**: Reactions and paged members are not supported.
+- **AgenticUser**: Reactions and paged members are not supported.
 - **Canary ring**: Reactions return 404, paged members return empty.
 - **Throttling**: Member caching prevents 429s but full-suite runs may still hit rate limits.
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -36,7 +36,7 @@ pytest tests/integration -k "test_create_activity" -v
 
 ## Known Limitations
 
-- **Agentic identity**: Reactions and paged members are not supported.
+- **AgentUser**: Reactions and paged members are not supported.
 - **Canary ring**: Reactions return 404, paged members return empty.
 - **Throttling**: Member caching prevents 429s but full-suite runs may still hit rate limits.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,6 @@
 """
-Integration test fixture for Microsoft Teams Python SDK.
-
-Provides shared authentication and configuration for all integration tests.
-Uses azure-identity for token acquisition and caches conversation
-members to avoid 429 throttling.
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
 """
 
 import os
@@ -29,8 +26,8 @@ class TestConfig:
     channel_id: str
     meeting_id: str
     user_id_2: Optional[str] = None
-    agentic_app_id: Optional[str] = None
-    agentic_user_id: Optional[str] = None
+    agent_app_instance_id: Optional[str] = None
+    agent_user_id: Optional[str] = None
     scope: str = "https://api.botframework.com/.default"
 
 
@@ -48,8 +45,8 @@ class TestFixture:
         return "canary" in self.config.service_url.lower()
 
     @property
-    def is_agentic(self) -> bool:
-        return self.config.agentic_app_id is not None and self.config.agentic_app_id != ""
+    def is_agent_user(self) -> bool:
+        return self.config.agent_app_instance_id is not None and self.config.agent_app_instance_id != ""
 
 
 # Module-level cache (persists across tests in the same process)
@@ -89,8 +86,8 @@ def _load_config() -> TestConfig:
         channel_id=env("TEST_CHANNEL_ID"),
         meeting_id=env("TEST_MEETING_ID"),
         user_id_2=os.environ.get("TEST_USER_ID_2"),
-        agentic_app_id=os.environ.get("TEST_AGENTIC_APP_ID"),
-        agentic_user_id=os.environ.get("TEST_AGENTIC_USER_ID"),
+        agent_app_instance_id=os.environ.get("TEST_AGENT_APP_INSTANCE_ID"),
+        agent_user_id=os.environ.get("TEST_AGENT_USER_ID"),
         scope=os.environ.get("AZURE_SCOPE", "https://api.botframework.com/.default"),
     )
     return _cached_config

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,7 +26,7 @@ class TestConfig:
     channel_id: str
     meeting_id: str
     user_id_2: Optional[str] = None
-    agent_app_instance_id: Optional[str] = None
+    agentic_app_instance_id: Optional[str] = None
     agentic_user_id: Optional[str] = None
     scope: str = "https://api.botframework.com/.default"
 
@@ -46,7 +46,7 @@ class TestFixture:
 
     @property
     def is_agentic_user(self) -> bool:
-        return self.config.agent_app_instance_id is not None and self.config.agent_app_instance_id != ""
+        return self.config.agentic_app_instance_id is not None and self.config.agentic_app_instance_id != ""
 
 
 # Module-level cache (persists across tests in the same process)
@@ -86,7 +86,7 @@ def _load_config() -> TestConfig:
         channel_id=env("TEST_CHANNEL_ID"),
         meeting_id=env("TEST_MEETING_ID"),
         user_id_2=os.environ.get("TEST_USER_ID_2"),
-        agent_app_instance_id=os.environ.get("TEST_AGENT_APP_INSTANCE_ID"),
+        agentic_app_instance_id=os.environ.get("TEST_AGENTIC_APP_INSTANCE_ID"),
         agentic_user_id=os.environ.get("TEST_AGENTIC_USER_ID"),
         scope=os.environ.get("AZURE_SCOPE", "https://api.botframework.com/.default"),
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,7 +27,7 @@ class TestConfig:
     meeting_id: str
     user_id_2: Optional[str] = None
     agent_app_instance_id: Optional[str] = None
-    agent_user_id: Optional[str] = None
+    agentic_user_id: Optional[str] = None
     scope: str = "https://api.botframework.com/.default"
 
 
@@ -45,7 +45,7 @@ class TestFixture:
         return "canary" in self.config.service_url.lower()
 
     @property
-    def is_agent_user(self) -> bool:
+    def is_agentic_user(self) -> bool:
         return self.config.agent_app_instance_id is not None and self.config.agent_app_instance_id != ""
 
 
@@ -87,7 +87,7 @@ def _load_config() -> TestConfig:
         meeting_id=env("TEST_MEETING_ID"),
         user_id_2=os.environ.get("TEST_USER_ID_2"),
         agent_app_instance_id=os.environ.get("TEST_AGENT_APP_INSTANCE_ID"),
-        agent_user_id=os.environ.get("TEST_AGENT_USER_ID"),
+        agentic_user_id=os.environ.get("TEST_AGENTIC_USER_ID"),
         scope=os.environ.get("AZURE_SCOPE", "https://api.botframework.com/.default"),
     )
     return _cached_config

--- a/tests/integration/test_members.py
+++ b/tests/integration/test_members.py
@@ -32,8 +32,8 @@ class TestMembers:
     @pytest.mark.asyncio
     async def test_get_paged_members(self, fixture):
         """Get members with paging."""
-        if fixture.is_canary or fixture.is_agent_user:
-            pytest.skip("Paged members not supported on canary/agent user")
+        if fixture.is_canary or fixture.is_agentic_user:
+            pytest.skip("Paged members not supported on canary/agentic user")
 
         api = fixture.api
         conv_id = fixture.config.conversation_id

--- a/tests/integration/test_members.py
+++ b/tests/integration/test_members.py
@@ -1,4 +1,7 @@
-"""Integration tests for member operations (get all, get by ID, get paged)."""
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
 
 import pytest
 
@@ -29,8 +32,8 @@ class TestMembers:
     @pytest.mark.asyncio
     async def test_get_paged_members(self, fixture):
         """Get members with paging."""
-        if fixture.is_canary or fixture.is_agentic:
-            pytest.skip("Paged members not supported on canary/agentic")
+        if fixture.is_canary or fixture.is_agent_user:
+            pytest.skip("Paged members not supported on canary/agent user")
 
         api = fixture.api
         conv_id = fixture.config.conversation_id

--- a/tests/integration/test_teams_and_reactions.py
+++ b/tests/integration/test_teams_and_reactions.py
@@ -1,4 +1,7 @@
-"""Integration tests for teams and reactions operations."""
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
 
 import pytest
 from microsoft_teams.api.activities import MessageActivityInput
@@ -32,8 +35,8 @@ class TestReactions:
     @pytest.mark.asyncio
     async def test_add_and_delete_reaction(self, fixture):
         """Add a reaction to an activity then remove it."""
-        if fixture.is_agentic:
-            pytest.skip("Reactions not supported with agentic identity")
+        if fixture.is_agent_user:
+            pytest.skip("Reactions not supported with agent user")
         if fixture.is_canary:
             pytest.skip("Reactions return 404 on canary")
 

--- a/tests/integration/test_teams_and_reactions.py
+++ b/tests/integration/test_teams_and_reactions.py
@@ -35,8 +35,8 @@ class TestReactions:
     @pytest.mark.asyncio
     async def test_add_and_delete_reaction(self, fixture):
         """Add a reaction to an activity then remove it."""
-        if fixture.is_agent_user:
-            pytest.skip("Reactions not supported with agent user")
+        if fixture.is_agentic_user:
+            pytest.skip("Reactions not supported with agentic user")
         if fixture.is_canary:
             pytest.skip("Reactions return 404 on canary")
 


### PR DESCRIPTION
Renames the Python Agent 365 SDK-facing surface to `AgenticUser`, `AgenticAppInstance`, and `AgenticBlueprint`.

This matters because reviewers and SDK users should see the final public Python naming consistently across models, helpers, examples, docs, and tests while service-owned Activity payload contracts remain compatible.

Interesting detail: SDK-facing names now use `AgenticUser` / `agentic_user`, `AgenticAppInstance` / `agentic_app_instance`, and `AgenticBlueprint` / `agentic_blueprint`. Incoming Activity wire values are intentionally preserved, including `agenticUserId`, `agenticAppId`, `agenticAppBlueprintId`, `agenticAppInstanceId`, lifecycle `agenticUser...` event/value type literals, lifecycle `agentIdentityBlueprintId`, and role `agenticUser`.

Reviewer tips: start with `AgenticUser`, `Account`, and agent lifecycle value models, then API scoping helpers, `App.get_agentic_user`, `TokenManager`, examples, and focused tests.

Testing:
- `uv run ruff format --check && uv run ruff check`
- `uv run pytest packages/api/tests/unit/test_agent_lifecycle_event.py packages/apps/tests/test_app_process.py packages/api/tests/unit/test_api_client.py packages/apps/tests/test_token_manager.py packages/apps/tests/test_app.py`
- `uv run pyright`
- Prior live Teams smoke test with `examples/agent365`, devtunnel host `pmbp2`, and Teams agentic user `Demo Test 2`: inbound Activity parsing succeeded and outbound reply/send succeeded. No secrets included.