### PR TITLE
fix: omit sequence from final stream messages

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/message/message.py
+++ b/packages/api/src/microsoft_teams/api/activities/message/message.py
@@ -316,6 +316,8 @@ class MessageActivityInput(_MessageBase, ActivityInputBase):
             self.channel_data.stream_id = self.id
         if hasattr(self.channel_data, "stream_type"):
             self.channel_data.stream_type = "final"
+        if hasattr(self.channel_data, "stream_sequence"):
+            self.channel_data.stream_sequence = None
 
         # Add stream info entity
         stream_entity = StreamInfoEntity(type="streaminfo", stream_id=self.id, stream_type="final")

--- a/packages/api/tests/unit/test_message_activities.py
+++ b/packages/api/tests/unit/test_message_activities.py
@@ -372,12 +372,15 @@ class TestMessageActivity:
         """Test adding stream final with existing channel data"""
         activity = self.create_message_activity()
         activity.id = "stream-msg-456"
-        activity.channel_data = ChannelData()
+        activity.channel_data = ChannelData(stream_sequence=3)
 
         activity.add_stream_final()
 
-        # Should use existing channel data
         assert activity.channel_data is not None
+        assert activity.channel_data.stream_sequence is None
+        data = activity.model_dump(by_alias=True, exclude_none=True)
+        assert "streamSequence" not in data["channelData"]
+        assert "streamSequence" not in data["entities"][0]
 
     def test_complex_message_building(self):
         """Test building a complex message with multiple features"""


### PR DESCRIPTION
## Summary

- clear stale `streamSequence` channel data when marking a message as final
- verify final stream payloads omit `streamSequence` from channel data and the stream entity

Follow-up to microsoft/teams.ts#688.

## Testing

- `poe check`
- `python -m pyright packages/api/src`
- `pytest packages/api` (322 passed)