### PR TITLE
Fix: reuse the shared HTTP client for file downloads

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/files/download.py
+++ b/packages/apps/src/microsoft_teams/apps/files/download.py
@@ -82,8 +82,14 @@ async def _open_personal_file_stream(
 
     try:
         # Plain GET with no bearer token: the download URL embeds its own `tempauth` credential, and attaching a
-        # credential can get the request rejected.
-        async with http.stream("GET", url) as response:
+        # credential can get the request rejected. The shared client is configured with the bot's default headers,
+        # so strip `Authorization` off this request rather than assuming the client carries none; otherwise it
+        # would be sent to a third-party storage host.
+        request = http.build_request("GET", url)
+        request.headers.pop("Authorization", None)
+        response = await http.send(request, stream=True)
+
+        try:
             if response.status_code in (401, 403):
                 raise FileUrlExpiredError("reread" if prior_fetch_succeeded else "first_fetch")
 
@@ -92,6 +98,8 @@ async def _open_personal_file_stream(
 
             content_type = response.headers.get("content-type") or target.content_type or "application/octet-stream"
             yield OpenedFileStream(chunks=response.aiter_bytes(), source_url=url, content_type=content_type)
+        finally:
+            await response.aclose()
     finally:
         if owns_client:
             await http.aclose()

--- a/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
+++ b/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
@@ -6,6 +6,7 @@ Licensed under the MIT License.
 import logging
 from typing import List, Optional
 
+import httpx
 from microsoft_teams.api import (
     FILE_DOWNLOAD_INFO_CONTENT_TYPE,
     ActivityBase,
@@ -36,10 +37,16 @@ class FilesAccessor:
     This covers the file-upload path, not "any uploaded media". What matters is how the content arrived, not the
     file's MIME type, so file *type* is unrestricted (pdf, docx, png, etc.) as long as it was sent as an uploaded
     file. An image sent as a file appears here, but the same image pasted inline does not.
+
+    The optional `client` is the app's shared `httpx.AsyncClient`, threaded into every `IncomingFile` so downloads
+    reuse one connection pool instead of building and tearing down a client per file. It is the raw client rather
+    than the SDK's wrapper on purpose: a download URL embeds its own `tempauth` credential, so the request must not
+    pick up the bot's `Authorization` header. When omitted, each download creates and closes its own client.
     """
 
-    def __init__(self, activity: ActivityBase) -> None:
+    def __init__(self, activity: ActivityBase, client: Optional[httpx.AsyncClient] = None) -> None:
         self._activity = activity
+        self._client = client
 
     async def list(self) -> List[IncomingFile]:
         """
@@ -114,6 +121,7 @@ class FilesAccessor:
             web_url=attachment.content_url,
             raw=attachment,
             download_url=download_url,
+            client=self._client,
         )
 
     def _coerce_content(self, content: object, index: int) -> Optional[FileDownloadInfo]:

--- a/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
@@ -36,9 +36,10 @@ class IncomingFile:
 
     content_type: Optional[str]
     """
-    The file's MIME type, when Teams provides it with the file. Files received today do not include one, so this is
-    usually `None`; the type resolved from the download response is on the returned `DownloadedFile`, not written back
-    here.
+    The file's MIME type when the source provides one. Always `None` for `botActivity` files: a `file.download.info`
+    attachment carries no MIME type, only the `file_type` extension surfaced as `extension`. Populated for sources
+    that do carry one, such as a `graph` drive item. To learn the type of the bytes you actually received, read
+    `DownloadedFile.content_type`, which is resolved from the download response.
     """
 
     extension: Optional[str]

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -124,7 +124,10 @@ class ActivityContext(Generic[T]):
         `activity.attachments`, mapped to `IncomingFile`. See `FilesAccessor`.
         """
         if self._files is None:
-            self._files = FilesAccessor(self.activity)
+            # Reuse the API client's underlying connection pool rather than building a new one per download. The raw
+            # `httpx.AsyncClient` is used deliberately: the SDK wrapper injects the bot's `Authorization` header per
+            # request, and a download URL carries its own `tempauth` credential that a bearer token can displace.
+            self._files = FilesAccessor(self.activity, self.api.http.http)
         return self._files
 
     @property

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -8,6 +8,7 @@ Licensed under the MIT License.
 from typing import List, Optional
 
 import httpx
+import pytest
 from microsoft_teams.api import (
     FILE_DOWNLOAD_INFO_CONTENT_TYPE,
     Account,
@@ -16,7 +17,7 @@ from microsoft_teams.api import (
     MessageActivity,
 )
 from microsoft_teams.api.activities.typing import TypingActivity
-from microsoft_teams.apps.files import FilesAccessor
+from microsoft_teams.apps.files import FilesAccessor, download
 
 
 def _activity_with(attachments: List[Attachment], conversation_type: Optional[str] = "personal") -> MessageActivity:
@@ -195,13 +196,31 @@ async def test_threads_the_shared_client_into_every_mapped_file() -> None:
 
 
 async def test_falls_back_to_a_private_client_when_none_is_injected() -> None:
-    """Omitting the client stays supported: the accessor is constructible and usable without one."""
+    """Omitting the client must still download, through a private client the download path creates and then closes."""
+    created: List[httpx.AsyncClient] = []
+    real_client_cls = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"private", headers={"content-type": "text/plain"})
+
+    def fake_client_cls(*_args: object, **_kwargs: object) -> httpx.AsyncClient:
+        client = real_client_cls(transport=httpx.MockTransport(handler))
+        created.append(client)
+        return client
+
     attachment = Attachment(
         content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
         name="notes.txt",
         content={"downloadUrl": "https://download.example/notes.txt"},
     )
 
-    files = await FilesAccessor(_activity_with([attachment])).list()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(download.httpx, "AsyncClient", fake_client_cls)
+        files = await FilesAccessor(_activity_with([attachment])).list()
+        downloaded = await files[0].download()
 
     assert len(files) == 1
+    assert downloaded.text() == "private"
+    # The download path owns the client it created, so it must also close it rather than leak the pool.
+    assert len(created) == 1
+    assert created[0].is_closed

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -7,6 +7,7 @@ Licensed under the MIT License.
 
 from typing import List, Optional
 
+import httpx
 from microsoft_teams.api import (
     FILE_DOWNLOAD_INFO_CONTENT_TYPE,
     Account,
@@ -165,3 +166,42 @@ async def test_first_returns_the_first_mapped_file_or_none() -> None:
 
     assert await FilesAccessor(_activity_with([attachment])).first() is not None
     assert await FilesAccessor(_activity_with([])).first() is None
+
+
+async def test_threads_the_shared_client_into_every_mapped_file() -> None:
+    """The injected client must reach the download path; otherwise each download builds its own connection pool."""
+    calls: List[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(str(request.url))
+        return httpx.Response(200, content=b"shared", headers={"content-type": "text/plain"})
+
+    shared = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="notes.txt",
+        content={"downloadUrl": "https://download.example/notes.txt?tempauth=abc"},
+    )
+
+    try:
+        files = await FilesAccessor(_activity_with([attachment]), shared).list()
+        downloaded = await files[0].download()
+    finally:
+        await shared.aclose()
+
+    # A file that fell back to its own client would never hit this transport.
+    assert calls == ["https://download.example/notes.txt?tempauth=abc"]
+    assert downloaded.text() == "shared"
+
+
+async def test_falls_back_to_a_private_client_when_none_is_injected() -> None:
+    """Omitting the client stays supported: the accessor is constructible and usable without one."""
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="notes.txt",
+        content={"downloadUrl": "https://download.example/notes.txt"},
+    )
+
+    files = await FilesAccessor(_activity_with([attachment])).list()
+
+    assert len(files) == 1

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -224,3 +224,60 @@ async def test_falls_back_to_a_private_client_when_none_is_injected() -> None:
     # The download path owns the client it created, so it must also close it rather than leak the pool.
     assert len(created) == 1
     assert created[0].is_closed
+
+
+async def test_does_not_forward_the_shared_clients_authorization_header() -> None:
+    """
+    The shared client carries the bot's default headers. The download URL embeds its own `tempauth` credential and
+    points at third-party storage, so the bot's `Authorization` must never ride along.
+    """
+    seen: List[Optional[str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("authorization"))
+        return httpx.Response(200, content=b"ok", headers={"content-type": "text/plain"})
+
+    shared = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer super-secret-app-token", "User-Agent": "teams.py-test/1.0"},
+    )
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="notes.txt",
+        content={"downloadUrl": "https://download.example/notes.txt?tempauth=abc"},
+    )
+
+    try:
+        files = await FilesAccessor(_activity_with([attachment]), shared).list()
+        await files[0].download()
+    finally:
+        await shared.aclose()
+
+    assert seen == [None]
+
+
+async def test_preserves_the_shared_clients_other_default_headers() -> None:
+    """Stripping `Authorization` must not cost us the rest of the client's configuration."""
+    seen: List[Optional[str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("user-agent"))
+        return httpx.Response(200, content=b"ok", headers={"content-type": "text/plain"})
+
+    shared = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": "Bearer super-secret-app-token", "User-Agent": "teams.py-test/1.0"},
+    )
+    attachment = Attachment(
+        content_type=FILE_DOWNLOAD_INFO_CONTENT_TYPE,
+        name="notes.txt",
+        content={"downloadUrl": "https://download.example/notes.txt?tempauth=abc"},
+    )
+
+    try:
+        files = await FilesAccessor(_activity_with([attachment]), shared).list()
+        await files[0].download()
+    finally:
+        await shared.aclose()
+
+    assert seen == ["teams.py-test/1.0"]


### PR DESCRIPTION
Follow-up to #550. Three fixes found while reviewing the equivalent .NET and TypeScript changes.

**Downloads now reuse the app's connection pool.** `IncomingFile` already accepted a `client` and `download.py` already reused one when given, but nothing ever passed it, so every download constructed and closed its own `httpx.AsyncClient`. `FilesAccessor` now takes an optional client, threads it into each `IncomingFile`, and `ActivityContext.files` supplies the API client's pool. Omitting it still works: the per-download fallback is unchanged, which keeps `FilesAccessor` usable standalone in tests.

The raw `httpx.AsyncClient` is passed rather than the SDK's `Client` wrapper, deliberately. A download URL carries its own `tempauth` credential, and the wrapper injects the bot's `Authorization` header per request, which must not ride along on a download. `download.py` calls `httpx` directly and bypasses that path, so the per-request credential is never attached.

**Downloads no longer forward a default `Authorization` header.** Bypassing the wrapper handles the *per-request* token, but not *client-level* default headers: `Client` builds its underlying `httpx.AsyncClient` with `headers=options.headers`, and httpx merges those into every request. An app configured with a default `Authorization` header would therefore send the bot's credential to a third-party OneDrive/SharePoint host. The download path now builds the request explicitly and pops `Authorization` before sending, so sharing the pool never means sharing the credential regardless of how the client was configured. Found by @lilyydu on the TypeScript PR (microsoft/teams.ts#712), which had the same gap; .NET was already safe because `FileDownloader` gets its own typed client.

**Corrected the `IncomingFile.content_type` docstring.** It said the field is "usually `None`", implying the platform might populate it. For `botActivity` files it is *always* `None`: a `file.download.info` attachment carries no MIME type, only the `file_type` extension already surfaced as `extension`. The new wording states that, points at `DownloadedFile.content_type` for the type resolved from the response, and leaves room for sources that do carry one. Matches the corresponding .NET and TypeScript wording and the docs update.

## Testing

- `test_threads_the_shared_client_into_every_mapped_file` asserts through a `MockTransport` that the injected client received the download. Mutation-tested: deleting the `client=self._client` argument makes it fail, so it discriminates rather than passing vacuously.
- `test_falls_back_to_a_private_client_when_none_is_injected` pins that the client stays optional.
- `test_does_not_forward_the_shared_clients_authorization_header` gives the shared client a default `Authorization` and asserts the download request carries none. Mutation-tested: restoring the old `http.stream(...)` call makes it fail.
- `test_preserves_the_shared_clients_other_default_headers` pins that stripping `Authorization` does not also drop the client's `User-Agent`.
- `ruff format`, `ruff check`, `pyright` all clean; full suite **979 passed**.
