### PR TITLE
Improve HTML Widget example rendering

### DIFF
--- a/examples/html-widgets/src/widgets/host_context.py
+++ b/examples/html-widgets/src/widgets/host_context.py
@@ -26,6 +26,7 @@ h3{margin:0 0 8px}
 .section h4{margin:0 0 4px;font-size:12px;color:#333}
 pre{white-space:pre-wrap;word-break:break-all;font-family:monospace;font-size:11px;color:#555}
 .update{margin-top:8px;padding:6px;background:#fff3cd;border-radius:4px;font-size:11px}
+#updates{max-height:250px;overflow-y:auto}
 </style></head><body>
 <h3>Host Context Inspector</h3>
 <p>Displays the <code>hostContext</code> from <code>ui/initialize</code> response and listens for changes.</p>
@@ -52,7 +53,9 @@ window.addEventListener('message', (event) => {
 
   // Handle responses to our requests
   if (data.id && pending[data.id]) {
-    pending[data.id](data);
+    const cb = pending[data.id];
+    delete pending[data.id];
+    cb(data);
     return;
   }
 
@@ -108,6 +111,10 @@ async function init() {
 function notifySize() {
   window.parent.postMessage({ jsonrpc: '2.0', method: 'ui/notifications/size-changed', params: { height: document.body.scrollHeight } }, '*');
 }
+
+// Re-report size when content changes (e.g. host-context updates) so the host keeps
+// the iframe fit to content. The #updates log is capped, so the height stays bounded.
+if (window.ResizeObserver) new ResizeObserver(notifySize).observe(document.body);
 
 init();
 </script>

--- a/examples/html-widgets/src/widgets/host_context.py
+++ b/examples/html-widgets/src/widgets/host_context.py
@@ -19,7 +19,7 @@ HOST_CONTEXT_WIDGET_HTML = """<!DOCTYPE html>
 <html><head><meta charset="utf-8">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
-html,body{height:100%;overflow:auto}
+html,body{overflow:auto}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:16px;background:#fff;color:#242424;font-size:13px}
 h3{margin:0 0 8px}
 .section{margin-top:12px;padding:8px;background:#f0f9ff;border-radius:4px}
@@ -97,6 +97,16 @@ async function init() {
 
   // Send initialized notification
   window.parent.postMessage({ jsonrpc: '2.0', method: 'ui/notifications/initialized', params: {} }, '*');
+
+  // Report content size so the host can size the iframe to fit. The SDK-injected
+  // protocol normally does this, but it skips injection for widgets (like this one)
+  // that run their own ui/initialize handshake, so we report the size ourselves.
+  notifySize();
+  setTimeout(notifySize, 100);
+}
+
+function notifySize() {
+  window.parent.postMessage({ jsonrpc: '2.0', method: 'ui/notifications/size-changed', params: { height: document.body.scrollHeight } }, '*');
 }
 
 init();

--- a/examples/html-widgets/src/widgets/open_link.py
+++ b/examples/html-widgets/src/widgets/open_link.py
@@ -21,7 +21,7 @@ OPEN_LINK_WIDGET_HTML = """<!DOCTYPE html>
 html,body{height:100%;overflow:auto}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:16px;background:#fff;color:#242424;font-size:13px}
 h3{margin:0 0 8px}
-button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;color:#242424;cursor:pointer;font-size:12px}
+button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;color:inherit;cursor:pointer;font-size:12px}
 button:hover{background:#e0e0e0}
 #status{margin-top:12px;padding:8px;background:#f0f9ff;border-radius:4px;white-space:pre-wrap;font-family:monospace;font-size:11px}
 </style></head><body>
@@ -40,7 +40,9 @@ const pending = {};
 window.addEventListener('message', (event) => {
   const data = event.data;
   if (data?.id && pending[data.id]) {
-    pending[data.id](data);
+    const cb = pending[data.id];
+    delete pending[data.id];
+    cb(data);
   }
 });
 

--- a/examples/html-widgets/src/widgets/open_link.py
+++ b/examples/html-widgets/src/widgets/open_link.py
@@ -21,7 +21,7 @@ OPEN_LINK_WIDGET_HTML = """<!DOCTYPE html>
 html,body{height:100%;overflow:auto}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:16px;background:#fff;color:#242424;font-size:13px}
 h3{margin:0 0 8px}
-button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;font-size:12px}
+button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;color:#242424;cursor:pointer;font-size:12px}
 button:hover{background:#e0e0e0}
 #status{margin-top:12px;padding:8px;background:#f0f9ff;border-radius:4px;white-space:pre-wrap;font-family:monospace;font-size:11px}
 </style></head><body>

--- a/examples/html-widgets/src/widgets/update_context.py
+++ b/examples/html-widgets/src/widgets/update_context.py
@@ -21,7 +21,7 @@ UPDATE_CONTEXT_WIDGET_HTML = """<!DOCTYPE html>
 html,body{height:100%;overflow:auto}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:16px;background:#fff;color:#242424;font-size:13px}
 h3{margin:0 0 8px}
-button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;color:#242424;cursor:pointer;font-size:12px}
+button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;color:inherit;cursor:pointer;font-size:12px}
 button:hover{background:#e0e0e0}
 textarea{width:100%;height:60px;margin:8px 0;padding:8px;border:1px solid #ccc;border-radius:4px;font-family:monospace;font-size:11px;resize:vertical}
 #status{margin-top:12px;padding:8px;background:#f0f9ff;border-radius:4px;white-space:pre-wrap;font-family:monospace;font-size:11px}
@@ -42,7 +42,9 @@ const pending = {};
 window.addEventListener('message', (event) => {
   const data = event.data;
   if (data?.id && pending[data.id]) {
-    pending[data.id](data);
+    const cb = pending[data.id];
+    delete pending[data.id];
+    cb(data);
   }
 });
 

--- a/examples/html-widgets/src/widgets/update_context.py
+++ b/examples/html-widgets/src/widgets/update_context.py
@@ -21,7 +21,7 @@ UPDATE_CONTEXT_WIDGET_HTML = """<!DOCTYPE html>
 html,body{height:100%;overflow:auto}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:16px;background:#fff;color:#242424;font-size:13px}
 h3{margin:0 0 8px}
-button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;cursor:pointer;font-size:12px}
+button{margin:4px 4px 4px 0;padding:6px 12px;border:1px solid #ccc;border-radius:4px;background:#f5f5f5;color:#242424;cursor:pointer;font-size:12px}
 button:hover{background:#e0e0e0}
 textarea{width:100%;height:60px;margin:8px 0;padding:8px;border:1px solid #ccc;border-radius:4px;font-family:monospace;font-size:11px;resize:vertical}
 #status{margin-top:12px;padding:8px;background:#f0f9ff;border-radius:4px;white-space:pre-wrap;font-family:monospace;font-size:11px}


### PR DESCRIPTION
Make improvements to HTML Widget example rendering

- Fixes button text rendering in white instead of black
- `/hostcontext` - as a self-initializing widget (`injectWidgetProtocol` bypassed by being populated) lacking `notifySize()` meant that render was too small against actual height of the widget. Removed `height: 100%` to remove circular measurement. 