### PR TITLE
feat: expose per-turn state (`ctx.state`, `App(state=...)`) and wire into dispatch

### DIFF
--- a/examples/state/README.md
+++ b/examples/state/README.md
@@ -1,0 +1,15 @@
+# State
+
+Demonstrates the per-turn state layer: enabling it with `App(state=True)` and
+reading/writing the `conversation` and `user` scopes through `ctx.state`.
+
+State is loaded before each turn, saved automatically after it, and then sealed
+(post-turn access raises `TurnStateSealedError`). With no storage configured the
+app uses in-memory `LocalStorage`; pass `App(state=StateOptions(storage=...))`
+for a durable backing store.
+
+## Run
+
+```bash
+uv run --directory examples/state src/main.py
+```

--- a/examples/state/pyproject.toml
+++ b/examples/state/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "state"
+version = "0.1.0"
+description = "Per-turn state app"
+readme = "README.md"
+requires-python = ">=3.11,<4.0"
+dependencies = [
+    "dotenv>=0.9.9",
+    "microsoft-teams-apps",
+    "microsoft-teams-api",
+]
+
+[tool.uv.sources]
+microsoft-teams-apps = { workspace = true }

--- a/examples/state/src/main.py
+++ b/examples/state/src/main.py
@@ -34,7 +34,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
     count = ctx.state.conversation.get("message_count", 0) + 1
     ctx.state.conversation["message_count"] = count
 
-    # User scope: per-sender. `user` is None only when the activity has no sender.
+    # User scope: per-sender. `user` is None when the activity has no usable, non-empty sender ID.
     greeting = ""
     if ctx.state.user is not None:
         if "name" not in ctx.state.user:

--- a/examples/state/src/main.py
+++ b/examples/state/src/main.py
@@ -1,0 +1,50 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+import logging
+
+from microsoft_teams.api import MessageActivity
+from microsoft_teams.apps import ActivityContext, App
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# `state=True` enables the per-turn state layer using the app's storage.
+#
+# With no other storage configured the app falls back to in-memory
+# `LocalStorage`, so state is scoped to a single process and lost on restart —
+# the SDK logs a warning to that effect. For production, pass a durable store
+# via `App(state=StateOptions(storage=...))`
+#
+# State is loaded before each turn and saved automatically after it, then
+# sealed — reading or writing `ctx.state` after the handler returns raises
+# `TurnStateSealedError`.
+app = App(state=True)
+
+
+@app.on_message
+async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
+    """Track a per-conversation message count and a per-user first-seen name."""
+    assert ctx.state is not None
+
+    # Conversation scope: shared by everyone in the chat/channel.
+    count = ctx.state.conversation.get("message_count", 0) + 1
+    ctx.state.conversation["message_count"] = count
+
+    # User scope: per-sender. `user` is None only when the activity has no sender.
+    greeting = ""
+    if ctx.state.user is not None:
+        if "name" not in ctx.state.user:
+            ctx.state.user["name"] = ctx.activity.from_.name
+            greeting = f"Nice to meet you, {ctx.activity.from_.name}! "
+        else:
+            greeting = f"Welcome back, {ctx.state.user['name']}! "
+
+    await ctx.send(f"{greeting}This conversation has seen {count} message(s).")
+
+
+if __name__ == "__main__":
+    asyncio.run(app.start())

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -17,7 +17,7 @@ from .http_stream import HttpStream
 from .options import AppOptions, AppTelemetryOptions
 from .plugins import *  # noqa: F401, F403
 from .routing import ActivityContext
-from .state import StateOptions, TurnState, TurnStateContainer, TurnStateSealedError
+from .state import StateOptions, TurnState, TurnStateContainer, TurnStateSealedError, create_state_loader
 from .token_provider import AppTokenProvider
 from .utils.html_widget import (
     DisplayMode,
@@ -50,6 +50,7 @@ __all__: list[str] = [
     "TurnState",
     "TurnStateContainer",
     "TurnStateSealedError",
+    "create_state_loader",
     "to_threaded_conversation_id",
     "build_html_widget_markdown",
     "build_html_widget_message",

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -17,6 +17,7 @@ from .http_stream import HttpStream
 from .options import AppOptions, AppTelemetryOptions
 from .plugins import *  # noqa: F401, F403
 from .routing import ActivityContext
+from .state import StateOptions, TurnState, TurnStateContainer, TurnStateSealedError
 from .token_provider import AppTokenProvider
 from .utils.html_widget import (
     DisplayMode,
@@ -45,6 +46,10 @@ __all__: list[str] = [
     "HttpStream",
     "ActivityContext",
     "AppTokenProvider",
+    "StateOptions",
+    "TurnState",
+    "TurnStateContainer",
+    "TurnStateSealedError",
     "to_threaded_conversation_id",
     "build_html_widget_markdown",
     "build_html_widget_message",

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -60,6 +60,7 @@ from .options import AppOptions, InternalAppOptions
 from .plugins import PluginBase, PluginStartEvent
 from .routing import ActivityHandlerMixin, ActivityRouter
 from .routing.activity_context import ActivityContext
+from .state import create_state_loader
 from .token_manager import DEFAULT_TENANT_FOR_GRAPH_TOKEN, TokenManager
 from .token_provider import AppTokenProvider
 from .utils import create_graph_client
@@ -91,6 +92,8 @@ class App(ActivityHandlerMixin):
         self.cloud = self.options.cloud or (cloud_from_name(cloud_env_name) if cloud_env_name else PUBLIC)
 
         self.storage = self.options.storage or LocalStorage()
+
+        self._state_loader = create_state_loader(self.options.state, self.storage)
 
         self.http_client = self._init_http_client()
 
@@ -143,6 +146,7 @@ class App(ActivityHandlerMixin):
             self.cloud,
             fetch_user_token=self.options.fetch_user_token,
             agent365_baggage_options=self.options.telemetry.get("agent365") if self.options.telemetry else None,
+            state_loader=self._state_loader,
         )
         self.event_manager = EventManager(self._events)
         self.activity_processor.event_manager = self.event_manager

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -4,7 +4,6 @@ Licensed under the MIT License.
 """
 
 import logging
-import sys
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, TypeGuard, Union, cast
 
@@ -291,6 +290,7 @@ class ActivityProcessor:
         if not self.event_manager:
             raise ValueError("EventManager was not initialized properly")
 
+        processing_completed = False
         try:
             await self._load_turn_state(activityCtx, activity)
 
@@ -303,15 +303,16 @@ class ActivityProcessor:
                 response = cast(InvokeResponse[Any], middleware_result)
             else:
                 response = InvokeResponse[Any](status=200, body=middleware_result)
+            processing_completed = True
         except StreamCancelledError:
             logger.debug("Activity processing was cancelled (stream stopped)")
             await activityCtx.stream.close()
             response = InvokeResponse[Any](status=200)
+            processing_completed = True
         except Exception as error:
             await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
             raise
         finally:
-            error_in_flight = sys.exc_info()[1] is not None
             try:
                 await self._persist_turn_state(activityCtx)
             except Exception as error:
@@ -319,7 +320,7 @@ class ActivityProcessor:
                     await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
                 except Exception:
                     logger.exception("Error handler failed while reporting state persistence failure")
-                if not error_in_flight:
+                if processing_completed:
                     raise
 
         try:
@@ -352,7 +353,7 @@ class ActivityProcessor:
         """
         if self.state_loader is None:
             return
-        ctx.state = await self.state_loader.load(activity.conversation.id, activity.from_.id)
+        ctx.state = await self.state_loader.load(activity.conversation.id, activity.from_.id or None)
 
     async def _persist_turn_state(self, ctx: ActivityContext[ActivityBase]) -> None:
         """Save dirty scopes and seal state at the end of the turn.

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -332,7 +332,9 @@ class ActivityProcessor:
                 plugins=plugins,
             )
         except StreamCancelledError:
-            logger.debug("Activity response processing was cancelled")
+            logger.debug("Activity processing was cancelled (stream stopped)")
+            await activityCtx.stream.close()
+            response = InvokeResponse[Any](status=200)
         except Exception as error:
             await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
             raise

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -46,6 +46,7 @@ from .events import ActivityEvent, ActivityResponseEvent, ActivitySentEvent, Err
 from .plugins import PluginActivityEvent, PluginBase, StreamCancelledError
 from .routing.activity_context import ActivityContext
 from .routing.router import ActivityHandler, ActivityRouter
+from .state import TurnStateLoader
 from .token_provider import AppTokenProvider
 from .utils import extract_tenant_id
 
@@ -74,6 +75,7 @@ class ActivityProcessor:
         cloud: CloudEnvironment = PUBLIC,
         fetch_user_token: bool = True,
         agent365_baggage_options: Agent365BaggageOptions | bool | None = None,
+        state_loader: Optional[TurnStateLoader] = None,
     ) -> None:
         self.router = router
         self.id = id
@@ -86,6 +88,7 @@ class ActivityProcessor:
         self.cloud = cloud
         self.fetch_user_token = fetch_user_token
         self.agent365_baggage_options = agent365_baggage_options
+        self.state_loader = state_loader
 
         # This will be set after the EventManager is initialized due to
         # a circular dependency
@@ -287,6 +290,8 @@ class ActivityProcessor:
         if not self.event_manager:
             raise ValueError("EventManager was not initialized properly")
 
+        await self._load_turn_state(activityCtx, activity)
+
         try:
             # If no registered handlers, middleware_result is set to None
             middleware_result = await self.execute_middleware_chain(activityCtx, handlers)
@@ -313,10 +318,36 @@ class ActivityProcessor:
         except Exception as error:
             await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
             raise error
+        finally:
+            await self._persist_turn_state(activityCtx)
 
         logger.debug("Completed processing activity")
 
         return response
+
+    async def _load_turn_state(self, ctx: ActivityContext[ActivityBase], activity: ValidatedActivity) -> None:
+        """Load per-turn state onto ``ctx.state`` when state is enabled.
+
+        Loads both the conversation scope and the user scope (keyed by the
+        activity's ``from`` identity). A no-op when state is disabled, leaving
+        ``ctx.state`` as ``None``.
+        """
+        if self.state_loader is None:
+            return
+        ctx.state = await self.state_loader.load(activity.conversation.id, activity.from_.id)
+
+    async def _persist_turn_state(self, ctx: ActivityContext[ActivityBase]) -> None:
+        """Save dirty scopes and seal state at the end of the turn.
+
+        Runs in a ``finally`` so dirty state is persisted even when the handler
+        raised. Sealing makes any post-turn access raise, guarding against use of
+        per-turn state in background work.
+        """
+        container = ctx.state
+        if self.state_loader is None or container is None:
+            return
+        await self.state_loader.save(container)
+        container.seal()
 
     def _activity_attributes(self, activity: ActivityBase) -> dict[str, str]:
         attributes = {

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 
 import logging
+import sys
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional, TypeGuard, Union, cast
 
@@ -302,7 +303,26 @@ class ActivityProcessor:
                 response = cast(InvokeResponse[Any], middleware_result)
             else:
                 response = InvokeResponse[Any](status=200, body=middleware_result)
+        except StreamCancelledError:
+            logger.debug("Activity processing was cancelled (stream stopped)")
+            await activityCtx.stream.close()
+            response = InvokeResponse[Any](status=200)
+        except Exception as error:
+            await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
+            raise
+        finally:
+            error_in_flight = sys.exc_info()[1] is not None
+            try:
+                await self._persist_turn_state(activityCtx)
+            except Exception as error:
+                try:
+                    await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
+                except Exception:
+                    logger.exception("Error handler failed while reporting state persistence failure")
+                if not error_in_flight:
+                    raise
 
+        try:
             await self.event_manager.on_activity_response(
                 ActivityResponseEvent(
                     activity=activity,
@@ -312,14 +332,10 @@ class ActivityProcessor:
                 plugins=plugins,
             )
         except StreamCancelledError:
-            logger.debug("Activity processing was cancelled (stream stopped)")
-            await activityCtx.stream.close()
-            response = InvokeResponse[Any](status=200)
+            logger.debug("Activity response processing was cancelled")
         except Exception as error:
             await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
             raise
-        finally:
-            await self._persist_turn_state(activityCtx)
 
         logger.debug("Completed processing activity")
 

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -290,9 +290,9 @@ class ActivityProcessor:
         if not self.event_manager:
             raise ValueError("EventManager was not initialized properly")
 
-        await self._load_turn_state(activityCtx, activity)
-
         try:
+            await self._load_turn_state(activityCtx, activity)
+
             # If no registered handlers, middleware_result is set to None
             middleware_result = await self.execute_middleware_chain(activityCtx, handlers)
 
@@ -317,7 +317,7 @@ class ActivityProcessor:
             response = InvokeResponse[Any](status=200)
         except Exception as error:
             await self.event_manager.on_error(ErrorEvent(error=error, activity=activity), plugins)
-            raise error
+            raise
         finally:
             await self._persist_turn_state(activityCtx)
 
@@ -346,8 +346,10 @@ class ActivityProcessor:
         container = ctx.state
         if self.state_loader is None or container is None:
             return
-        await self.state_loader.save(container)
-        container.seal()
+        try:
+            await self.state_loader.save(container)
+        finally:
+            container.seal()
 
     def _activity_attributes(self, activity: ActivityBase) -> dict[str, str]:
         attributes = {

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -94,7 +94,7 @@ class AppOptions(TypedDict, total=False):
 
     ``state=True`` enables state on the app's shared ``storage`` (in-memory by
     default). Pass a ``StateOptions`` to configure the
-    key prefix, TTL, or a dedicated ``Storage`` backend. When enabled, handlers
+    key prefix or a dedicated ``Storage`` backend. When enabled, handlers
     read/write ``ctx.state.conversation`` and ``ctx.state.user``; when off,
     ``ctx.state`` is ``None``."""
     dangerously_allow_unauthenticated_requests: Optional[bool]
@@ -194,7 +194,7 @@ class InternalAppOptions:
     storage: Optional[Storage[str, Any]] = None
     state: Optional[Union[bool, StateOptions]] = None
     """Per-turn state opt-in. ``None``/``False`` disables it; ``True`` enables it on
-    the app's shared storage; a ``StateOptions`` configures prefix/TTL/backend."""
+    the app's shared storage; a ``StateOptions`` configures the key prefix or backend."""
     service_url: Optional[str] = None
     """
     Base Service URL for BotBackend.

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -19,6 +19,7 @@ from typing_extensions import Unpack
 from .diagnostics import Agent365BaggageOptions
 from .http.adapter import HttpServerAdapter
 from .plugins import PluginBase
+from .state import StateOptions
 
 DANGEROUSLY_ALLOW_UNAUTHENTICATED_REQUESTS_ENV_VAR = "DANGEROUSLY_ALLOW_UNAUTHENTICATED_REQUESTS"
 _TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
@@ -88,6 +89,14 @@ class AppOptions(TypedDict, total=False):
     # Infrastructure
     storage: Optional[Storage[str, Any]]
     plugins: Optional[List[PluginBase]]
+    state: Optional[Union[bool, StateOptions]]
+    """Per-turn state opt-in. Off by default (``None``/``False``).
+
+    ``state=True`` enables state on the app's shared ``storage`` (in-memory by
+    default). Pass a ``StateOptions`` to configure the
+    key prefix, TTL, or a dedicated ``Storage`` backend. When enabled, handlers
+    read/write ``ctx.state.conversation`` and ``ctx.state.user``; when off,
+    ``ctx.state`` is ``None``."""
     dangerously_allow_unauthenticated_requests: Optional[bool]
     """
     Whether to accept incoming requests without JWT validation.
@@ -183,6 +192,9 @@ class InternalAppOptions:
     If not set or equals client_id, uses direct managed identity (no federation).
     """
     storage: Optional[Storage[str, Any]] = None
+    state: Optional[Union[bool, StateOptions]] = None
+    """Per-turn state opt-in. ``None``/``False`` disables it; ``True`` enables it on
+    the app's shared storage; a ``StateOptions`` configures prefix/TTL/backend."""
     service_url: Optional[str] = None
     """
     Base Service URL for BotBackend.

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -44,6 +44,7 @@ from ..activity_send import send_or_update_activity
 from ..files import FilesAccessor
 from ..http_stream import HttpStream
 from ..plugins.streamer import StreamerProtocol
+from ..state import TurnStateContainer
 from ..utils import create_graph_client
 
 if TYPE_CHECKING:
@@ -101,6 +102,7 @@ class ActivityContext(Generic[T]):
         self.connection_name = connection_name
         self.is_signed_in = is_signed_in
         self.cloud = cloud
+        self.state: Optional[TurnStateContainer] = None
         self._app_token = app_token
         self._stream: Optional[StreamerProtocol] = None
         self._files: Optional[FilesAccessor] = None

--- a/packages/apps/src/microsoft_teams/apps/state/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/state/__init__.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 from .container import TurnStateContainer
-from .loader import TurnStateLoader
+from .loader import TurnStateLoader, create_state_loader
 from .options import StateOptions
 from .turn_state import TurnState, TurnStateSealedError
 
@@ -14,4 +14,5 @@ __all__ = [
     "TurnStateContainer",
     "TurnStateLoader",
     "StateOptions",
+    "create_state_loader",
 ]

--- a/packages/apps/src/microsoft_teams/apps/state/loader.py
+++ b/packages/apps/src/microsoft_teams/apps/state/loader.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional, Union, cast
 from urllib.parse import quote
 
-from microsoft_teams.common import Storage
+from microsoft_teams.common import LocalStorage, Storage
 
 from .container import TurnStateContainer
 from .options import StateOptions
@@ -160,3 +160,28 @@ class TurnStateLoader:
         if not all(isinstance(key, str) for key in mapping):
             return None
         return cast(Dict[str, Any], mapping)
+
+
+def create_state_loader(
+    state: Optional[Union[bool, "StateOptions"]],
+    fallback_storage: Storage[str, Any],
+) -> Optional[TurnStateLoader]:
+    """Resolve the ``App(state=...)`` option into a loader (or ``None`` when off).
+
+    ``state`` is the opt-in value: falsy disables state; ``True`` enables it with
+    defaults; a ``StateOptions`` configures it. The loader's storage is the one on
+    ``StateOptions`` when provided, otherwise the app's shared ``fallback_storage``.
+    A warning is logged when that resolves to in-memory ``LocalStorage``.
+    """
+    if not state:
+        return None
+
+    options = StateOptions() if state is True else state
+    storage: Storage[str, Any] = options.storage if options.storage is not None else fallback_storage
+
+    if isinstance(storage, LocalStorage):
+        logger.warning(
+            "State is enabled with in-memory storage (LocalStorage): per-turn state is lost on "
+            + "restart and is not shared across instances."
+        )
+    return TurnStateLoader(storage=storage, options=options)

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 """
 # pyright: basic
 
+import asyncio
 from contextlib import contextmanager
 from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
@@ -491,6 +492,10 @@ class TestActivityProcessor:
         # Assert
         assert result.status == expected_result.status
         assert result.body == expected_result.body
+        activity_processor.event_manager.on_activity_response.assert_awaited_once()
+        response_event = activity_processor.event_manager.on_activity_response.await_args.args[0]
+        assert response_event.response.status == expected_result.status
+        assert response_event.response.body == expected_result.body
 
     @pytest.mark.asyncio
     async def test_process_activity_invokes_plugin_route_when_plugin_qualifies(self, activity_processor):
@@ -981,6 +986,7 @@ class TestActivityProcessor:
     @pytest.mark.asyncio
     async def test_state_is_sealed_when_save_raises(self, activity_processor):
         """State is sealed even when persistence fails."""
+        save_error = RuntimeError("save failed")
         container = TurnStateContainer(
             conversation=TurnState({"value": "dirty"}),
             conversation_id="conv-789",
@@ -991,7 +997,7 @@ class TestActivityProcessor:
 
         activity_processor.state_loader = MagicMock()
         activity_processor.state_loader.load = AsyncMock(return_value=container)
-        activity_processor.state_loader.save = AsyncMock(side_effect=RuntimeError("save failed"))
+        activity_processor.state_loader.save = AsyncMock(side_effect=save_error)
         self._wire_event_manager(activity_processor)
         activity_processor.router.select_handlers = MagicMock(return_value=[])
 
@@ -1000,3 +1006,92 @@ class TestActivityProcessor:
 
         assert container.conversation.is_sealed is True
         assert container.user is not None and container.user.is_sealed is True
+        error_event = activity_processor.event_manager.on_error.await_args.args[0]
+        assert error_event.error is save_error
+        activity_processor.event_manager.on_activity_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_state_save_failure_does_not_mask_handler_error(self, activity_processor):
+        """A persistence failure is reported without replacing the handler failure."""
+        handler_error = ValueError("handler failed")
+        save_error = RuntimeError("save failed")
+        reporting_error = RuntimeError("error reporter failed")
+        container = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="conv-789",
+        )
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is container
+            ctx.state.conversation["value"] = "changed"
+            raise handler_error
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(return_value=container)
+        activity_processor.state_loader.save = AsyncMock(side_effect=save_error)
+        self._wire_event_manager(activity_processor)
+        activity_processor.event_manager.on_error.side_effect = [None, reporting_error]
+        activity_processor.router.select_handlers = MagicMock(return_value=[handler])
+
+        with pytest.raises(ValueError, match="handler failed") as exc_info:
+            await activity_processor.process_activity([], self._message_event())
+
+        assert exc_info.value is handler_error
+        assert container.conversation.is_sealed is True
+        errors = [call.args[0].error for call in activity_processor.event_manager.on_error.await_args_list]
+        assert errors == [handler_error, save_error]
+        activity_processor.event_manager.on_activity_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_state_save_failure_does_not_mask_task_cancellation(self, activity_processor):
+        """Task cancellation remains authoritative when persistence also fails."""
+        save_error = RuntimeError("save failed")
+        container = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="conv-789",
+        )
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is container
+            ctx.state.conversation["value"] = "changed"
+            raise asyncio.CancelledError()
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(return_value=container)
+        activity_processor.state_loader.save = AsyncMock(side_effect=save_error)
+        self._wire_event_manager(activity_processor)
+        activity_processor.router.select_handlers = MagicMock(return_value=[handler])
+
+        with pytest.raises(asyncio.CancelledError):
+            await activity_processor.process_activity([], self._message_event())
+
+        assert container.conversation.is_sealed is True
+        error_event = activity_processor.event_manager.on_error.await_args.args[0]
+        assert error_event.error is save_error
+        activity_processor.event_manager.on_activity_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_activity_response_failure_occurs_after_state_is_persisted(self, activity_processor):
+        """Response-event failures are reported after state has been safely persisted."""
+        response_error = RuntimeError("response event failed")
+        storage: LocalStorage[str] = LocalStorage()
+        activity_processor.state_loader = TurnStateLoader(storage)
+        self._wire_event_manager(activity_processor)
+        activity_processor.event_manager.on_activity_response.side_effect = response_error
+        holder: dict[str, TurnStateContainer] = {}
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is not None
+            holder["state"] = ctx.state
+            ctx.state.conversation["value"] = "saved"
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[handler])
+
+        with pytest.raises(RuntimeError, match="response event failed"):
+            await activity_processor.process_activity([], self._message_event())
+
+        assert holder["state"].conversation.is_sealed is True
+        reloaded = await TurnStateLoader(storage).load("conv-789", "user-123")
+        assert reloaded.conversation["value"] == "saved"
+        error_event = activity_processor.event_manager.on_error.await_args.args[0]
+        assert error_event.error is response_error

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -22,6 +22,7 @@ from microsoft_teams.apps.app_events import EventManager
 from microsoft_teams.apps.app_process import ActivityProcessor
 from microsoft_teams.apps.events import CoreActivity
 from microsoft_teams.apps.routing.router import ActivityHandler, ActivityRouter
+from microsoft_teams.apps.state import TurnStateLoader, TurnStateSealedError
 from microsoft_teams.apps.token_provider import AppTokenProvider
 from microsoft_teams.common import Client, LocalStorage
 from opentelemetry import baggage
@@ -846,3 +847,112 @@ class TestActivityProcessor:
 
         # Assert error event was called
         assert activity_processor.event_manager.on_error.called
+
+    # --- Per-turn state (App(state=...)) integration -----------------------
+
+    @staticmethod
+    def _message_event(activity_id: str = "activity-state") -> ActivityEvent:
+        core_activity = CoreActivity(
+            type="message",
+            id=activity_id,
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-123", "name": "Test User"},
+                "conversation": {"id": "conv-789"},
+                "recipient": {"id": "bot-456", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        return ActivityEvent(body=core_activity, token=mock_token)
+
+    def _wire_event_manager(self, activity_processor):
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_state_disabled_leaves_ctx_state_none(self, activity_processor):
+        """With no state loader, ctx.state is None for handlers."""
+        captured: dict[str, Any] = {}
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            captured["state"] = ctx.state
+
+        activity_processor.state_loader = None
+        activity_processor.router.select_handlers = MagicMock(return_value=[handler])
+        self._wire_event_manager(activity_processor)
+
+        await activity_processor.process_activity([], self._message_event())
+
+        assert captured["state"] is None
+
+    @pytest.mark.asyncio
+    async def test_state_enabled_exposes_scopes_and_persists_across_turns(self, activity_processor):
+        """Handlers see loaded scopes, and writes persist to the next turn."""
+
+        storage: LocalStorage[str] = LocalStorage()
+        activity_processor.state_loader = TurnStateLoader(storage)
+        self._wire_event_manager(activity_processor)
+
+        async def writer(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is not None
+            ctx.state.conversation["greeted"] = True
+            assert ctx.state.user is not None
+            ctx.state.user["count"] = 1
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[writer])
+        await activity_processor.process_activity([], self._message_event("turn-1"))
+
+        seen: dict[str, Any] = {}
+
+        async def reader(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is not None and ctx.state.user is not None
+            seen["greeted"] = ctx.state.conversation.get("greeted")
+            seen["count"] = ctx.state.user.get("count")
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[reader])
+        await activity_processor.process_activity([], self._message_event("turn-2"))
+
+        assert seen == {"greeted": True, "count": 1}
+
+    @pytest.mark.asyncio
+    async def test_state_is_sealed_after_turn(self, activity_processor):
+        """State is sealed once the turn ends; later access raises."""
+
+        storage: LocalStorage[str] = LocalStorage()
+        activity_processor.state_loader = TurnStateLoader(storage)
+        self._wire_event_manager(activity_processor)
+
+        holder: dict[str, Any] = {}
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            holder["state"] = ctx.state
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[handler])
+        await activity_processor.process_activity([], self._message_event())
+
+        with pytest.raises(TurnStateSealedError):
+            _ = holder["state"].conversation["greeted"]
+
+    @pytest.mark.asyncio
+    async def test_state_saved_even_when_handler_raises(self, activity_processor):
+        """Dirty state is persisted in the finally even if the handler throws."""
+
+        storage: LocalStorage[str] = LocalStorage()
+        activity_processor.state_loader = TurnStateLoader(storage)
+        self._wire_event_manager(activity_processor)
+
+        async def boom(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is not None
+            ctx.state.conversation["partial"] = True
+            raise RuntimeError("boom")
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[boom])
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await activity_processor.process_activity([], self._message_event())
+
+        reloaded = await TurnStateLoader(storage).load("conv-789", "user-123")
+        assert reloaded.conversation["partial"] is True

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -22,7 +22,7 @@ from microsoft_teams.apps.app_events import EventManager
 from microsoft_teams.apps.app_process import ActivityProcessor
 from microsoft_teams.apps.events import CoreActivity
 from microsoft_teams.apps.routing.router import ActivityHandler, ActivityRouter
-from microsoft_teams.apps.state import TurnStateLoader, TurnStateSealedError
+from microsoft_teams.apps.state import TurnState, TurnStateContainer, TurnStateLoader, TurnStateSealedError
 from microsoft_teams.apps.token_provider import AppTokenProvider
 from microsoft_teams.common import Client, LocalStorage
 from opentelemetry import baggage
@@ -848,6 +848,27 @@ class TestActivityProcessor:
         # Assert error event was called
         assert activity_processor.event_manager.on_error.called
 
+    @pytest.mark.asyncio
+    async def test_state_load_failure_emits_error_event(self, activity_processor):
+        """State load failures are handled by the same on_error path as handler failures."""
+        mock_plugins = []
+        mock_activity_event = self._message_event("activity-load-failure")
+        load_error = RuntimeError("storage unavailable")
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(side_effect=load_error)
+        activity_processor.state_loader.save = AsyncMock()
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.execute_middleware_chain = AsyncMock()
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="storage unavailable"):
+            await activity_processor.process_activity(mock_plugins, mock_activity_event)
+
+        activity_processor.event_manager.on_error.assert_called_once()
+        activity_processor.execute_middleware_chain.assert_not_called()
+
     # --- Per-turn state (App(state=...)) integration -----------------------
 
     @staticmethod
@@ -956,3 +977,26 @@ class TestActivityProcessor:
 
         reloaded = await TurnStateLoader(storage).load("conv-789", "user-123")
         assert reloaded.conversation["partial"] is True
+
+    @pytest.mark.asyncio
+    async def test_state_is_sealed_when_save_raises(self, activity_processor):
+        """State is sealed even when persistence fails."""
+        container = TurnStateContainer(
+            conversation=TurnState({"value": "dirty"}),
+            conversation_id="conv-789",
+            user=TurnState({"value": "dirty"}),
+            user_id="user-123",
+        )
+        container.conversation["value"] = "changed"
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(return_value=container)
+        activity_processor.state_loader.save = AsyncMock(side_effect=RuntimeError("save failed"))
+        self._wire_event_manager(activity_processor)
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+
+        with pytest.raises(RuntimeError, match="save failed"):
+            await activity_processor.process_activity([], self._message_event())
+
+        assert container.conversation.is_sealed is True
+        assert container.user is not None and container.user.is_sealed is True

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -22,6 +22,7 @@ from microsoft_teams.apps import ActivityContext, ActivityEvent, App
 from microsoft_teams.apps.app_events import EventManager
 from microsoft_teams.apps.app_process import ActivityProcessor
 from microsoft_teams.apps.events import CoreActivity
+from microsoft_teams.apps.plugins import StreamCancelledError
 from microsoft_teams.apps.routing.router import ActivityHandler, ActivityRouter
 from microsoft_teams.apps.state import TurnState, TurnStateContainer, TurnStateLoader, TurnStateSealedError
 from microsoft_teams.apps.token_provider import AppTokenProvider
@@ -789,8 +790,6 @@ class TestActivityProcessor:
     @pytest.mark.asyncio
     async def test_process_activity_handles_stream_cancelled(self, activity_processor):
         """StreamCancelledError from middleware is caught; response status is 200."""
-        from microsoft_teams.apps.plugins import StreamCancelledError
-
         core_activity = CoreActivity(
             type="message",
             id="activity-cancel",
@@ -817,10 +816,32 @@ class TestActivityProcessor:
         assert result.status == 200
 
     @pytest.mark.asyncio
+    async def test_process_activity_stream_cancelled_raises_state_save_failure(self, activity_processor):
+        """A handled stream cancellation does not hide a persistence failure."""
+        save_error = RuntimeError("save failed")
+        container = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="conv-789",
+        )
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(return_value=container)
+        activity_processor.state_loader.save = AsyncMock(side_effect=save_error)
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.execute_middleware_chain = AsyncMock(side_effect=StreamCancelledError())
+        self._wire_event_manager(activity_processor)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await activity_processor.process_activity([], self._message_event())
+
+        assert exc_info.value is save_error
+        error_event = activity_processor.event_manager.on_error.await_args.args[0]
+        assert error_event.error is save_error
+        activity_processor.event_manager.on_activity_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_process_activity_handles_response_event_stream_cancelled(self, activity_processor):
         """StreamCancelledError from the response event retains the legacy 200 response."""
-        from microsoft_teams.apps.plugins import StreamCancelledError
-
         core_activity = CoreActivity(
             type="message",
             id="activity-response-cancel",
@@ -914,13 +935,13 @@ class TestActivityProcessor:
     # --- Per-turn state (App(state=...)) integration -----------------------
 
     @staticmethod
-    def _message_event(activity_id: str = "activity-state") -> ActivityEvent:
+    def _message_event(activity_id: str = "activity-state", user_id: str = "user-123") -> ActivityEvent:
         core_activity = CoreActivity(
             type="message",
             id=activity_id,
             service_url="https://service.url",
             **{
-                "from": {"id": "user-123", "name": "Test User"},
+                "from": {"id": user_id, "name": "Test User"},
                 "conversation": {"id": "conv-789"},
                 "recipient": {"id": "bot-456", "name": "Test Bot"},
                 "channelId": "msteams",
@@ -979,6 +1000,29 @@ class TestActivityProcessor:
         await activity_processor.process_activity([], self._message_event("turn-2"))
 
         assert seen == {"greeted": True, "count": 1}
+
+    @pytest.mark.asyncio
+    async def test_state_empty_sender_id_persists_conversation_without_user_scope(self, activity_processor):
+        """An empty sender ID omits user state without blocking conversation persistence."""
+        storage: LocalStorage[str] = LocalStorage()
+        activity_processor.state_loader = TurnStateLoader(storage)
+        self._wire_event_manager(activity_processor)
+        holder: dict[str, TurnStateContainer] = {}
+
+        async def handler(ctx: ActivityContext[Activity]) -> None:
+            assert ctx.state is not None
+            holder["state"] = ctx.state
+            assert ctx.state.user is None
+            ctx.state.conversation["value"] = "saved"
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[handler])
+
+        response = await activity_processor.process_activity([], self._message_event(user_id=""))
+
+        assert response.status == 200
+        assert holder["state"].user is None
+        reloaded = await TurnStateLoader(storage).load("conv-789")
+        assert reloaded.conversation["value"] == "saved"
 
     @pytest.mark.asyncio
     async def test_state_is_sealed_after_turn(self, activity_processor):
@@ -1048,6 +1092,32 @@ class TestActivityProcessor:
         activity_processor.event_manager.on_activity_response.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_state_save_failure_raised_inside_unrelated_exception_handler(self, activity_processor):
+        """A caller's handled exception does not hide a persistence failure."""
+        save_error = RuntimeError("save failed")
+        container = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="conv-789",
+        )
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(return_value=container)
+        activity_processor.state_loader.save = AsyncMock(side_effect=save_error)
+        self._wire_event_manager(activity_processor)
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+
+        try:
+            raise ValueError("unrelated caller error")
+        except ValueError:
+            with pytest.raises(RuntimeError) as exc_info:
+                await activity_processor.process_activity([], self._message_event())
+
+        assert exc_info.value is save_error
+        error_event = activity_processor.event_manager.on_error.await_args.args[0]
+        assert error_event.error is save_error
+        activity_processor.event_manager.on_activity_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_state_save_failure_does_not_mask_handler_error(self, activity_processor):
         """A persistence failure is reported without replacing the handler failure."""
         handler_error = ValueError("handler failed")
@@ -1080,8 +1150,8 @@ class TestActivityProcessor:
         activity_processor.event_manager.on_activity_response.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_state_save_failure_does_not_mask_task_cancellation(self, activity_processor):
-        """Task cancellation remains authoritative when persistence also fails."""
+    async def test_state_save_failure_does_not_mask_handler_cancellation(self, activity_processor):
+        """Handler cancellation remains authoritative when persistence also fails."""
         save_error = RuntimeError("save failed")
         container = TurnStateContainer(
             conversation=TurnState(),
@@ -1105,6 +1175,36 @@ class TestActivityProcessor:
         assert container.conversation.is_sealed is True
         error_event = activity_processor.event_manager.on_error.await_args.args[0]
         assert error_event.error is save_error
+        activity_processor.event_manager.on_activity_response.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_task_cancellation_during_state_save_seals_state(self, activity_processor):
+        """Cancellation during persistence propagates after sealing state."""
+        container = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="conv-789",
+        )
+        save_started = asyncio.Event()
+        block_save = asyncio.Event()
+
+        async def save(_: TurnStateContainer) -> None:
+            save_started.set()
+            await block_save.wait()
+
+        activity_processor.state_loader = MagicMock()
+        activity_processor.state_loader.load = AsyncMock(return_value=container)
+        activity_processor.state_loader.save = AsyncMock(side_effect=save)
+        self._wire_event_manager(activity_processor)
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+
+        task = asyncio.create_task(activity_processor.process_activity([], self._message_event()))
+        await save_started.wait()
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert container.conversation.is_sealed is True
         activity_processor.event_manager.on_activity_response.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_app_process.py
+++ b/packages/apps/tests/test_app_process.py
@@ -817,6 +817,43 @@ class TestActivityProcessor:
         assert result.status == 200
 
     @pytest.mark.asyncio
+    async def test_process_activity_handles_response_event_stream_cancelled(self, activity_processor):
+        """StreamCancelledError from the response event retains the legacy 200 response."""
+        from microsoft_teams.apps.plugins import StreamCancelledError
+
+        core_activity = CoreActivity(
+            type="message",
+            id="activity-response-cancel",
+            service_url="https://service.url",
+            **{
+                "from": {"id": "user-1", "name": "Test User"},
+                "conversation": {"id": "conv-1"},
+                "recipient": {"id": "bot-1", "name": "Test Bot"},
+                "channelId": "msteams",
+            },
+        )
+        mock_token = MagicMock(spec=TokenProtocol)
+        mock_token.service_url = "https://service.url"
+        mock_activity_event = ActivityEvent(body=core_activity, token=mock_token)
+
+        activity_processor.router.select_handlers = MagicMock(return_value=[])
+        activity_processor.execute_middleware_chain = AsyncMock(
+            return_value=InvokeResponse(status=202, body={"accepted": True})
+        )
+        activity_processor.event_manager = MagicMock()
+        activity_processor.event_manager.on_activity_response = AsyncMock(side_effect=StreamCancelledError())
+        activity_processor.event_manager.on_error = AsyncMock()
+
+        with patch("microsoft_teams.apps.routing.activity_context.HttpStream") as mock_stream_class:
+            mock_stream = mock_stream_class.return_value
+            mock_stream.close = AsyncMock()
+
+            result = await activity_processor.process_activity([], mock_activity_event)
+
+        assert result.status == 200
+        assert mock_stream.close.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_process_activity_raises_exception(self, activity_processor):
         """Test process_activity raises exception when middleware chain fails."""
         # Setup mocks

--- a/packages/apps/tests/test_state.py
+++ b/packages/apps/tests/test_state.py
@@ -4,7 +4,9 @@ Licensed under the MIT License.
 """
 
 import json
+import logging
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from microsoft_teams.apps.state import (
@@ -13,8 +15,9 @@ from microsoft_teams.apps.state import (
     TurnStateContainer,
     TurnStateLoader,
     TurnStateSealedError,
+    create_state_loader,
 )
-from microsoft_teams.common import LocalStorage
+from microsoft_teams.common import LocalStorage, Storage
 
 # ---------------------------------------------------------------------------
 # TurnState
@@ -369,3 +372,41 @@ class TestTurnStateLoader:
         container.conversation["k"] = "v"
         await loader.save(container)
         assert storage.get("ts:conv:c1") is not None
+
+
+# ---------------------------------------------------------------------------
+# create_state_loader (App(state=...) resolution)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateStateLoader:
+    def test_returns_none_when_disabled(self):
+        assert create_state_loader(None, LocalStorage()) is None
+        assert create_state_loader(False, LocalStorage()) is None
+
+    def test_true_enables_on_fallback_storage_and_warns(self, caplog):
+        fallback = LocalStorage()
+        with caplog.at_level(logging.WARNING):
+            loader = create_state_loader(True, fallback)
+        assert isinstance(loader, TurnStateLoader)
+        assert any("localstorage" in r.message.lower() for r in caplog.records)
+
+    async def test_options_storage_is_used_over_fallback(self):
+        dedicated: LocalStorage[str] = LocalStorage()
+        fallback: LocalStorage[str] = LocalStorage()
+        loader = create_state_loader(StateOptions(storage=dedicated), fallback)
+        assert loader is not None
+
+        container = await loader.load("c1")
+        container.conversation["k"] = "v"
+        await loader.save(container)
+
+        assert dedicated.get("ts:conv:c1") is not None
+        assert fallback.get("ts:conv:c1") is None
+
+    def test_non_local_storage_does_not_warn(self, caplog):
+        fake_storage = MagicMock(spec=Storage)
+        with caplog.at_level(logging.WARNING):
+            loader = create_state_loader(StateOptions(storage=fake_storage), LocalStorage())
+        assert isinstance(loader, TurnStateLoader)
+        assert not any("localstorage" in r.message.lower() for r in caplog.records)

--- a/packages/apps/tests/test_state.py
+++ b/packages/apps/tests/test_state.py
@@ -380,6 +380,12 @@ class TestTurnStateLoader:
 
 
 class TestCreateStateLoader:
+    def test_create_state_loader_is_exported_from_apps_surface(self):
+        import microsoft_teams.apps as apps
+
+        assert apps.create_state_loader is create_state_loader
+        assert "create_state_loader" in apps.__all__
+
     def test_returns_none_when_disabled(self):
         assert create_state_loader(None, LocalStorage()) is None
         assert create_state_loader(False, LocalStorage()) is None

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,7 @@ members = [
     "microsoft-teams-m365extensions",
     "oauth",
     "proactive-messaging",
+    "state",
     "stream",
     "suggested-actions",
     "tab",
@@ -3233,6 +3234,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "state"
+version = "0.1.0"
+source = { virtual = "examples/state" }
+dependencies = [
+    { name = "dotenv" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This is **PR 2 of 5** in the multi-connection OAuth stack.

PR #553 introduced the state foundation. This PR exposes state through `ctx.state`, adds the `App(state=...)` opt-in, and integrates state loading and persistence into activity dispatch.

State remains disabled by default. When disabled, `ctx.state` is `None` and no state storage operations occur.

## What changed

### Public API

- Adds `ActivityContext.state`.
- Adds `state` to `AppOptions`.
- Re-exports:
  - `StateOptions`
  - `TurnState`
  - `TurnStateContainer`
  - `TurnStateSealedError`
  - `create_state_loader`

### Configuration

```python
# State disabled (default)
app = App()

# Use the app's shared storage
app = App(state=True)

# Use a dedicated provider or key prefix
app = App(
    state=StateOptions(
        storage=my_storage,
        key_prefix="my-app",
    )
)
```

`StateOptions` does not manage TTL. Expiration and other provider-specific behavior are configured directly on the selected storage provider.

When state resolves to in-memory `LocalStorage`, the SDK logs a warning because the data is process-local and lost on restart.

### Turn lifecycle

For each activity when state is enabled:

1. Conversation and user state are loaded before middleware and handlers run.
2. Handlers access them through:
   - `ctx.state.conversation`
   - `ctx.state.user`
3. Dirty state is persisted at the end of the turn, including when processing fails.
4. The container is always sealed after persistence, preventing post-turn access.
5. `on_activity_response` runs only after persistence succeeds.

Persistence failures are reported through `on_error`:

- If processing succeeded, the persistence failure propagates.
- If processing already failed or was cancelled, that original error remains authoritative.
- Failures from error-reporting plugins cannot replace the original processing error.

Existing `StreamCancelledError` behavior remains: the stream is closed and the activity returns a 200 response.

### Storage resolution

`create_state_loader()` centralizes resolution of:

- `None` / `False` → state disabled
- `True` → app storage with default state options
- `StateOptions(...)` → configured prefix and optional dedicated storage

### Example

Adds `examples/state/`, demonstrating:

- A conversation-scoped message counter
- User-scoped profile data
- Automatic loading and persistence
- `LocalStorage` development behavior