### PR TITLE
Feature: Receive files in personal scope

### DIFF
--- a/packages/api/src/microsoft_teams/api/models/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/__init__.py
@@ -38,6 +38,7 @@ from .channel_data import *  # noqa: F403
 from .channel_id import ChannelID
 from .config import *  # noqa: F403
 from .conversation import *  # noqa: F403
+from .conversation_type import ConversationType
 from .custom_base_model import CustomBaseModel
 from .delivery_mode import DeliveryMode
 from .entity import *  # noqa: F403
@@ -86,6 +87,7 @@ __all__: list[str] = [
     "CacheInfo",
     "ChannelID",
     "ConversationAccount",
+    "ConversationType",
     "CustomBaseModel",
     "DeliveryMode",
     "ErrorResponse",

--- a/packages/api/src/microsoft_teams/api/models/account.py
+++ b/packages/api/src/microsoft_teams/api/models/account.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Literal, Optional
 from pydantic import AliasChoices, Field
 
 from .agentic_identity import AgenticIdentity
+from .conversation_type import ConversationType
 from .custom_base_model import CustomBaseModel
 
 AccountType = Literal["person", "tag", "channel", "team", "bot"]
@@ -158,7 +159,7 @@ class ConversationAccount(CustomBaseModel):
     """
     The tenant ID for the conversation.
     """
-    conversation_type: Optional[str] = None
+    conversation_type: Optional[ConversationType] = None
     """
     The type of conversation (personal, groupChat, etc.).
     """

--- a/packages/api/src/microsoft_teams/api/models/attachment/attachment.py
+++ b/packages/api/src/microsoft_teams/api/models/attachment/attachment.py
@@ -24,4 +24,7 @@ class Attachment(CustomBaseModel):
     "The name of the attachment"
 
     thumbnail_url: Optional[str] = None
-    "Thumbnail associated with attachment"
+    """
+    Thumbnail associated with attachment.
+    Not set by Teams when a bot receives an upload.
+    """

--- a/packages/api/src/microsoft_teams/api/models/conversation/conversation.py
+++ b/packages/api/src/microsoft_teams/api/models/conversation/conversation.py
@@ -3,12 +3,11 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import List, Literal, Optional
+from typing import List, Optional
 
 from ..account import Account
+from ..conversation_type import ConversationType
 from ..custom_base_model import CustomBaseModel
-
-ConversationType = Literal["personal", "groupChat"]
 
 
 class Conversation(CustomBaseModel):

--- a/packages/api/src/microsoft_teams/api/models/conversation_type.py
+++ b/packages/api/src/microsoft_teams/api/models/conversation_type.py
@@ -1,0 +1,12 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Literal, Union
+
+# Define the literal types for known conversation types
+KnownConversationType = Literal["personal", "groupChat", "channel"]
+
+# Type alias for conversation type that can be either a known type or any other string
+ConversationType = Union[KnownConversationType, str]

--- a/packages/api/src/microsoft_teams/api/models/file/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/file/__init__.py
@@ -4,12 +4,15 @@ Licensed under the MIT License.
 """
 
 from .file_consent_card import FileConsentCard, FileConsentCardResponse
+from .file_download_info import FILE_DOWNLOAD_INFO_CONTENT_TYPE, FileDownloadInfo
 from .file_info_card import FileInfoCard
 from .file_upload_info import FileUploadInfo
 
 __all__ = [
     "FileConsentCard",
     "FileConsentCardResponse",
+    "FILE_DOWNLOAD_INFO_CONTENT_TYPE",
+    "FileDownloadInfo",
     "FileInfoCard",
     "FileUploadInfo",
 ]

--- a/packages/api/src/microsoft_teams/api/models/file/file_download_info.py
+++ b/packages/api/src/microsoft_teams/api/models/file/file_download_info.py
@@ -1,0 +1,33 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Any, Optional
+
+from ..custom_base_model import CustomBaseModel
+
+FILE_DOWNLOAD_INFO_CONTENT_TYPE = "application/vnd.microsoft.teams.file.download.info"
+"""
+Content type of an inbound uploaded-file attachment.
+Its `content` is a `FileDownloadInfo` describing a file fetchable from a short-lived, pre-authorized download URL.
+"""
+
+
+class FileDownloadInfo(CustomBaseModel):
+    """
+    The content of a `file.download.info` attachment, describing an uploaded file received in a personal (1:1) chat.
+    The file is fetched from the short-lived, pre-authorized `download_url` with a plain GET (no bearer token).
+    """
+
+    download_url: Optional[str] = None
+    "Pre-authorized, short-lived URL the file can be fetched from with a plain GET (no bearer token)."
+
+    unique_id: Optional[str] = None
+    "The OneDrive/ODSP drive-item id for the file. This is the storage-specific file identity a Graph fetch keys off."
+
+    file_type: Optional[str] = None
+    "Type of file (extension, e.g. `pdf`, `docx`)."
+
+    etag: Optional[Any] = None
+    "ETag for the file."

--- a/packages/api/src/microsoft_teams/api/models/file/file_download_info.py
+++ b/packages/api/src/microsoft_teams/api/models/file/file_download_info.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Any, Optional
+from typing import Optional
 
 from ..custom_base_model import CustomBaseModel
 
@@ -29,5 +29,8 @@ class FileDownloadInfo(CustomBaseModel):
     file_type: Optional[str] = None
     "Type of file (extension, e.g. `pdf`, `docx`)."
 
-    etag: Optional[Any] = None
-    "ETag for the file."
+    etag: Optional[str] = None
+    """
+    A server-assigned version tag identifying this version of the file's contents, for detecting whether the file
+    changed between reads. Read-only; populated when Teams provides it with the file.
+    """

--- a/packages/api/src/microsoft_teams/api/models/file/file_info_card.py
+++ b/packages/api/src/microsoft_teams/api/models/file/file_info_card.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Any, Optional
+from typing import Optional
 
 from ..custom_base_model import CustomBaseModel
 
@@ -19,5 +19,8 @@ class FileInfoCard(CustomBaseModel):
     file_type: Optional[str] = None
     "Type of file."
 
-    etag: Optional[Any] = None
-    "ETag for the file."
+    etag: Optional[str] = None
+    """
+    A server-assigned version tag identifying the uploaded file's contents.
+    Populated from the storage service's upload response.
+    """

--- a/packages/api/tests/unit/test_conversation_type.py
+++ b/packages/api/tests/unit/test_conversation_type.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+# pyright: basic
+
+import pytest
+from microsoft_teams.api.models import Conversation, ConversationAccount
+
+
+@pytest.mark.unit
+class TestConversationType:
+    """Unit tests for the shared ConversationType open union on Conversation and ConversationAccount."""
+
+    def test_conversation_accepts_channel(self) -> None:
+        """Regression: a 'channel' conversation must validate.
+
+        The previous closed Literal["personal", "groupChat"] rejected 'channel', and
+        CustomBaseModel's extra='allow' does not relax Literal validation, so a channel
+        conversation failed validation.
+        """
+        conversation = Conversation.model_validate({"id": "c1", "conversationType": "channel"})
+        assert conversation.conversation_type == "channel"
+
+    @pytest.mark.parametrize("value", ["personal", "groupChat", "channel"])
+    def test_conversation_known_values_round_trip(self, value: str) -> None:
+        conversation = Conversation.model_validate({"id": "c1", "conversationType": value})
+        assert conversation.conversation_type == value
+        assert conversation.model_dump(by_alias=True, exclude_none=True)["conversationType"] == value
+
+    def test_conversation_accepts_unknown_value(self) -> None:
+        """The open union stays forward-compatible with values the SDK has not enumerated."""
+        conversation = Conversation.model_validate({"id": "c1", "conversationType": "someFutureScope"})
+        assert conversation.conversation_type == "someFutureScope"
+
+    def test_conversation_account_accepts_channel(self) -> None:
+        account = ConversationAccount.model_validate({"id": "c1", "conversationType": "channel"})
+        assert account.conversation_type == "channel"
+
+    def test_conversation_account_type_is_optional(self) -> None:
+        account = ConversationAccount.model_validate({"id": "c1"})
+        assert account.conversation_type is None

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -5,12 +5,13 @@ Licensed under the MIT License.
 
 import logging
 
-from . import auth, contexts, diagnostics, events, plugins
+from . import auth, contexts, diagnostics, events, files, plugins
 from .app import App
 from .auth import *  # noqa: F403
 from .contexts import *  # noqa: F403
 from .diagnostics import *  # noqa: F403
 from .events import *  # noqa: F401, F403
+from .files import *  # noqa: F403
 from .http import FastAPIAdapter, HttpServer, HttpServerAdapter
 from .http_stream import HttpStream
 from .options import AppOptions, AppTelemetryOptions
@@ -59,5 +60,6 @@ __all__: list[str] = [
 __all__.extend(auth.__all__)
 __all__.extend(diagnostics.__all__)
 __all__.extend(events.__all__)
+__all__.extend(files.__all__)
 __all__.extend(plugins.__all__)
 __all__.extend(contexts.__all__)

--- a/packages/apps/src/microsoft_teams/apps/files/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/files/__init__.py
@@ -3,11 +3,17 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from .downloaded_file import DownloadedFile
 from .errors import FileScopeNotSupportedError, FileUrlExpiredError
+from .files_accessor import FilesAccessor
+from .incoming_file import IncomingFile
 from .types import FileSource
 
 __all__ = [
     "FileSource",
     "FileScopeNotSupportedError",
     "FileUrlExpiredError",
+    "DownloadedFile",
+    "IncomingFile",
+    "FilesAccessor",
 ]

--- a/packages/apps/src/microsoft_teams/apps/files/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/files/__init__.py
@@ -1,0 +1,13 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from .errors import FileScopeNotSupportedError, FileUrlExpiredError
+from .types import FileSource
+
+__all__ = [
+    "FileSource",
+    "FileScopeNotSupportedError",
+    "FileUrlExpiredError",
+]

--- a/packages/apps/src/microsoft_teams/apps/files/download.py
+++ b/packages/apps/src/microsoft_teams/apps/files/download.py
@@ -72,7 +72,10 @@ async def _open_personal_file_stream(
     url = target.download_url
 
     if not url:
-        raise RuntimeError("cannot download personal file: no download URL is available")
+        raise RuntimeError("cannot download file: no download URL is available")
+
+    if not url.lower().startswith("https://"):
+        raise RuntimeError("cannot download file: download URL must use https")
 
     owns_client = client is None
     http = client or httpx.AsyncClient()

--- a/packages/apps/src/microsoft_teams/apps/files/download.py
+++ b/packages/apps/src/microsoft_teams/apps/files/download.py
@@ -1,0 +1,104 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+import httpx
+from microsoft_teams.api import ConversationType
+
+from .errors import FileScopeNotSupportedError, FileUrlExpiredError
+
+
+@dataclass
+class FileFetchTarget:
+    """The minimal file description the download dispatcher needs to open a byte stream."""
+
+    scope: ConversationType
+    """Conversation scope; the dispatcher is keyed on this."""
+
+    download_url: Optional[str] = None
+    """Short-lived, pre-authorized download URL (personal scope)."""
+
+    content_type: Optional[str] = None
+    """MIME type reported by the incoming file, used as a fallback when the response omits one."""
+
+
+@dataclass
+class OpenedFileStream:
+    """A freshly opened, single-consumption byte stream plus the metadata resolved while opening it."""
+
+    chunks: AsyncIterator[bytes]
+    """The raw response body stream. Uncapped; the caller bounds it."""
+
+    source_url: str
+    """The URL the bytes were actually fetched from."""
+
+    content_type: str
+    """MIME type resolved from the response, falling back to the incoming file's."""
+
+
+@asynccontextmanager
+async def open_file_stream(
+    target: FileFetchTarget,
+    *,
+    prior_fetch_succeeded: bool = False,
+    client: Optional[httpx.AsyncClient] = None,
+) -> AsyncIterator[OpenedFileStream]:
+    """
+    Open a byte stream for an inbound file, keyed on its conversation scope so every scope's receive path extends this
+    one place rather than branching in callers.
+
+    Only `personal` is implemented; `groupChat`/`channel` (and any future scope) raise `FileScopeNotSupportedError`
+    until their Graph receive path lands.
+    """
+    if target.scope != "personal":
+        raise FileScopeNotSupportedError(str(target.scope))
+
+    async with _open_personal_file_stream(target, prior_fetch_succeeded=prior_fetch_succeeded, client=client) as opened:
+        yield opened
+
+
+@asynccontextmanager
+async def _open_personal_file_stream(
+    target: FileFetchTarget,
+    *,
+    prior_fetch_succeeded: bool,
+    client: Optional[httpx.AsyncClient],
+) -> AsyncIterator[OpenedFileStream]:
+    url = target.download_url
+
+    if not url:
+        raise RuntimeError("cannot download personal file: no download URL is available")
+
+    owns_client = client is None
+    http = client or httpx.AsyncClient()
+
+    try:
+        # Plain GET with no bearer token: the download URL embeds its own `tempauth` credential, and attaching a
+        # credential can get the request rejected.
+        async with http.stream("GET", url) as response:
+            if response.status_code in (401, 403):
+                raise FileUrlExpiredError("reread" if prior_fetch_succeeded else "first_fetch")
+
+            if not response.is_success:
+                raise RuntimeError(f"failed to download file: {response.status_code} {response.reason_phrase}".strip())
+
+            content_type = response.headers.get("content-type") or target.content_type or "application/octet-stream"
+            yield OpenedFileStream(chunks=response.aiter_bytes(), source_url=url, content_type=content_type)
+    finally:
+        if owns_client:
+            await http.aclose()
+
+
+async def collect_stream(chunks: AsyncIterator[bytes]) -> bytes:
+    """Read a byte stream to completion into a single `bytes` object."""
+    buffer = bytearray()
+
+    async for chunk in chunks:
+        buffer.extend(chunk)
+
+    return bytes(buffer)

--- a/packages/apps/src/microsoft_teams/apps/files/download.py
+++ b/packages/apps/src/microsoft_teams/apps/files/download.py
@@ -56,7 +56,7 @@ async def open_file_stream(
     until their Graph receive path lands.
     """
     if target.scope != "personal":
-        raise FileScopeNotSupportedError(str(target.scope))
+        raise FileScopeNotSupportedError(target.scope)
 
     async with _open_personal_file_stream(target, prior_fetch_succeeded=prior_fetch_succeeded, client=client) as opened:
         yield opened

--- a/packages/apps/src/microsoft_teams/apps/files/downloaded_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/downloaded_file.py
@@ -23,7 +23,9 @@ class DownloadedFile:
     """The file bytes, buffered from `stream()` read to completion."""
 
     content_type: str
-    """MIME type resolved from the response or the incoming file."""
+    """MIME type resolved from the download response header, or the incoming file's metadata type if the
+    response omits one. Falls back to `application/octet-stream` when neither provides a type, so this is
+    never empty."""
 
     filename: str
     """Resolved filename."""

--- a/packages/apps/src/microsoft_teams/apps/files/downloaded_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/downloaded_file.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class DownloadedFile:
+    """
+    A buffered, point-in-time snapshot of a downloaded file's bytes that the caller owns.
+
+    Returned by `IncomingFile.download()`. The bytes are already in memory, so the convenience readers here are
+    synchronous and never re-download.
+    Because it is a snapshot, holding one and reusing it is the way to read the same file several ways without
+    re-fetching through the live `IncomingFile` handle.
+    """
+
+    bytes: bytes
+    """The file bytes, buffered from `stream()` read to completion."""
+
+    content_type: str
+    """MIME type resolved from the response or the incoming file."""
+
+    filename: str
+    """Resolved filename."""
+
+    source_url: str
+    """The URL the bytes were actually fetched from."""
+
+    def text(self, encoding: str = "utf-8") -> str:
+        """
+        Decode bytes as UTF-8 (or a provided encoding). No content-type check.
+        Lossy: invalid bytes become the U+FFFD replacement character and never throw.
+        For strict or binary-safe reads, use `bytes`.
+        """
+        return self.bytes.decode(encoding, errors="replace")
+
+    async def save_as(self, path: str) -> None:
+        """
+        Write the already-buffered bytes to a local file path (no re-fetch, unlike `IncomingFile.save_as()` which
+        streams a fresh download).
+        """
+        await asyncio.to_thread(Path(path).write_bytes, self.bytes)

--- a/packages/apps/src/microsoft_teams/apps/files/errors.py
+++ b/packages/apps/src/microsoft_teams/apps/files/errors.py
@@ -5,6 +5,8 @@ Licensed under the MIT License.
 
 from typing import Literal, Optional
 
+from microsoft_teams.api import ConversationType
+
 FileUrlExpiredReason = Literal["first_fetch", "reread"]
 
 
@@ -51,10 +53,10 @@ class FileScopeNotSupportedError(Exception):
     `download()`/`stream()` throws until that path lands.
     """
 
-    scope: str
+    scope: ConversationType
     """The conversation scope that is not yet fetchable."""
 
-    def __init__(self, scope: str, message: Optional[str] = None) -> None:
+    def __init__(self, scope: ConversationType, message: Optional[str] = None) -> None:
         if message is None:
             message = f"downloading files from '{scope}' conversations is not supported via SDK at this time"
         super().__init__(message)

--- a/packages/apps/src/microsoft_teams/apps/files/errors.py
+++ b/packages/apps/src/microsoft_teams/apps/files/errors.py
@@ -49,7 +49,7 @@ class FileScopeNotSupportedError(Exception):
     Raised when file bytes are requested for a conversation scope whose download path is not implemented.
 
     Only `personal` (1:1) uploaded files download directly.
-    `groupChat` and `channel` files are surfaced by `list()`, but fetching their bytes needs Graph;
+    `groupChat` files are surfaced by `list()`, but fetching their bytes needs Graph;
     `download()`/`stream()` throws until that path lands.
     """
 

--- a/packages/apps/src/microsoft_teams/apps/files/errors.py
+++ b/packages/apps/src/microsoft_teams/apps/files/errors.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Literal, Optional
+
+FileUrlExpiredReason = Literal["first_fetch", "reread"]
+
+
+class FileUrlExpiredError(Exception):
+    """
+    Raised when an inbound file's short-lived download URL has expired and can no longer fetch bytes.
+
+    A personal file's pre-authorized `tempauth` download URL is valid only briefly.
+    A fetch after it lapses gets a `401`/`403` from the platform. A handler that downloads once (and does not keep the
+    handle) should not hit this.
+    `reason` distinguishes the two cases:
+    - `first_fetch`: the first fetch came after the URL lapsed, so no bytes were retrieved. Recovery needs Graph
+      drive-item re-resolution, not available via the SDK at this time.
+    - `reread`: edge case. An earlier download succeeded, then a later re-fetch through the same handle lapsed. Avoid it
+      by calling `download()` once and reusing the returned `DownloadedFile` rather than re-reading the handle.
+    """
+
+    reason: FileUrlExpiredReason
+    """
+    Lets callers branch without string-matching the message.
+    `first_fetch`: no bytes were ever fetched.
+    `reread`: the uncommon case, a previously successful handle re-fetched too late.
+    """
+
+    def __init__(self, reason: FileUrlExpiredReason, message: Optional[str] = None) -> None:
+        if message is None:
+            message = (
+                "file download URL expired before any bytes were fetched; recovery needs Graph drive-item "
+                "re-resolution (not available via the SDK at this time)"
+                if reason == "first_fetch"
+                else "file download URL expired before a repeat read; reuse a single DownloadedFile from one "
+                "download() call instead of re-reading the handle"
+            )
+        super().__init__(message)
+        self.reason = reason
+
+
+class FileScopeNotSupportedError(Exception):
+    """
+    Raised when file bytes are requested for a conversation scope whose download path is not implemented.
+
+    Only `personal` (1:1) uploaded files download directly.
+    `groupChat` and `channel` files are surfaced by `list()`, but fetching their bytes needs Graph;
+    `download()`/`stream()` throws until that path lands.
+    """
+
+    scope: str
+    """The conversation scope that is not yet fetchable."""
+
+    def __init__(self, scope: str, message: Optional[str] = None) -> None:
+        if message is None:
+            message = f"downloading files from '{scope}' conversations is not supported via SDK at this time"
+        super().__init__(message)
+        self.scope = scope

--- a/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
+++ b/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
@@ -14,6 +14,7 @@ from microsoft_teams.api import (
     FileDownloadInfo,
     MessageActivity,
 )
+from pydantic import ValidationError
 
 from .incoming_file import IncomingFile
 
@@ -88,7 +89,7 @@ class FilesAccessor:
         if attachment.content_type != FILE_DOWNLOAD_INFO_CONTENT_TYPE:
             return None
 
-        content = self._coerce_content(attachment.content)
+        content = self._coerce_content(attachment.content, index)
         download_url = content.download_url if content else None
         name = attachment.name
 
@@ -114,11 +115,16 @@ class FilesAccessor:
             download_url=download_url,
         )
 
-    @staticmethod
-    def _coerce_content(content: object) -> Optional[FileDownloadInfo]:
+    def _coerce_content(self, content: object, index: int) -> Optional[FileDownloadInfo]:
         """Normalize the attachment's raw `content` (a wire dict or an already-parsed model) to `FileDownloadInfo`."""
         if isinstance(content, FileDownloadInfo):
             return content
         if isinstance(content, dict):
-            return FileDownloadInfo.model_validate(content)
+            try:
+                return FileDownloadInfo.model_validate(content)
+            except ValidationError:
+                self._logger.debug(
+                    f"files: skipping file.download.info attachment at index {index}; content failed validation"
+                )
+                return None
         return None

--- a/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
+++ b/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
@@ -18,6 +18,8 @@ from pydantic import ValidationError
 
 from .incoming_file import IncomingFile
 
+logger = logging.getLogger(__name__)
+
 
 class FilesAccessor:
     """
@@ -36,9 +38,8 @@ class FilesAccessor:
     file. An image sent as a file appears here, but the same image pasted inline does not.
     """
 
-    def __init__(self, activity: ActivityBase, logger: logging.Logger) -> None:
+    def __init__(self, activity: ActivityBase) -> None:
         self._activity = activity
-        self._logger = logger
 
     async def list(self) -> List[IncomingFile]:
         """
@@ -97,7 +98,7 @@ class FilesAccessor:
         # leave a breadcrumb rather than throwing.
         if not download_url or not name:
             missing = "name" if not name else "download_url"
-            self._logger.debug(f"files: skipping file.download.info attachment at index {index}; missing {missing}")
+            logger.debug(f"files: skipping file.download.info attachment at index {index}; missing {missing}")
             return None
 
         return IncomingFile(
@@ -123,7 +124,7 @@ class FilesAccessor:
             try:
                 return FileDownloadInfo.model_validate(content)
             except ValidationError:
-                self._logger.debug(
+                logger.debug(
                     f"files: skipping file.download.info attachment at index {index}; content failed validation"
                 )
                 return None

--- a/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
+++ b/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
@@ -1,0 +1,124 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import logging
+from typing import List, Optional
+
+from microsoft_teams.api import (
+    FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+    ActivityBase,
+    Attachment,
+    ConversationType,
+    FileDownloadInfo,
+    MessageActivity,
+)
+
+from .incoming_file import IncomingFile
+
+
+class FilesAccessor:
+    """
+    Accessor for the uploaded files on the current inbound activity, exposed as `ctx.files`.
+
+    "Files" is the uploaded-file view over the raw `ctx.activity.attachments` array. Uploaded files arrive as
+    attachments where `content_type` is `file.download.info`, carrying file metadata (a `download_url` plus
+    identifiers) rather than the bytes themselves, which are fetched from that URL. This accessor maps each to an
+    `IncomingFile`, and skips everything else in `attachments` (adaptive cards, mentions, other non-file content) as
+    well as malformed file entries, never throwing. For each file it returns, the original wire attachment (the
+    metadata object, not the bytes) is retained on `IncomingFile.raw`. A malformed or non-file attachment is reachable
+    only through the raw `activity.attachments` array.
+
+    This covers the file-upload path, not "any uploaded media". What matters is how the content arrived, not the
+    file's MIME type, so file *type* is unrestricted (pdf, docx, png, etc.) as long as it was sent as an uploaded
+    file. An image sent as a file appears here, but the same image pasted inline does not.
+    """
+
+    def __init__(self, activity: ActivityBase, logger: logging.Logger) -> None:
+        self._activity = activity
+        self._logger = logger
+
+    async def list(self) -> List[IncomingFile]:
+        """
+        The files attached to the current inbound activity. Async because later scopes hydrate through Graph; the
+        personal path resolves synchronously from the activity but keeps the async signature so the shape never
+        breaks.
+
+        Currently takes no arguments and returns only uploaded files. The signature is reserved to grow options later
+        (e.g. `include_inline_images`, `content_types`, `include_raw`) so coverage can widen opt-in without a break;
+        the default stays narrow.
+        """
+        # Uploaded files only ride on inbound message activities so we validate the shape and return an empty list
+        # rather than throwing.
+        if not isinstance(self._activity, MessageActivity):
+            return []
+
+        attachments = self._activity.attachments or []
+        scope = self._detect_scope()
+
+        files: List[IncomingFile] = []
+        for index, attachment in enumerate(attachments):
+            file = self._to_incoming_file(attachment, index, scope)
+            if file is not None:
+                files.append(file)
+
+        return files
+
+    async def first(self) -> Optional[IncomingFile]:
+        """
+        Convenience: the first attached file, or `None` when none. Sugar over `list()[0]`; shares `list()`'s
+        resolution so it stays correct when later scopes hydrate through Graph.
+        """
+        files = await self.list()
+        return files[0] if files else None
+
+    def _detect_scope(self) -> ConversationType:
+        """Derive the conversation scope from the inbound activity."""
+        conversation = getattr(self._activity, "conversation", None)
+        conversation_type = getattr(conversation, "conversation_type", None)
+        return conversation_type or "personal"
+
+    def _to_incoming_file(self, attachment: Attachment, index: int, scope: ConversationType) -> Optional[IncomingFile]:
+        """
+        Map a single activity attachment to an `IncomingFile`, or `None` when the attachment is not an uploaded file
+        or is malformed. Never throws: unusable attachments are skipped so one bad entry cannot drop the rest.
+        """
+        # Not an uploaded file (card, mention, adaptive card, etc.). Silently ignored.
+        if attachment.content_type != FILE_DOWNLOAD_INFO_CONTENT_TYPE:
+            return None
+
+        content = self._coerce_content(attachment.content)
+        download_url = content.download_url if content else None
+        name = attachment.name
+
+        # A `file.download.info` without fetchable URL or name cannot be turned into a usable handle. Skip it and
+        # leave a breadcrumb rather than throwing.
+        if not download_url or not name:
+            missing = "name" if not name else "download_url"
+            self._logger.debug(f"files: skipping file.download.info attachment at index {index}; missing {missing}")
+            return None
+
+        return IncomingFile(
+            name=name,
+            scope=scope,
+            source="botActivity",
+            unique_id=content.unique_id if content else None,
+            # `file_type` is the platform-supplied extension (e.g. `pdf`); left `None` when the wire omits it,
+            # matching how peer SDKs surface it.
+            extension=content.file_type if content else None,
+            # Maps the wire's `content_url` (a browsable link to the file in OneDrive/SharePoint) to `web_url`; not
+            # fetchable like `download_url`.
+            web_url=attachment.content_url,
+            raw=attachment,
+            download_url=download_url,
+        )
+
+    @staticmethod
+    def _coerce_content(content: object) -> Optional[FileDownloadInfo]:
+        """Normalize the attachment's raw `content` (a wire dict or an already-parsed model) to `FileDownloadInfo`."""
+        if isinstance(content, FileDownloadInfo):
+            return content
+        if isinstance(content, dict):
+            return FileDownloadInfo.model_validate(content)
+        return None

--- a/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
@@ -1,0 +1,146 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Optional
+
+import httpx
+from microsoft_teams.api import ConversationType
+
+from .download import FileFetchTarget, OpenedFileStream, collect_stream, open_file_stream
+from .downloaded_file import DownloadedFile
+from .types import FileSource
+
+
+class IncomingFile:
+    """
+    A lazy handle to a file attached to the current inbound activity.
+
+    Nothing is downloaded until a byte method is called. The handle stays live and holds no memoized bytes, so each of
+    `stream()`/`download()`/`text()`/`save_as()` fetches afresh. For a personal file that re-fetch is bounded by the
+    short-lived download URL lifetime and may hit its expiry; to read the same file several ways, call `download()`
+    once and reuse the returned `DownloadedFile`.
+    """
+
+    unique_id: Optional[str]
+    """
+    The OneDrive/ODSP drive-item id when the platform reports it (`content.uniqueId`); the storage-specific locator a
+    Graph fetch keys off. Present only when the wire provided it.
+    """
+
+    name: str
+    """Display name including extension when known."""
+
+    content_type: Optional[str]
+    """MIME type when known."""
+
+    extension: Optional[str]
+    """
+    File extension without the dot (e.g. `pdf`), taken from the platform-supplied `file_type`. Absent when the wire
+    omits it.
+    """
+
+    scope: ConversationType
+    """Conversation scope the file arrived in (the SDK's `ConversationType`)."""
+
+    source: FileSource
+    """Where the SDK found the file. Only `botActivity` is produced today."""
+
+    web_url: Optional[str]
+    """Web URL to the file in OneDrive/SharePoint when known."""
+
+    raw: Any
+    """The raw underlying attachment/graph object for escape-hatch access."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        scope: ConversationType,
+        source: FileSource,
+        unique_id: Optional[str] = None,
+        content_type: Optional[str] = None,
+        extension: Optional[str] = None,
+        web_url: Optional[str] = None,
+        raw: Any = None,
+        download_url: Optional[str] = None,
+        client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self.name = name
+        self.scope = scope
+        self.source = source
+        self.unique_id = unique_id
+        self.content_type = content_type
+        self.extension = extension
+        self.web_url = web_url
+        self.raw = raw
+        self._download_url = download_url
+        self._client = client
+        self._prior_fetch_succeeded = False
+
+    async def stream(self) -> AsyncIterator[bytes]:
+        """
+        Stream the bytes. Low-level primitive: yields the response body chunks directly from the fetch,
+        single-consumption, not buffered or retained. Use for large files and pipelines (parse-as-you-go, pipe to
+        disk). `download()` is built on this. Uncapped: the consumer bounds it by how much it reads.
+        """
+        async with self._open() as opened:
+            async for chunk in opened.chunks:
+                yield chunk
+
+    async def download(self) -> DownloadedFile:
+        """
+        Fetch the whole file and buffer it into a `DownloadedFile` snapshot you own. Lazy and not memoized: calling
+        again re-fetches. If you already hold a `DownloadedFile`, call its `save_as()` rather than this handle's, which
+        would re-fetch.
+        """
+        async with self._open() as opened:
+            data = await collect_stream(opened.chunks)
+            return DownloadedFile(
+                bytes=data,
+                content_type=opened.content_type,
+                filename=self.name,
+                source_url=opened.source_url,
+            )
+
+    async def text(self, encoding: str = "utf-8") -> str:
+        """
+        Convenience: run `download()` then decode the bytes as UTF-8 (or a provided encoding). Re-fetches on each call
+        (no memoized bytes); to read bytes several ways hold one `DownloadedFile` instead. No content-type check;
+        decoding is lossy (invalid bytes become U+FFFD and never throw). For strict or binary-safe reads, use
+        `download().bytes`.
+        """
+        downloaded = await self.download()
+        return downloaded.text(encoding)
+
+    async def save_as(self, path: str) -> None:
+        """
+        Stream the bytes straight to a local file path, so saving a large file never materializes it in memory.
+        """
+        async with self._open() as opened:
+            file = await asyncio.to_thread(open, path, "wb")
+            try:
+                async for chunk in opened.chunks:
+                    await asyncio.to_thread(file.write, chunk)
+            finally:
+                await asyncio.to_thread(file.close)
+
+    @asynccontextmanager
+    async def _open(self) -> AsyncIterator[OpenedFileStream]:
+        async with open_file_stream(
+            self._target(),
+            prior_fetch_succeeded=self._prior_fetch_succeeded,
+            client=self._client,
+        ) as opened:
+            self._prior_fetch_succeeded = True
+            yield opened
+
+    def _target(self) -> FileFetchTarget:
+        return FileFetchTarget(
+            scope=self.scope,
+            download_url=self._download_url,
+            content_type=self.content_type,
+        )

--- a/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
@@ -35,7 +35,11 @@ class IncomingFile:
     """Display name including extension when known."""
 
     content_type: Optional[str]
-    """MIME type when known."""
+    """
+    The file's MIME type, when Teams provides it with the file. Files received today do not include one, so this is
+    usually `None`; the type resolved from the download response is on the returned `DownloadedFile`, not written back
+    here.
+    """
 
     extension: Optional[str]
     """

--- a/packages/apps/src/microsoft_teams/apps/files/types.py
+++ b/packages/apps/src/microsoft_teams/apps/files/types.py
@@ -1,0 +1,13 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Literal
+
+FileSource = Literal["botActivity", "graph"]
+"""
+Where the SDK found an inbound file.
+- `botActivity` files come straight from the inbound activity's attachments;
+- `graph` files are hydrated through Microsoft Graph.
+"""

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -124,7 +124,7 @@ class ActivityContext(Generic[T]):
         `activity.attachments`, mapped to `IncomingFile`. See `FilesAccessor`.
         """
         if self._files is None:
-            self._files = FilesAccessor(self.activity, self.logger)
+            self._files = FilesAccessor(self.activity)
         return self._files
 
     @property

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -41,6 +41,7 @@ from microsoft_teams.common.experimental import ExperimentalWarning
 from microsoft_teams.common.http.client_token import Token
 
 from ..activity_send import send_or_update_activity
+from ..files import FilesAccessor
 from ..http_stream import HttpStream
 from ..plugins.streamer import StreamerProtocol
 from ..utils import create_graph_client
@@ -102,6 +103,7 @@ class ActivityContext(Generic[T]):
         self.cloud = cloud
         self._app_token = app_token
         self._stream: Optional[StreamerProtocol] = None
+        self._files: Optional[FilesAccessor] = None
 
         self._next_handler: Optional[Callable[[], Awaitable[None]]] = None
 
@@ -114,6 +116,16 @@ class ActivityContext(Generic[T]):
         if self._stream is None:
             self._stream = HttpStream(self.api, self.conversation_ref)
         return self._stream
+
+    @property
+    def files(self) -> FilesAccessor:
+        """
+        The uploaded files on the current inbound activity, i.e. the `content_type: file.download.info` subset of
+        `activity.attachments`, mapped to `IncomingFile`. See `FilesAccessor`.
+        """
+        if self._files is None:
+            self._files = FilesAccessor(self.activity, self.logger)
+        return self._files
 
     @property
     def user_graph(self) -> "GraphServiceClient":

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -76,6 +76,20 @@ async def test_skips_a_malformed_file_download_info_missing_download_url() -> No
     assert files == []
 
 
+async def test_skips_a_file_download_info_whose_content_fails_validation() -> None:
+    # `content` is a dict but the wire shape is wrong (downloadUrl is not a string), so
+    # `FileDownloadInfo.model_validate` would raise. The accessor must skip it, not throw.
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="broken.pdf",
+        content={"downloadUrl": {"not": "a string"}},
+    )
+
+    files = await FilesAccessor(_activity_with([attachment]), log).list()
+
+    assert files == []
+
+
 async def test_skips_a_file_download_info_missing_a_name() -> None:
     attachment = Attachment(
         content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -1,0 +1,156 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+# pyright: basic
+
+import logging
+from typing import List, Optional
+
+from microsoft_teams.api import (
+    FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+    Account,
+    Attachment,
+    ConversationAccount,
+    MessageActivity,
+)
+from microsoft_teams.api.activities.typing import TypingActivity
+from microsoft_teams.apps.files import FilesAccessor
+
+log = logging.getLogger("test_files_accessor")
+
+
+def _activity_with(attachments: List[Attachment], conversation_type: Optional[str] = "personal") -> MessageActivity:
+    return MessageActivity(
+        id="activity-id",
+        from_=Account(id="user-id"),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(id="conversation-id", conversation_type=conversation_type),
+        attachments=attachments,
+    )
+
+
+async def test_maps_a_file_download_info_attachment_to_an_incoming_file() -> None:
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        content_url="https://contoso.sharepoint.com/report.pdf",
+        name="report.pdf",
+        content={
+            "downloadUrl": "https://download.example/report.pdf?tempauth=abc",
+            "uniqueId": "odsp-unique-id",
+            "fileType": "pdf",
+        },
+    )
+
+    files = await FilesAccessor(_activity_with([attachment]), log).list()
+
+    assert len(files) == 1
+    file = files[0]
+    assert file.unique_id == "odsp-unique-id"
+    assert file.name == "report.pdf"
+    assert file.extension == "pdf"
+    assert file.scope == "personal"
+    assert file.source == "botActivity"
+    assert file.web_url == "https://contoso.sharepoint.com/report.pdf"
+    assert file.raw is attachment
+
+
+async def test_ignores_attachments_that_are_not_uploaded_files() -> None:
+    card = Attachment(content_type="application/vnd.microsoft.card.adaptive", content={})
+
+    files = await FilesAccessor(_activity_with([card]), log).list()
+
+    assert files == []
+
+
+async def test_skips_a_malformed_file_download_info_missing_download_url() -> None:
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="broken.pdf",
+        content={"uniqueId": "no-url"},
+    )
+
+    files = await FilesAccessor(_activity_with([attachment]), log).list()
+
+    assert files == []
+
+
+async def test_skips_a_file_download_info_missing_a_name() -> None:
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        content={"downloadUrl": "https://download.example/anon"},
+    )
+
+    files = await FilesAccessor(_activity_with([attachment]), log).list()
+
+    assert files == []
+
+
+async def test_maps_a_file_that_has_no_unique_id() -> None:
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="anon.pdf",
+        content={"downloadUrl": "https://download.example/anon.pdf"},
+    )
+
+    files = await FilesAccessor(_activity_with([attachment]), log).list()
+
+    file = files[0]
+    assert file.name == "anon.pdf"
+    assert file.unique_id is None
+
+
+async def test_defaults_the_scope_to_personal_when_conversation_type_is_absent() -> None:
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="a.pdf",
+        content={"downloadUrl": "https://download.example/a.pdf", "uniqueId": "a"},
+    )
+
+    files = await FilesAccessor(_activity_with([attachment], conversation_type=None), log).list()
+
+    assert files[0].scope == "personal"
+
+
+async def test_returns_empty_list_when_the_activity_has_no_attachments() -> None:
+    files = await FilesAccessor(_activity_with([]), log).list()
+
+    assert files == []
+
+
+async def test_returns_empty_list_when_the_attachments_field_is_absent() -> None:
+    activity = MessageActivity(
+        id="activity-id",
+        from_=Account(id="user-id"),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(id="conversation-id", conversation_type="personal"),
+    )
+
+    files = await FilesAccessor(activity, log).list()
+
+    assert files == []
+
+
+async def test_returns_empty_list_for_non_message_activities() -> None:
+    typing = TypingActivity(
+        id="activity-id",
+        from_=Account(id="user-id"),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(id="conversation-id", conversation_type="personal"),
+    )
+
+    files = await FilesAccessor(typing, log).list()
+
+    assert files == []
+
+
+async def test_first_returns_the_first_mapped_file_or_none() -> None:
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="a.pdf",
+        content={"downloadUrl": "https://download.example/a.pdf", "uniqueId": "a"},
+    )
+
+    assert await FilesAccessor(_activity_with([attachment]), log).first() is not None
+    assert await FilesAccessor(_activity_with([]), log).first() is None

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -5,7 +5,6 @@ Licensed under the MIT License.
 
 # pyright: basic
 
-import logging
 from typing import List, Optional
 
 from microsoft_teams.api import (
@@ -17,8 +16,6 @@ from microsoft_teams.api import (
 )
 from microsoft_teams.api.activities.typing import TypingActivity
 from microsoft_teams.apps.files import FilesAccessor
-
-log = logging.getLogger("test_files_accessor")
 
 
 def _activity_with(attachments: List[Attachment], conversation_type: Optional[str] = "personal") -> MessageActivity:
@@ -43,7 +40,7 @@ async def test_maps_a_file_download_info_attachment_to_an_incoming_file() -> Non
         },
     )
 
-    files = await FilesAccessor(_activity_with([attachment]), log).list()
+    files = await FilesAccessor(_activity_with([attachment])).list()
 
     assert len(files) == 1
     file = files[0]
@@ -59,7 +56,7 @@ async def test_maps_a_file_download_info_attachment_to_an_incoming_file() -> Non
 async def test_ignores_attachments_that_are_not_uploaded_files() -> None:
     card = Attachment(content_type="application/vnd.microsoft.card.adaptive", content={})
 
-    files = await FilesAccessor(_activity_with([card]), log).list()
+    files = await FilesAccessor(_activity_with([card])).list()
 
     assert files == []
 
@@ -71,7 +68,7 @@ async def test_skips_a_malformed_file_download_info_missing_download_url() -> No
         content={"uniqueId": "no-url"},
     )
 
-    files = await FilesAccessor(_activity_with([attachment]), log).list()
+    files = await FilesAccessor(_activity_with([attachment])).list()
 
     assert files == []
 
@@ -85,7 +82,7 @@ async def test_skips_a_file_download_info_whose_content_fails_validation() -> No
         content={"downloadUrl": {"not": "a string"}},
     )
 
-    files = await FilesAccessor(_activity_with([attachment]), log).list()
+    files = await FilesAccessor(_activity_with([attachment])).list()
 
     assert files == []
 
@@ -96,7 +93,7 @@ async def test_skips_a_file_download_info_missing_a_name() -> None:
         content={"downloadUrl": "https://download.example/anon"},
     )
 
-    files = await FilesAccessor(_activity_with([attachment]), log).list()
+    files = await FilesAccessor(_activity_with([attachment])).list()
 
     assert files == []
 
@@ -108,7 +105,7 @@ async def test_maps_a_file_that_has_no_unique_id() -> None:
         content={"downloadUrl": "https://download.example/anon.pdf"},
     )
 
-    files = await FilesAccessor(_activity_with([attachment]), log).list()
+    files = await FilesAccessor(_activity_with([attachment])).list()
 
     file = files[0]
     assert file.name == "anon.pdf"
@@ -122,13 +119,13 @@ async def test_defaults_the_scope_to_personal_when_conversation_type_is_absent()
         content={"downloadUrl": "https://download.example/a.pdf", "uniqueId": "a"},
     )
 
-    files = await FilesAccessor(_activity_with([attachment], conversation_type=None), log).list()
+    files = await FilesAccessor(_activity_with([attachment], conversation_type=None)).list()
 
     assert files[0].scope == "personal"
 
 
 async def test_returns_empty_list_when_the_activity_has_no_attachments() -> None:
-    files = await FilesAccessor(_activity_with([]), log).list()
+    files = await FilesAccessor(_activity_with([])).list()
 
     assert files == []
 
@@ -141,7 +138,7 @@ async def test_returns_empty_list_when_the_attachments_field_is_absent() -> None
         conversation=ConversationAccount(id="conversation-id", conversation_type="personal"),
     )
 
-    files = await FilesAccessor(activity, log).list()
+    files = await FilesAccessor(activity).list()
 
     assert files == []
 
@@ -154,7 +151,7 @@ async def test_returns_empty_list_for_non_message_activities() -> None:
         conversation=ConversationAccount(id="conversation-id", conversation_type="personal"),
     )
 
-    files = await FilesAccessor(typing, log).list()
+    files = await FilesAccessor(typing).list()
 
     assert files == []
 
@@ -166,5 +163,5 @@ async def test_first_returns_the_first_mapped_file_or_none() -> None:
         content={"downloadUrl": "https://download.example/a.pdf", "uniqueId": "a"},
     )
 
-    assert await FilesAccessor(_activity_with([attachment]), log).first() is not None
-    assert await FilesAccessor(_activity_with([]), log).first() is None
+    assert await FilesAccessor(_activity_with([attachment])).first() is not None
+    assert await FilesAccessor(_activity_with([])).first() is None

--- a/packages/apps/tests/test_incoming_file.py
+++ b/packages/apps/tests/test_incoming_file.py
@@ -1,0 +1,143 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+# pyright: basic
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+
+import httpx
+import pytest
+from microsoft_teams.apps.files import IncomingFile
+from microsoft_teams.apps.files.errors import FileScopeNotSupportedError, FileUrlExpiredError
+
+DOWNLOAD_URL = "https://download.example/notes.txt?tempauth=abc"
+
+
+def _json_body(text: str, headers: Optional[Dict[str, str]] = None) -> httpx.Response:
+    return httpx.Response(200, content=text.encode(), headers=headers or {})
+
+
+def _sequence_client(responses: List[httpx.Response]) -> Tuple[httpx.AsyncClient, List[str]]:
+    """A client whose transport hands back the given responses in call order, recording the urls it saw."""
+    calls: List[str] = []
+    state = {"i": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        index = min(state["i"], len(responses) - 1)
+        state["i"] += 1
+        return responses[index]
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler)), calls
+
+
+@asynccontextmanager
+async def _personal_file(responses: List[httpx.Response], **init: Any) -> AsyncIterator[Tuple[IncomingFile, List[str]]]:
+    client, calls = _sequence_client(responses)
+    params: Dict[str, Any] = {
+        "name": "notes.txt",
+        "scope": "personal",
+        "source": "botActivity",
+        "download_url": DOWNLOAD_URL,
+    }
+    params.update(init)
+    try:
+        yield IncomingFile(client=client, **params), calls
+    finally:
+        await client.aclose()
+
+
+class TestDownload:
+    async def test_fetches_the_download_url_and_buffers_the_bytes(self) -> None:
+        async with _personal_file([_json_body("hello world", {"content-type": "text/plain"})]) as (file, calls):
+            downloaded = await file.download()
+
+            assert calls == [DOWNLOAD_URL]
+            assert downloaded.text() == "hello world"
+            assert downloaded.content_type == "text/plain"
+            assert downloaded.filename == "notes.txt"
+            assert downloaded.source_url == DOWNLOAD_URL
+
+    async def test_re_fetches_on_each_call(self) -> None:
+        async with _personal_file([_json_body("a"), _json_body("b")]) as (file, calls):
+            assert (await file.download()).text() == "a"
+            assert (await file.download()).text() == "b"
+            assert len(calls) == 2
+
+    async def test_falls_back_to_incoming_content_type_when_response_omits_one(self) -> None:
+        async with _personal_file([_json_body("bytes")], content_type="application/pdf") as (file, _):
+            assert (await file.download()).content_type == "application/pdf"
+
+
+class TestTextReader:
+    async def test_decodes_the_downloaded_bytes(self) -> None:
+        async with _personal_file([_json_body("hello")]) as (file, _):
+            assert await file.text() == "hello"
+
+
+class TestExpiredDownloadUrl:
+    async def test_raises_first_fetch_when_the_first_fetch_is_unauthorized(self) -> None:
+        async with _personal_file([httpx.Response(401)]) as (file, _):
+            with pytest.raises(FileUrlExpiredError) as error:
+                await file.download()
+            assert error.value.reason == "first_fetch"
+
+    async def test_treats_403_the_same_as_401(self) -> None:
+        async with _personal_file([httpx.Response(403)]) as (file, _):
+            with pytest.raises(FileUrlExpiredError):
+                await file.download()
+
+    async def test_raises_reread_when_a_later_fetch_lapses_after_success(self) -> None:
+        async with _personal_file([_json_body("first read ok"), httpx.Response(401)]) as (file, _):
+            assert (await file.download()).text() == "first read ok"
+            with pytest.raises(FileUrlExpiredError) as error:
+                await file.download()
+            assert error.value.reason == "reread"
+
+
+class TestStream:
+    async def test_yields_the_raw_uncapped_body_chunks(self) -> None:
+        async with _personal_file([_json_body("streamed")]) as (file, _):
+            chunks = [chunk async for chunk in file.stream()]
+            assert b"".join(chunks).decode() == "streamed"
+
+
+class TestUnsupportedScope:
+    async def test_raises_for_group_chat_files(self) -> None:
+        async with _personal_file([_json_body("unused")], scope="groupChat") as (file, _):
+            with pytest.raises(FileScopeNotSupportedError) as error:
+                await file.download()
+            assert error.value.scope == "groupChat"
+
+
+class TestDownloadFailures:
+    async def test_raises_when_a_personal_file_has_no_download_url(self) -> None:
+        async with _personal_file([_json_body("unused")], download_url=None) as (file, calls):
+            with pytest.raises(RuntimeError, match="no download URL"):
+                await file.download()
+            assert len(calls) == 0
+
+    async def test_raises_on_a_non_auth_error_response(self) -> None:
+        async with _personal_file([httpx.Response(500)]) as (file, _):
+            with pytest.raises(RuntimeError, match="failed to download file: 500"):
+                await file.download()
+
+
+class TestSaveAs:
+    async def test_streams_the_bytes_straight_to_a_local_file(self, tmp_path: Path) -> None:
+        async with _personal_file([_json_body("saved contents")]) as (file, _):
+            path = tmp_path / "out.txt"
+            await file.save_as(str(path))
+            assert path.read_text() == "saved contents"
+
+    async def test_writes_a_buffered_snapshot_without_re_fetching(self, tmp_path: Path) -> None:
+        async with _personal_file([_json_body("snapshot bytes")]) as (file, calls):
+            downloaded = await file.download()
+            path = tmp_path / "snapshot.txt"
+            await downloaded.save_as(str(path))
+            assert path.read_text() == "snapshot bytes"
+            assert len(calls) == 1

--- a/packages/apps/tests/test_incoming_file.py
+++ b/packages/apps/tests/test_incoming_file.py
@@ -121,6 +121,12 @@ class TestDownloadFailures:
                 await file.download()
             assert len(calls) == 0
 
+    async def test_raises_when_a_personal_file_download_url_is_not_https(self) -> None:
+        async with _personal_file([_json_body("unused")], download_url="http://dl.example/x") as (file, calls):
+            with pytest.raises(RuntimeError, match="must use https"):
+                await file.download()
+            assert len(calls) == 0
+
     async def test_raises_on_a_non_auth_error_response(self) -> None:
         async with _personal_file([httpx.Response(500)]) as (file, _):
             with pytest.raises(RuntimeError, match="failed to download file: 500"):


### PR DESCRIPTION
Adds API for receiving files to the app in personal scope. A user uploads a file, which arrives on the activity, and `ctx.files.list()` provides metadata of the file(s) and lazy handlers to download it. The url is `tempauth` and will expire.

- **`ctx.files`**: `list()` / `first()` map inbound `file.download.info` attachments to `IncomingFile`. Never throws: non-message activities and empty/malformed attachments yield an empty list; bad entries are skipped.
- **`IncomingFile`**: file metadata with lazy `download()`, `stream()`, `text(encoding=...)`, `save_as(path)`. Each read re-fetches (bounded by the short-lived URL).
- **`DownloadedFile`**: buffered snapshot you own (`bytes`, `content_type`, `filename`, `source_url`), with synchronous `text()`/`save_as()`.
- **Errors**: Differentiates between first fetch error (url expired before first fetch), reread error (url expired after first fetch), and scope not supported error (today, only 1:1).
- **Types**: new `FileDownloadInfo` model + `file.download.info` content-type constant; `ConversationType` extended with `channel` (forward-compatible).

## Testing

- Unit tests: `test_files_accessor.py`, `test_incoming_file.py`
- Manual e2e

## Note

- After investigating thumbnail url behavior, I adjusted `Attachments.thumbnail_url` docstrings to indicate it will not be populated on incoming files.
- Similarly for `etag`, this field may be set by Graph, which is not in scope for this PR.