### PR TITLE
Port Windows encoding fix to 2.1

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -162,6 +162,7 @@ The CI pipeline (`.github/workflows/ci.yml`) runs:
 - **ALWAYS activate virtual environment or use uv run** before running Python commands
 - **ALWAYS validate with a test app** after making changes to core packages
 - **ALWAYS run pre-commit validation** (`poe check && pyright`) before committing
+- **KEEP filesystem code and tests cross-platform** - Release validation runs on Windows and Linux. Use `pathlib` or path APIs, specify text encodings explicitly (normally UTF-8), and avoid locale-specific or Unix-only filesystem behavior.
 - **NEVER skip manual testing** - Automated tests don't cover integration scenarios
 
 ## Repository Quick Reference

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -245,11 +245,11 @@ def test_sdk_source_does_not_import_microsoft_otel_or_agents_sdk():
     )
 
     for source_file in packages_dir.glob("*/src/**/*.py"):
-        source = source_file.read_text()
+        source = source_file.read_text(encoding="utf-8")
         assert not any(forbidden in source for forbidden in forbidden_imports), source_file
 
     for pyproject_file in packages_dir.glob("*/pyproject.toml"):
-        manifest = pyproject_file.read_text()
+        manifest = pyproject_file.read_text(encoding="utf-8")
         assert "microsoft-opentelemetry" not in manifest
         assert "microsoft-agents" not in manifest
 

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": -7,
+  "versionHeightOffset": -9,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"
   ]

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": -4,
+  "versionHeightOffset": -5,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"
   ]

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": -5,
+  "versionHeightOffset": -7,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"
   ]


### PR DESCRIPTION
## Summary

Backports [#541](https://github.com/microsoft/teams.py/pull/541) to the 2.1 alpha line. This restores Windows publish validation by making the SDK import diagnostics test independent of the host locale.

## Decision

- **Preserve the unpublished first alpha.** The attempted deployment failed before publishing any 2.1.0 package to PyPI. The `versionHeightOffset` accounts for the complete backport and protected-branch merge topology so the release still produces `2.1.0-alpha.1` / `2.1.0a1`; public-release builds omit local commit metadata.