### PR TITLE
Prepare 2.1 alpha release

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -77,25 +77,53 @@ extends:
           target:
             container: host
 
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+          target:
+            container: host
+
         - task: PowerShell@2
           displayName: 'Install uv, nbgv and set cloud build version'
           inputs:
             targetType: inline
             script: |
+              $ErrorActionPreference = 'Stop'
+
               # Install uv
               irm https://astral.sh/uv/install.ps1 | iex
               $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
               [System.Environment]::SetEnvironmentVariable('Path', "$env:USERPROFILE\.local\bin;$([System.Environment]::GetEnvironmentVariable('Path', 'User'))", 'User')
               Write-Host "##vso[task.prependpath]$env:USERPROFILE\.local\bin"
               uv --version
+              if ($LASTEXITCODE -ne 0) { throw "uv --version failed with exit code $LASTEXITCODE." }
 
               # Install nbgv
-              dotnet tool install -g nbgv
+              $nugetConfig = "$(Agent.TempDirectory)\NuGet.TeamsSDKPreviews.config"
+              @'
+              <?xml version="1.0" encoding="utf-8"?>
+              <configuration>
+                <packageSources>
+                  <clear />
+                  <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
+                </packageSources>
+              </configuration>
+              '@ | Set-Content -Path $nugetConfig -Encoding UTF8
+
+              dotnet nuget list source --configfile $nugetConfig
+              if ($LASTEXITCODE -ne 0) { throw "dotnet nuget list source failed with exit code $LASTEXITCODE." }
+
+              dotnet tool install -g nbgv --configfile $nugetConfig
+              if ($LASTEXITCODE -ne 0) { throw "dotnet tool install failed with exit code $LASTEXITCODE." }
+
+              $toolsPath = Join-Path $env:USERPROFILE ".dotnet\tools"
+              $env:Path = "$toolsPath;$env:Path"
               Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
               nbgv --version
+              if ($LASTEXITCODE -ne 0) { throw "nbgv --version failed with exit code $LASTEXITCODE." }
 
               # Set cloud build number and variables (resolves detached HEAD in ADO)
               nbgv cloud
+              if ($LASTEXITCODE -ne 0) { throw "nbgv cloud failed with exit code $LASTEXITCODE." }
           target:
             container: host
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,7 @@ dotnet tool install -g nbgv
 | Branch | Versions | Published |
 |--------|----------|-----------|
 | `main` | `2.1.0.dev1`, `2.1.0.dev2`, ... | No |
+| `release/v2.1` | `2.1.0a1` → `2.1.0b1` → `2.1.0` | Yes |
 | `release/v2.0` | `2.0.x` | Yes |
 
 Release branches are **long-lived per minor line** and use the `release/v<major>.<minor>` naming convention. Create a
@@ -45,10 +46,10 @@ release branch as merged without pulling in any of its content.
    git checkout -b <you>/prep-release-<version> origin/main
    ```
 
-2. Edit `version.json` and change `"version"` from `"X.Y.Z-dev.{height}"` to `"X.Y.Z"` (the stable version you're releasing), then commit:
+2. Edit `version.json` for the release stage described below, then commit:
    ```bash
    git add version.json
-   git commit -m "Release <version>: set version to <version> stable"
+   git commit -m "Prepare <version> release"
    ```
 
 3. Merge the target release branch into your branch using `-s ours` (records it as a parent but keeps main's tree):
@@ -87,10 +88,26 @@ version core resets Nerdbank.GitVersioning's height for the new development line
 
 > **Note:** Running the pipeline on a branch not in `publicReleaseRefSpec` (e.g., a feature branch) produces versions with the commit hash appended, like `2.1.0.dev5+g1a2b3c4`. This is expected and useful for testing.
 
+### Producing Prereleases
+
+For the first alpha on a new release branch, use:
+
+```json
+{
+  "version": "2.1.0-alpha.{height}",
+  "versionHeightOffset": 1
+}
+```
+
+On the public release branch, the first version commit resolves to SemVer `2.1.0-alpha.1`; the package build normalizes
+that to PEP 440 `2.1.0a1`. Keep this configuration for later alphas so each release commit advances the height. To
+start beta, change `alpha` to `beta` and reset `versionHeightOffset` to `1`, producing `2.1.0b1`. Only use a higher
+offset when continuing an already-published prerelease sequence.
+
 ### Producing a Stable Release
 
-The version on a release branch should be a plain stable string (e.g. `2.1.0`, no `-dev` suffix). The PR opened in
-the [Workflow](#workflow) section above already handles this — just edit `version.json` before pushing:
+To promote a release branch from prerelease to stable, replace the prerelease template with a plain stable string
+(e.g. `2.1.0`, with no suffix):
 
 ```json
 {

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -95,14 +95,16 @@ For the first alpha on a new release branch, use:
 ```json
 {
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": 1
+  "versionHeightOffset": -1
 }
 ```
 
-On the public release branch, the first version commit resolves to SemVer `2.1.0-alpha.1`; the package build normalizes
-that to PEP 440 `2.1.0a1`. Keep this configuration for later alphas so each release commit advances the height. To
-start beta, change `alpha` to `beta` and reset `versionHeightOffset` to `1`, producing `2.1.0b1`. Only use a higher
-offset when continuing an already-published prerelease sequence.
+The example assumes a one-commit preparation PR followed by the required merge commit. Set `versionHeightOffset` to
+`1 - VersionHeight` for the expected merge commit, then verify that commit with
+`nbgv get-version --public-release=true`. This makes the public SemVer `2.1.0-alpha.1`; the package build normalizes
+it to PEP 440 `2.1.0a1`. Keep this configuration for later alphas so each release commit advances the height. To
+start beta, change `alpha` to `beta`, recalculate the offset for the expected merge commit, and verify that it produces
+`2.1.0b1`. Use the same process when continuing an already-published prerelease sequence, targeting the next ordinal.
 
 ### Producing a Stable Release
 
@@ -111,8 +113,7 @@ To promote a release branch from prerelease to stable, replace the prerelease te
 
 ```json
 {
-  "version": "2.1.0",
-  "versionHeightOffset": 1
+  "version": "2.1.0"
 }
 ```
 

--- a/packages/api/src/microsoft_teams/api/activities/message/message.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message.py
@@ -316,6 +316,8 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
             self.channel_data.stream_id = self.id
         if hasattr(self.channel_data, "stream_type"):
             self.channel_data.stream_type = "final"
+        if hasattr(self.channel_data, "stream_sequence"):
+            self.channel_data.stream_sequence = None
 
         # Add stream info entity
         stream_entity = StreamInfoEntity(type="streaminfo", stream_id=self.id, stream_type="final")

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -372,12 +372,15 @@ class TestMessageActivity:
         """Test adding stream final with existing channel data"""
         activity = self.create_message_activity()
         activity.id = "stream-msg-456"
-        activity.channel_data = ChannelData()
+        activity.channel_data = ChannelData(stream_sequence=3)
 
         activity.add_stream_final()
 
-        # Should use existing channel data
         assert activity.channel_data is not None
+        assert activity.channel_data.stream_sequence is None
+        data = activity.model_dump(by_alias=True, exclude_none=True)
+        assert "streamSequence" not in data["channelData"]
+        assert "streamSequence" not in data["entities"][0]
 
     def test_complex_message_building(self):
         """Test building a complex message with multiple features"""

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": 1,
+  "versionHeightOffset": -2,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"
   ]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1.0-dev.{height}",
+  "version": "2.1.0-alpha.{height}",
   "versionHeightOffset": 1,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": -2,
+  "versionHeightOffset": -4,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"
   ]


### PR DESCRIPTION
## Summary

Prepares the versioned 2.1 release line for its first public alpha without triggering publication. It also incorporates the latest `main`, including the NBGV publish-pipeline setup fix. The resulting protected-branch merge resolves to SemVer `2.1.0-alpha.1`, which all Python package artifacts normalize to PEP 440 `2.1.0a1`.

## Decisions

- **Height offset follows the final merge topology.** The `-4` offset accounts for the preparation history, the merge from `main`, the offset correction, and the ruleset-required PR merge; the simulated protected-branch merge has `VersionHeight: 5` and therefore resolves to alpha 1.
- **Prerelease promotion remains on the versioned release branch.** The release guide makes alpha-to-beta-to-stable progression explicit and requires verifying the expected merge commit before publishing.

## Deferred

The Azure DevOps Public publish remains intentionally manual and must run only after this PR merges.