### PR TITLE
Fix Windows encoding in SDK import test

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,6 +162,7 @@ The CI pipeline (`.github/workflows/ci.yml`) runs:
 - **ALWAYS activate virtual environment or use uv run** before running Python commands
 - **ALWAYS validate with a test app** after making changes to core packages
 - **ALWAYS run pre-commit validation** (`poe check && pyright`) before committing
+- **KEEP filesystem code and tests cross-platform** - Release validation runs on Windows and Linux. Use `pathlib` or path APIs, specify text encodings explicitly (normally UTF-8), and avoid locale-specific or Unix-only filesystem behavior.
 - **NEVER skip manual testing** - Automated tests don't cover integration scenarios
 
 ## Repository Quick Reference

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -245,11 +245,11 @@ def test_sdk_source_does_not_import_microsoft_otel_or_agents_sdk():
     )
 
     for source_file in packages_dir.glob("*/src/**/*.py"):
-        source = source_file.read_text()
+        source = source_file.read_text(encoding="utf-8")
         assert not any(forbidden in source for forbidden in forbidden_imports), source_file
 
     for pyproject_file in packages_dir.glob("*/pyproject.toml"):
-        manifest = pyproject_file.read_text()
+        manifest = pyproject_file.read_text(encoding="utf-8")
         assert "microsoft-opentelemetry" not in manifest
         assert "microsoft-agents" not in manifest
 


### PR DESCRIPTION
## Summary

The SDK import guard relied on the process locale when reading source and manifest files. Linux CI masked that dependency, while the Azure Windows publish runner exposed it when scanning non-ASCII UTF-8 source.

Both scan inputs now use UTF-8 explicitly, and the canonical contributor guidance documents cross-platform filesystem practices for Windows and Linux. Release branches and version metadata are intentionally unchanged.

## Validation

- Exact SDK import guard test passed.
- Ruff lint/format and pre-commit checks passed for the changed files.
- UTF-8 scan read all 332 Python files and 6 manifests and detected a synthetic forbidden-import sentinel.