### PR TITLE
Fix NBGV setup in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -77,25 +77,53 @@ extends:
           target:
             container: host
 
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate to Azure Artifacts'
+          target:
+            container: host
+
         - task: PowerShell@2
           displayName: 'Install uv, nbgv and set cloud build version'
           inputs:
             targetType: inline
             script: |
+              $ErrorActionPreference = 'Stop'
+
               # Install uv
               irm https://astral.sh/uv/install.ps1 | iex
               $env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
               [System.Environment]::SetEnvironmentVariable('Path', "$env:USERPROFILE\.local\bin;$([System.Environment]::GetEnvironmentVariable('Path', 'User'))", 'User')
               Write-Host "##vso[task.prependpath]$env:USERPROFILE\.local\bin"
               uv --version
+              if ($LASTEXITCODE -ne 0) { throw "uv --version failed with exit code $LASTEXITCODE." }
 
               # Install nbgv
-              dotnet tool install -g nbgv
+              $nugetConfig = "$(Agent.TempDirectory)\NuGet.TeamsSDKPreviews.config"
+              @'
+              <?xml version="1.0" encoding="utf-8"?>
+              <configuration>
+                <packageSources>
+                  <clear />
+                  <add key="TeamsSDKPreviews" value="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/nuget/v3/index.json" />
+                </packageSources>
+              </configuration>
+              '@ | Set-Content -Path $nugetConfig -Encoding UTF8
+
+              dotnet nuget list source --configfile $nugetConfig
+              if ($LASTEXITCODE -ne 0) { throw "dotnet nuget list source failed with exit code $LASTEXITCODE." }
+
+              dotnet tool install -g nbgv --configfile $nugetConfig
+              if ($LASTEXITCODE -ne 0) { throw "dotnet tool install failed with exit code $LASTEXITCODE." }
+
+              $toolsPath = Join-Path $env:USERPROFILE ".dotnet\tools"
+              $env:Path = "$toolsPath;$env:Path"
               Write-Host "##vso[task.prependpath]$env:USERPROFILE\.dotnet\tools"
               nbgv --version
+              if ($LASTEXITCODE -ne 0) { throw "nbgv --version failed with exit code $LASTEXITCODE." }
 
               # Set cloud build number and variables (resolves detached HEAD in ADO)
               nbgv cloud
+              if ($LASTEXITCODE -ne 0) { throw "nbgv cloud failed with exit code $LASTEXITCODE." }
           target:
             container: host
 


### PR DESCRIPTION
## Summary

The 1ES publish agent needs authenticated Azure Artifacts access to install NBGV reliably. This uses the TeamsSDKPreviews NuGet feed exclusively, following [microsoft/teams.ts#650](https://github.com/microsoft/teams.ts/pull/650).

## Decisions

- **Fail at the source.** Native command exit codes now terminate the setup task at the real install failure instead of cascading into a misleading `nbgv` command-not-found error.

## Deferred

The `release/v2.1` port is intentionally deferred to a separate PR after this change merges.