### PR TITLE
Port locked publish dependencies to 2.1

### DIFF
--- a/.azdo/publish.yml
+++ b/.azdo/publish.yml
@@ -156,12 +156,13 @@ extends:
               $pythonPath = (Get-Command python).Source
               Write-Host "Using Python at: $pythonPath"
               python --version
-              # Create venv
-              uv venv --python $pythonPath
               # Always use internal feed for dependency resolution (avoids firewall issues on 1ES pool)
               $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
               Write-Host "Using authenticated Azure Artifacts feed"
-              uv pip install -e packages/common -e packages/api -e packages/cards -e packages/apps -e packages/botbuilder -e packages/graph
+              uv venv --python $pythonPath
+              $lockedRequirements = "$(Agent.TempDirectory)\publish-requirements.txt"
+              uv export --quiet --frozen --all-packages --group dev --format requirements-txt --output-file $lockedRequirements
+              uv pip sync --python .venv\Scripts\python.exe $lockedRequirements
           env:
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           target:
@@ -175,7 +176,6 @@ extends:
               Write-Host "Running tests..."
               # Always use internal feed for dependency resolution (avoids firewall issues on 1ES pool)
               $env:UV_INDEX_URL = "https://build:$($env:SYSTEM_ACCESSTOKEN)@pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/TeamsSDKPreviews/pypi/simple/"
-              uv pip install pytest pytest-asyncio
               .venv\Scripts\Activate.ps1
               pytest packages --junitxml=test-results.xml
           env:

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.1.0-alpha.{height}",
-  "versionHeightOffset": -9,
+  "versionHeightOffset": -12,
   "publicReleaseRefSpec": [
     "^refs/heads/release/v\\d+\\.\\d+$"
   ]


### PR DESCRIPTION
## Summary

Ports the verified Windows publish dependency setup from [#543](https://github.com/microsoft/teams.py/pull/543) to the protected 2.1 alpha line. This keeps the publish runner aligned with the frozen workspace lock so test plugins such as `syrupy` are available without direct downloads from blocked PyPI artifact hosts, while preserving the still-unpublished `2.1.0a1` release.

## Decisions

- **Preserve the alpha across the protected merge topology.** The release tip is NBGV height 10 with offset -9. The pipeline port, offset commit, and GitHub merge commit raise the protected tip to height 13, so the offset moves to -12 and the public version remains `2.1.0-alpha.1` / PEP 440 `2.1.0a1`.
- **Port only the publish fix.** This cherry-picks #543's one-file pipeline change rather than merging unrelated work from `main`.

## Validation

A synthetic protected merge with `PublicRelease=true` produced all six wheels and six sdists at exactly `2.1.0a1`, with no local hashes. The frozen export contained all workspace packages and `syrupy==5.5.1` without `files.pythonhosted.org` URLs; an isolated sync registered the `snapshot` fixture and passed the previously failing HTML widget snapshot test. Azure pipeline YAML, Ruff formatting/linting, and Pyright also passed.
