### PR TITLE
Correct AgenticIdentity helper and scoped API naming

### DIFF
--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -18,7 +18,7 @@ uv run --project examples/agent365 python src/main.py
 
 ## Proactive API Send
 
-`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample uses `app.get_agentic_identity(...)` with `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID` and the tenant ID comes from `TENANT_ID`.
+`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample passes `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID` unless explicitly overridden in code.
 
 ```bash
 export CLIENT_ID=<agentic-app-blueprint-id>

--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -18,7 +18,7 @@ uv run --project examples/agent365 python src/main.py
 
 ## Proactive API Send
 
-`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample passes `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID` unless explicitly overridden in code.
+`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample uses `app.get_agentic_identity(...)` with `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID` and the tenant ID comes from `TENANT_ID`.
 
 ```bash
 export CLIENT_ID=<agentic-app-blueprint-id>

--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -18,7 +18,7 @@ uv run --project examples/agent365 python src/main.py
 
 ## Proactive API Send
 
-`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample passes `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID` unless explicitly overridden in code.
+`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample constructs `AgenticIdentity` directly with `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID`, and the tenant ID comes from `TENANT_ID`.
 
 ```bash
 export CLIENT_ID=<agentic-app-blueprint-id>

--- a/examples/agent365/README.md
+++ b/examples/agent365/README.md
@@ -18,7 +18,7 @@ uv run --project examples/agent365 python src/main.py
 
 ## Proactive API Send
 
-`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample constructs `AgenticIdentity` directly with `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID`, and the tenant ID comes from `TENANT_ID`.
+`src/proactive.py` shows both `app.send(..., agentic_identity=...)` and a scoped lower-level conversation activity API client. This user-backed sample uses `app.get_agentic_identity(...)` with `agentic_app_id` and `agentic_user_id` because that token flow needs both IDs; the blueprint ID comes from `CLIENT_ID` and the tenant ID comes from `TENANT_ID`.
 
 ```bash
 export CLIENT_ID=<agentic-app-blueprint-id>

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -7,7 +7,7 @@ import argparse
 import asyncio
 import logging
 
-from microsoft_teams.api import AgenticIdentity, MessageActivityInput
+from microsoft_teams.api import MessageActivityInput
 from microsoft_teams.apps import App
 
 logging.basicConfig(level=logging.INFO)
@@ -24,17 +24,7 @@ async def main():
     app = App()
     await app.initialize()
 
-    if app.id is None:
-        raise ValueError("CLIENT_ID is required to construct an AgenticIdentity.")
-    if app.credentials is None or app.credentials.tenant_id is None:
-        raise ValueError("TENANT_ID is required to construct an AgenticIdentity.")
-
-    agentic_identity = AgenticIdentity(
-        agentic_app_blueprint_id=app.id,
-        agentic_app_id=args.agentic_app_id,
-        agentic_user_id=args.agentic_user_id,
-        tenant_id=app.credentials.tenant_id,
-    )
+    agentic_identity = app.get_agentic_identity(args.agentic_app_id, args.agentic_user_id)
     sent = await app.send(
         args.conversation_id,
         "Hello from app.send with an AgenticIdentity.",
@@ -42,7 +32,7 @@ async def main():
     )
     logger.info("Sent activity through app.send. Activity ID: %s", sent.id)
 
-    api_sent = await app.api.from_agentic_identity(agentic_identity).conversations.create_activity(
+    api_sent = await app.api.for_agentic_identity(agentic_identity).conversations.create_activity(
         args.conversation_id,
         MessageActivityInput(text="Hello from the conversation activity API with an AgenticIdentity."),
     )

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -7,7 +7,7 @@ import argparse
 import asyncio
 import logging
 
-from microsoft_teams.api import MessageActivityInput
+from microsoft_teams.api import AgenticIdentity, MessageActivityInput
 from microsoft_teams.apps import App
 
 logging.basicConfig(level=logging.INFO)
@@ -24,7 +24,17 @@ async def main():
     app = App()
     await app.initialize()
 
-    agentic_identity = app.get_agentic_identity(args.agentic_app_id, args.agentic_user_id)
+    if app.id is None:
+        raise ValueError("CLIENT_ID is required to construct an AgenticIdentity.")
+    if app.credentials is None or app.credentials.tenant_id is None:
+        raise ValueError("TENANT_ID is required to construct an AgenticIdentity.")
+
+    agentic_identity = AgenticIdentity(
+        agentic_app_blueprint_id=app.id,
+        agentic_app_id=args.agentic_app_id,
+        agentic_user_id=args.agentic_user_id,
+        tenant_id=app.credentials.tenant_id,
+    )
     sent = await app.send(
         args.conversation_id,
         "Hello from app.send with an AgenticIdentity.",

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -32,7 +32,7 @@ async def main():
     )
     logger.info("Sent activity through app.send. Activity ID: %s", sent.id)
 
-    api_sent = await app.api.from_agentic_identity(agentic_identity).conversations.create_activity(
+    api_sent = await app.api.for_agentic_identity(agentic_identity).conversations.create_activity(
         args.conversation_id,
         MessageActivityInput(text="Hello from the conversation activity API with an AgenticIdentity."),
     )

--- a/examples/agent365/src/proactive.py
+++ b/examples/agent365/src/proactive.py
@@ -32,7 +32,7 @@ async def main():
     )
     logger.info("Sent activity through app.send. Activity ID: %s", sent.id)
 
-    api_sent = await app.api.for_agentic_identity(agentic_identity).conversations.create_activity(
+    api_sent = await app.api.from_agentic_identity(agentic_identity).conversations.create_activity(
         args.conversation_id,
         MessageActivityInput(text="Hello from the conversation activity API with an AgenticIdentity."),
     )

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -136,13 +136,9 @@ class ApiClient(BaseClient):
         """Create a scoped API client for a different Teams service URL."""
         return self.clone(service_url=service_url)
 
-    def from_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
+    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
         """Create a scoped API client for an agentic identity."""
         return self.clone(agentic_identity=agentic_identity)
-
-    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
-        """Alias for from_agentic_identity."""
-        return self.from_agentic_identity(agentic_identity)
 
     def _scope_conversations(
         self,

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -140,10 +140,6 @@ class ApiClient(BaseClient):
         """Create a scoped API client for an agentic identity."""
         return self.clone(agentic_identity=agentic_identity)
 
-    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
-        """Alias for from_agentic_identity."""
-        return self.from_agentic_identity(agentic_identity)
-
     def _scope_conversations(
         self,
         service_url: str | None,

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -136,7 +136,7 @@ class ApiClient(BaseClient):
         """Create a scoped API client for a different Teams service URL."""
         return self.clone(service_url=service_url)
 
-    def from_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
+    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
         """Create a scoped API client for an agentic identity."""
         return self.clone(agentic_identity=agentic_identity)
 

--- a/packages/api/src/microsoft_teams/api/clients/api_client.py
+++ b/packages/api/src/microsoft_teams/api/clients/api_client.py
@@ -136,9 +136,13 @@ class ApiClient(BaseClient):
         """Create a scoped API client for a different Teams service URL."""
         return self.clone(service_url=service_url)
 
-    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
+    def from_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
         """Create a scoped API client for an agentic identity."""
         return self.clone(agentic_identity=agentic_identity)
+
+    def for_agentic_identity(self, agentic_identity: AgenticIdentity) -> "ApiClient":
+        """Alias for from_agentic_identity."""
+        return self.from_agentic_identity(agentic_identity)
 
     def _scope_conversations(
         self,

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -261,11 +261,9 @@ class TestApiClientScoping:
 
         service_scoped = client.from_service_url("https://override.service.url/")
         identity_scoped = client.from_agentic_identity(identity)
-        alias_scoped = client.for_agentic_identity(identity)
 
         assert service_scoped.service_url == "https://override.service.url"
         assert identity_scoped._default_agentic_identity is identity
-        assert alias_scoped._default_agentic_identity is identity
 
     @pytest.mark.asyncio
     async def test_clone_uses_scoped_agentic_identity_for_auth(self, request_capture, mock_activity):

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -217,7 +217,7 @@ class TestApiClientScoping:
             agentic_identity=default_identity,
         )
 
-        clone = client.from_agentic_identity(override_identity)
+        clone = client.for_agentic_identity(override_identity)
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
@@ -260,12 +260,10 @@ class TestApiClientScoping:
         client = ApiClient("https://mock.service.url", mock_http_client)
 
         service_scoped = client.from_service_url("https://override.service.url/")
-        identity_scoped = client.from_agentic_identity(identity)
-        alias_scoped = client.for_agentic_identity(identity)
+        identity_scoped = client.for_agentic_identity(identity)
 
         assert service_scoped.service_url == "https://override.service.url"
         assert identity_scoped._default_agentic_identity is identity
-        assert alias_scoped._default_agentic_identity is identity
 
     @pytest.mark.asyncio
     async def test_clone_uses_scoped_agentic_identity_for_auth(self, request_capture, mock_activity):
@@ -295,7 +293,7 @@ class TestApiClientScoping:
             agentic_identity=default_identity,
         )
 
-        await client.from_agentic_identity(override_identity).conversations.create_activity(
+        await client.for_agentic_identity(override_identity).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -334,11 +332,11 @@ class TestApiClientScoping:
             token_provider=TestTokenProvider(),
         )
 
-        await client.from_agentic_identity(identity_1).conversations.create_activity(
+        await client.for_agentic_identity(identity_1).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
         first_request = request_capture._capture.last_request
-        await client.from_agentic_identity(identity_2).conversations.create_activity(
+        await client.for_agentic_identity(identity_2).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
         second_request = request_capture._capture.last_request
@@ -383,13 +381,13 @@ class TestApiClientScoping:
 
         await (
             client.from_service_url("https://override.service.url")
-            .from_agentic_identity(identity_1)
+            .for_agentic_identity(identity_1)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         first_request = request_capture._capture.last_request
         await (
-            client.from_agentic_identity(identity_1)
-            .from_agentic_identity(identity_2)
+            client.for_agentic_identity(identity_1)
+            .for_agentic_identity(identity_2)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         second_request = request_capture._capture.last_request

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -217,7 +217,7 @@ class TestApiClientScoping:
             agentic_identity=default_identity,
         )
 
-        clone = client.for_agentic_identity(override_identity)
+        clone = client.from_agentic_identity(override_identity)
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
@@ -260,10 +260,12 @@ class TestApiClientScoping:
         client = ApiClient("https://mock.service.url", mock_http_client)
 
         service_scoped = client.from_service_url("https://override.service.url/")
-        identity_scoped = client.for_agentic_identity(identity)
+        identity_scoped = client.from_agentic_identity(identity)
+        alias_scoped = client.for_agentic_identity(identity)
 
         assert service_scoped.service_url == "https://override.service.url"
         assert identity_scoped._default_agentic_identity is identity
+        assert alias_scoped._default_agentic_identity is identity
 
     @pytest.mark.asyncio
     async def test_clone_uses_scoped_agentic_identity_for_auth(self, request_capture, mock_activity):
@@ -293,7 +295,7 @@ class TestApiClientScoping:
             agentic_identity=default_identity,
         )
 
-        await client.for_agentic_identity(override_identity).conversations.create_activity(
+        await client.from_agentic_identity(override_identity).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -332,11 +334,11 @@ class TestApiClientScoping:
             token_provider=TestTokenProvider(),
         )
 
-        await client.for_agentic_identity(identity_1).conversations.create_activity(
+        await client.from_agentic_identity(identity_1).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
         first_request = request_capture._capture.last_request
-        await client.for_agentic_identity(identity_2).conversations.create_activity(
+        await client.from_agentic_identity(identity_2).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
         second_request = request_capture._capture.last_request
@@ -381,13 +383,13 @@ class TestApiClientScoping:
 
         await (
             client.from_service_url("https://override.service.url")
-            .for_agentic_identity(identity_1)
+            .from_agentic_identity(identity_1)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         first_request = request_capture._capture.last_request
         await (
-            client.for_agentic_identity(identity_1)
-            .for_agentic_identity(identity_2)
+            client.from_agentic_identity(identity_1)
+            .from_agentic_identity(identity_2)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         second_request = request_capture._capture.last_request

--- a/packages/api/tests/unit/test_api_client.py
+++ b/packages/api/tests/unit/test_api_client.py
@@ -217,7 +217,7 @@ class TestApiClientScoping:
             agentic_identity=default_identity,
         )
 
-        clone = client.from_agentic_identity(override_identity)
+        clone = client.for_agentic_identity(override_identity)
 
         assert clone.http is not client.http
         assert clone.http.http is client.http.http
@@ -260,7 +260,7 @@ class TestApiClientScoping:
         client = ApiClient("https://mock.service.url", mock_http_client)
 
         service_scoped = client.from_service_url("https://override.service.url/")
-        identity_scoped = client.from_agentic_identity(identity)
+        identity_scoped = client.for_agentic_identity(identity)
 
         assert service_scoped.service_url == "https://override.service.url"
         assert identity_scoped._default_agentic_identity is identity
@@ -293,7 +293,7 @@ class TestApiClientScoping:
             agentic_identity=default_identity,
         )
 
-        await client.from_agentic_identity(override_identity).conversations.create_activity(
+        await client.for_agentic_identity(override_identity).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
 
@@ -332,11 +332,11 @@ class TestApiClientScoping:
             token_provider=TestTokenProvider(),
         )
 
-        await client.from_agentic_identity(identity_1).conversations.create_activity(
+        await client.for_agentic_identity(identity_1).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
         first_request = request_capture._capture.last_request
-        await client.from_agentic_identity(identity_2).conversations.create_activity(
+        await client.for_agentic_identity(identity_2).conversations.create_activity(
             "test_conversation_id", mock_activity
         )
         second_request = request_capture._capture.last_request
@@ -381,13 +381,13 @@ class TestApiClientScoping:
 
         await (
             client.from_service_url("https://override.service.url")
-            .from_agentic_identity(identity_1)
+            .for_agentic_identity(identity_1)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         first_request = request_capture._capture.last_request
         await (
-            client.from_agentic_identity(identity_1)
-            .from_agentic_identity(identity_2)
+            client.for_agentic_identity(identity_1)
+            .for_agentic_identity(identity_2)
             .conversations.create_activity("test_conversation_id", mock_activity)
         )
         second_request = request_capture._capture.last_request

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -414,7 +414,7 @@ class TestConversationActivityOperations:
                 token_provider=TestTokenProvider(),
                 agentic_identity=default_identity,
             )
-            .from_agentic_identity(override_identity)
+            .for_agentic_identity(override_identity)
             .conversations
         )
 
@@ -609,7 +609,7 @@ class TestConversationActivityOperations:
             agentic_user_id="agentic-user-id",
             tenant_id="tenant-id",
         )
-        client = ApiClient("https://test.service.url", request_capture).from_agentic_identity(identity).conversations
+        client = ApiClient("https://test.service.url", request_capture).for_agentic_identity(identity).conversations
 
         await client.activities("test_conversation_id").create(mock_activity)
 

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -341,6 +341,33 @@ class App(ActivityHandlerMixin):
             agentic_identity=agentic_identity,
         )
 
+    def get_agentic_identity(
+        self,
+        agentic_app_id: Optional[str] = None,
+        agentic_user_id: Optional[str] = None,
+        *,
+        tenant_id: Optional[str] = None,
+        agentic_app_blueprint_id: Optional[str] = None,
+    ) -> AgenticIdentity:
+        """Get an AgenticIdentity for API calls.
+
+        When ``agentic_app_blueprint_id`` is omitted, it defaults to the app's own
+        client/app id (``self.id``).
+        """
+        resolved_tenant_id = tenant_id or (self.credentials.tenant_id if self.credentials else None)
+        if resolved_tenant_id is None:
+            raise ValueError("tenant_id is required to get an agentic identity")
+
+        resolved_blueprint_id = agentic_app_blueprint_id or self.id
+        if resolved_blueprint_id is None:
+            raise ValueError("agentic_app_blueprint_id is required to get an agentic identity")
+        return AgenticIdentity(
+            agentic_app_blueprint_id=resolved_blueprint_id,
+            agentic_app_id=agentic_app_id,
+            agentic_user_id=agentic_user_id,
+            tenant_id=resolved_tenant_id,
+        )
+
     @overload
     async def reply(
         self,

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -341,33 +341,6 @@ class App(ActivityHandlerMixin):
             agentic_identity=agentic_identity,
         )
 
-    def get_agentic_identity(
-        self,
-        agentic_app_id: Optional[str] = None,
-        agentic_user_id: Optional[str] = None,
-        *,
-        tenant_id: Optional[str] = None,
-        agentic_app_blueprint_id: Optional[str] = None,
-    ) -> AgenticIdentity:
-        """Get an AgenticIdentity for API calls.
-
-        When ``agentic_app_blueprint_id`` is omitted, it defaults to the app's own
-        client/app id (``self.id``).
-        """
-        resolved_tenant_id = tenant_id or (self.credentials.tenant_id if self.credentials else None)
-        if resolved_tenant_id is None:
-            raise ValueError("tenant_id is required to get an agentic identity")
-
-        resolved_blueprint_id = agentic_app_blueprint_id or self.id
-        if resolved_blueprint_id is None:
-            raise ValueError("agentic_app_blueprint_id is required to get an agentic identity")
-        return AgenticIdentity(
-            agentic_app_blueprint_id=resolved_blueprint_id,
-            agentic_app_id=agentic_app_id,
-            agentic_user_id=agentic_user_id,
-            tenant_id=resolved_tenant_id,
-        )
-
     @overload
     async def reply(
         self,

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -985,6 +985,9 @@ class TestApp:
         )
 
         assert identity.agentic_app_blueprint_id == "explicit-blueprint-id"
+        assert identity.agentic_app_id == "agentic-app-id"
+        assert identity.agentic_user_id == "agentic-user-id"
+        assert identity.tenant_id == "tenant-id"
 
     def test_get_agentic_identity_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
         """When agentic_app_blueprint_id is omitted, it should default to the app's client id."""
@@ -999,6 +1002,21 @@ class TestApp:
 
         assert identity.agentic_app_blueprint_id == app.id
         assert identity.agentic_app_blueprint_id == "test-client-id"
+
+    def test_get_agentic_identity_allows_nullable_agentic_app_id(self, mock_storage) -> None:
+        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        identity = app.get_agentic_identity(
+            agentic_user_id="agentic-user-id",
+            tenant_id="tenant-id",
+            agentic_app_blueprint_id="blueprint-id",
+        )
+
+        assert identity.agentic_app_blueprint_id == "blueprint-id"
+        assert identity.agentic_app_id is None
+        assert identity.agentic_user_id == "agentic-user-id"
+        assert identity.tenant_id == "tenant-id"
 
 
 class TestAppInitialize:

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -985,9 +985,6 @@ class TestApp:
         )
 
         assert identity.agentic_app_blueprint_id == "explicit-blueprint-id"
-        assert identity.agentic_app_id == "agentic-app-id"
-        assert identity.agentic_user_id == "agentic-user-id"
-        assert identity.tenant_id == "tenant-id"
 
     def test_get_agentic_identity_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
         """When agentic_app_blueprint_id is omitted, it should default to the app's client id."""
@@ -1002,21 +999,6 @@ class TestApp:
 
         assert identity.agentic_app_blueprint_id == app.id
         assert identity.agentic_app_blueprint_id == "test-client-id"
-
-    def test_get_agentic_identity_allows_nullable_agentic_app_id(self, mock_storage) -> None:
-        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
-        app = App(**options)
-
-        identity = app.get_agentic_identity(
-            agentic_user_id="agentic-user-id",
-            tenant_id="tenant-id",
-            agentic_app_blueprint_id="blueprint-id",
-        )
-
-        assert identity.agentic_app_blueprint_id == "blueprint-id"
-        assert identity.agentic_app_id is None
-        assert identity.agentic_user_id == "agentic-user-id"
-        assert identity.tenant_id == "tenant-id"
 
 
 class TestAppInitialize:

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -972,6 +972,52 @@ class TestApp:
 
         app.api.clone.assert_not_called()
 
+    def test_get_agentic_identity_preserves_explicit_blueprint_id(self, mock_storage) -> None:
+        """An explicitly provided agentic_app_blueprint_id should be preserved."""
+        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        identity = app.get_agentic_identity(
+            "agentic-app-id",
+            "agentic-user-id",
+            tenant_id="tenant-id",
+            agentic_app_blueprint_id="explicit-blueprint-id",
+        )
+
+        assert identity.agentic_app_blueprint_id == "explicit-blueprint-id"
+        assert identity.agentic_app_id == "agentic-app-id"
+        assert identity.agentic_user_id == "agentic-user-id"
+        assert identity.tenant_id == "tenant-id"
+
+    def test_get_agentic_identity_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
+        """When agentic_app_blueprint_id is omitted, it should default to the app's client id."""
+        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        identity = app.get_agentic_identity(
+            "agentic-app-id",
+            "agentic-user-id",
+            tenant_id="tenant-id",
+        )
+
+        assert identity.agentic_app_blueprint_id == app.id
+        assert identity.agentic_app_blueprint_id == "test-client-id"
+
+    def test_get_agentic_identity_allows_nullable_agentic_app_id(self, mock_storage) -> None:
+        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
+        app = App(**options)
+
+        identity = app.get_agentic_identity(
+            agentic_user_id="agentic-user-id",
+            tenant_id="tenant-id",
+            agentic_app_blueprint_id="blueprint-id",
+        )
+
+        assert identity.agentic_app_blueprint_id == "blueprint-id"
+        assert identity.agentic_app_id is None
+        assert identity.agentic_user_id == "agentic-user-id"
+        assert identity.tenant_id == "tenant-id"
+
 
 class TestAppInitialize:
     """Test cases for App.initialize() method."""

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -972,34 +972,6 @@ class TestApp:
 
         app.api.clone.assert_not_called()
 
-    def test_get_agentic_identity_preserves_explicit_blueprint_id(self, mock_storage) -> None:
-        """An explicitly provided agentic_app_blueprint_id should be preserved."""
-        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
-        app = App(**options)
-
-        identity = app.get_agentic_identity(
-            "agentic-app-id",
-            "agentic-user-id",
-            tenant_id="tenant-id",
-            agentic_app_blueprint_id="explicit-blueprint-id",
-        )
-
-        assert identity.agentic_app_blueprint_id == "explicit-blueprint-id"
-
-    def test_get_agentic_identity_defaults_blueprint_id_to_client_id(self, mock_storage) -> None:
-        """When agentic_app_blueprint_id is omitted, it should default to the app's client id."""
-        options = AppOptions(storage=mock_storage, client_id="test-client-id", client_secret="test-secret")
-        app = App(**options)
-
-        identity = app.get_agentic_identity(
-            "agentic-app-id",
-            "agentic-user-id",
-            tenant_id="tenant-id",
-        )
-
-        assert identity.agentic_app_blueprint_id == app.id
-        assert identity.agentic_app_blueprint_id == "test-client-id"
-
 
 class TestAppInitialize:
     """Test cases for App.initialize() method."""


### PR DESCRIPTION
## Summary

This follow-up corrects the Agent365 Python API shape after #533: `App.get_agentic_identity(...)` remains the app-level convenience for filling blueprint and tenant context, while the lower-level API client keeps one scoped identity method. The result preserves the useful app helper and avoids two equivalent scoped client names.

## Decisions

- **Keep the app helper, not the client alias pair.** `App.get_agentic_identity(...)` is useful because the app already owns the configured blueprint/client ID and tenant ID; the API client does not need both `from_` and `for_` names for the same scope operation.
- **Allow app-backed and user-backed identities.** The helper keeps `agentic_app_id` nullable so callers can construct `AgenticIdentity` for agentic app or agentic user flows without implying that every scope is user-backed.

## Validation

The echo sample starts successfully in this branch; `/` returns the existing 404 response because the sample does not expose a root route.
