### PR TITLE
Install locked test dependencies in publish pipeline

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -159,7 +159,7 @@ extends:
               # Always use internal feed for dependency resolution (avoids firewall issues on 1ES pool)
               $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
               Write-Host "Using authenticated Azure Artifacts feed"
-              uv sync --locked --python $pythonPath --all-packages --group dev
+              uv sync --frozen --python $pythonPath --all-packages --group dev
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           target:

--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -156,12 +156,10 @@ extends:
               $pythonPath = (Get-Command python).Source
               Write-Host "Using Python at: $pythonPath"
               python --version
-              # Create venv
-              uv venv --python $pythonPath
               # Always use internal feed for dependency resolution (avoids firewall issues on 1ES pool)
               $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
               Write-Host "Using authenticated Azure Artifacts feed"
-              uv pip install -e packages/common -e packages/api -e packages/cards -e packages/apps -e packages/botbuilder -e packages/graph
+              uv sync --locked --python $pythonPath --all-packages --group dev
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           target:
@@ -175,7 +173,6 @@ extends:
               Write-Host "Running tests..."
               # Always use internal feed for dependency resolution (avoids firewall issues on 1ES pool)
               $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
-              uv pip install pytest pytest-asyncio
               .venv\Scripts\Activate.ps1
               pytest packages --junitxml=test-results.xml
           env:

--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -159,7 +159,10 @@ extends:
               # Always use internal feed for dependency resolution (avoids firewall issues on 1ES pool)
               $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
               Write-Host "Using authenticated Azure Artifacts feed"
-              uv sync --frozen --python $pythonPath --all-packages --group dev
+              uv venv --python $pythonPath
+              $lockedRequirements = "$(Agent.TempDirectory)\publish-requirements.txt"
+              uv export --quiet --frozen --all-packages --group dev --format requirements-txt --output-file $lockedRequirements
+              uv pip sync --python .venv\Scripts\python.exe $lockedRequirements
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           target:


### PR DESCRIPTION
## Summary

The Azure publish runner bypassed the root dev dependency group by installing only `pytest` and `pytest-asyncio`, so its test plugins drifted from normal CI and omitted the `syrupy` snapshot fixture. The publish job now consumes `pyproject.toml` and `uv.lock` as the source of truth for workspace and test dependencies while downloading through the authenticated Azure Artifacts feed.

## Decisions

- **Export the frozen lock before syncing the environment.** A direct `uv sync --frozen` follows artifact URLs embedded in `uv.lock`, which point to blocked `files.pythonhosted.org`. Exporting the frozen lock to hashed requirements preserves locked versions and integrity, includes every editable workspace member, and lets `uv pip sync` resolve those artifacts through the configured internal index.

## Deferred

`release/v2.1` is intentionally unchanged and will be ported only after this fix merges to `main`.

## Validation

- The frozen export contains all workspace members, locked versions, and hashes without direct PyPI artifact URLs.
- A clean export/sync installed `syrupy==5.5.1`, registered the `snapshot` fixture, and passed the previously failing snapshot test.
- Azure pipeline YAML parsed successfully.