### PR TITLE
docs(examples/ai-mcp): remove public preview caution

### DIFF
--- a/examples/ai-mcp/README.md
+++ b/examples/ai-mcp/README.md
@@ -1,6 +1,3 @@
-> [!CAUTION]
-> This project is in public preview. We'll do our best to maintain compatibility, but there may be breaking changes in upcoming releases.
-
 # Teams AI Agent with MCP tools
 
 A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and Azure OpenAI. It streams responses token-by-token, attaches inline citations from MCP search results, asks clarifying questions via Adaptive Cards, and suggests follow-up questions after each reply.


### PR DESCRIPTION
## Summary
The Teams Python SDK has reached GA, so the `> [!CAUTION]` "public preview" admonition at the top of `examples/ai-mcp/README.md` no longer applies. This removes it.

## Change
- Deleted the two-line caution block (and its trailing blank line) so the README opens directly with the `# Teams AI Agent with MCP tools` heading.

Docs-only; no code or example behavior changes. This was the only file in the repo still carrying the "public preview" caution.