### PR TITLE
add m365 extension and sample

### DIFF
--- a/examples/m365extensions/README.md
+++ b/examples/m365extensions/README.md
@@ -1,0 +1,142 @@
+# M365 Extensions Sample
+
+This sample embeds the teams.py `App` inside a Microsoft Agents SDK `AgentApplication` using
+the `microsoft-teams-m365extensions` bridge. Teams turns that match a teams.py route are handled
+by teams.py; everything else — non-Teams channels, and Teams turns with no matching route — falls
+through to the `AgentApplication`.
+
+## How It Works
+
+`use_teams_sdk` extracts `client_id`/`tenant_id` from the connection manager, wires teams.py's
+outbound token callback to it, constructs the `microsoft_teams.apps.App`, and installs
+`TeamsMiddleware` on the Agents SDK adapter — returning the configured `App` ready for handler
+registration.
+
+For every Teams turn the middleware checks whether `TEAMS_APP` has a matching route; if so it
+processes the activity with teams.py and propagates the returned `InvokeResponse` back through the
+Agents SDK pipeline. If no teams.py route matches, the turn falls through to `AGENT_SDK_APP`.
+
+## Commands
+
+Teams SDK routes (`TEAMS_APP`, Teams channel only):
+
+- `help` — Adaptive Card listing every command
+- `react` — bot adds then removes an emoji reaction
+- `quote` — bot replies with a quoted reply
+- `targeted` — ephemeral message visible only to the sender
+- `task` — task module fetch/submit flow
+
+Agents SDK routes (`AGENT_SDK_APP`, fallthrough + non-Teams channels):
+
+- `channel` — report the channel this turn arrived on and how it was routed
+- `agents sdk react` — reach teams.py's API client from an Agents SDK handler
+- `agents sdk proactive` — trigger a proactive send from an Agents SDK handler
+- `whoami` / `mail` — Microsoft Graph via two separate OAuth connections (see below)
+- `signout` — sign out of both Graph handlers
+- anything else — echoed by the Agents SDK
+
+## Setup
+
+This sample uses the official [Teams CLI](https://microsoft.github.io/teams-sdk/cli/)
+(`@microsoft/teams.cli`) to register the bot. Install it (requires Node.js 20+) and sign in to
+Microsoft 365:
+
+```bash
+npm install -g @microsoft/teams.cli
+teams login
+```
+
+Expose this sample's local `/api/messages` endpoint with a dev tunnel, then create the bot. The
+`whoami`/`mail` sign-in and the [Web Chat harness](./tools/webchat) both need an Azure Bot resource,
+so create the bot with `--azure`:
+
+```bash
+teams app create \
+  --name "m365extensions" \
+  --azure --resource-group <rg> --create-resource-group \
+  --endpoint "https://<your-tunnel>/api/messages"
+```
+
+`teams app create` registers the AAD app, generates a client secret, builds and imports the
+manifest, and prints your credentials:
+
+```
+CLIENT_ID=<client-id>
+CLIENT_SECRET=<client-secret>
+TENANT_ID=<tenant-id>
+```
+
+Copy `sample.env` to `.env` and paste those three values into the `CONNECTIONS__…` fields. The
+Agents SDK's `MsalConnectionManager` reads this nested configuration schema, not the flat
+`CLIENT_ID` names the CLI prints — so map them across rather than pointing `teams app create --env`
+at `.env`:
+
+```bash
+cp sample.env .env
+# CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID=<CLIENT_ID>
+# CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET=<CLIENT_SECRET>
+# CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID=<TENANT_ID>
+```
+
+## Running
+
+Install dependencies from the repo root, then run the sample from its own directory so `.env` is
+discovered automatically:
+
+```bash
+uv sync --all-packages
+cd examples/m365extensions
+uv run src/main.py
+```
+
+Install the bot in Teams and send `help` — replies are prefixed `[Teams SDK]` (teams.py route) or
+`[Agent SDK]` (fallthrough to `AgentApplication`).
+
+## Multi Authentication (two Graph connections)
+
+`whoami` and `mail` both call Microsoft Graph, but through separate OAuth connections on the same
+AAD app, so each keeps its own token cache — signing in for `whoami` does not satisfy `mail`.
+
+| Command | Handler | ABS connection | Scopes |
+| --- | --- | --- | --- |
+| `whoami` | `graphuser` | `graphuser` | `User.Read` |
+| `mail` | `graphmail` | `graphmail` | `User.Read Mail.Read` |
+
+Create the two OAuth connections (`graphuser`, `graphmail`) on the Azure Bot registration — via the
+Azure Portal or `az bot authsetting create`, since the Teams CLI doesn't manage OAuth connections —
+then uncomment their handler entries in `.env` (see the commented block in `sample.env`). Handlers
+are configured from `.env`, not in code. Auth
+lives on the Agents SDK side because the intercept runs inside `AgentApplication.on_turn`, which
+the middleware only calls when no teams.py route matches — a teams.py route would run
+unauthenticated rather than fail. The sample also passes a `should_bypass_teams` predicate so
+`signin/*` invokes always stay with the Agents SDK.
+
+## Multichannel
+
+`TeamsMiddleware` routes to teams.py only for Teams activities; every other channel passes straight
+through to the Agents SDK. Teams alone can't show that half of the contract, so the sample runs on
+three channels:
+
+| | Teams | Web Chat / Direct Line | Email |
+| --- | --- | --- | --- |
+| `channel` | fell through | passed through | passed through |
+| `help` | Adaptive Card (teams.py) | plain text (Agents SDK) | plain text (Agents SDK) |
+| `quote`, `task`, `react`, `targeted` | handled by teams.py | no route → echoed | no route → echoed |
+| `whoami`, `mail` | OAuth card | OAuth card | declined (cards are inert on email) |
+
+### Web Chat / Direct Line
+
+This example ships a small Direct Line harness in [`tools/webchat`](./tools/webchat) — a browser UI
+plus a scriptable CLI — for exercising the non-Teams path:
+
+```bash
+python tools/webchat/serve.py                  # browser UI at http://localhost:3000
+python tools/webchat/dl_test.py help channel   # scripted, prints card contents too
+```
+
+### Email
+
+Enable the Email channel on the bot registration. Two things differ: `activity.text` is the message
+body only (the subject arrives in `channelData.Subject`), and the body carries a signature/quoted
+thread — which is why `_command()` anchors matches to the first line. Sign-in is declined on email
+because Azure Bot Service flattens OAuth cards into a static, unclickable image.

--- a/examples/m365extensions/pyproject.toml
+++ b/examples/m365extensions/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "m365extensions"
+version = "0.1.0"
+description = "Test app that embeds Teams SDK into M365 Agents SDK."
+readme = "README.md"
+requires-python = ">=3.11,<4.0"
+dependencies = [
+    "dotenv>=0.9.9",
+    "aiohttp>=3.10.0",
+    "microsoft-agents-activity>=1.3.0",
+    "microsoft-agents-hosting-core>=1.3.0",
+    "microsoft-agents-hosting-aiohttp>=1.3.0",
+    "microsoft-agents-authentication-msal>=1.3.0",
+    "microsoft-teams-api",
+    "microsoft-teams-apps",
+    "microsoft-teams-cards",
+    "microsoft-teams-m365extensions",
+]
+
+[tool.uv.sources]
+microsoft-teams-api = { workspace = true }
+microsoft-teams-apps = { workspace = true }
+microsoft-teams-cards = { workspace = true }
+microsoft-teams-m365extensions = { workspace = true }

--- a/examples/m365extensions/sample.env
+++ b/examples/m365extensions/sample.env
@@ -1,0 +1,15 @@
+# Azure Bot / App registration credentials (required)
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID=<your-azure-bot-app-id>
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET=<your-azure-bot-app-secret>
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID=<your-tenant-id>
+
+# Optional: skip JWT validation for local development
+# TOKENVALIDATION__ENABLED=false
+
+# Optional: custom port (defaults to 3978 if not specified)
+# PORT=3978
+
+# Sign-in demo (optional): two Graph OAuth handlers on the same AAD app.
+# Each value is the ABS OAuth connection name configured on the bot registration.
+# AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__graphuser__SETTINGS__AZUREBOTOAUTHCONNECTIONNAME=graphuser
+# AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__graphmail__SETTINGS__AZUREBOTOAUTHCONNECTIONNAME=graphmail

--- a/examples/m365extensions/src/cards.py
+++ b/examples/m365extensions/src/cards.py
@@ -1,0 +1,81 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+from microsoft_teams.cards.core import (
+    AdaptiveCard,
+    Fact,
+    FactSet,
+    SubmitAction,
+    TextBlock,
+    TextInput,
+)
+from microsoft_teams.cards.utilities import OpenDialogData
+
+
+def help_card() -> AdaptiveCard:
+    return AdaptiveCard(
+        version="1.5",
+        body=[
+            TextBlock(text="Teams SDK Feature Showcase", weight="Bolder", size="Large"),
+            TextBlock(
+                text="Teams SDK handlers (TEAMS_APP)",
+                weight="Bolder",
+                spacing="Medium",
+            ),
+            FactSet(
+                facts=[
+                    Fact(title="help", value="This command list"),
+                    Fact(title="react", value="Bot adds/removes emoji reactions"),
+                    Fact(title="quote", value="Bot quotes its own message"),
+                    Fact(title="targeted", value="Ephemeral message visible only to sender"),
+                    Fact(title="task", value="Task module fetch/submit flow"),
+                ]
+            ),
+            TextBlock(
+                text="Agents SDK fallthrough handlers (AGENT_SDK_APP)",
+                weight="Bolder",
+                spacing="Medium",
+            ),
+            FactSet(
+                facts=[
+                    Fact(title="agents sdk react", value="Reach teams.py's API client from an Agents SDK handler"),
+                    Fact(title="agents sdk proactive", value="Trigger a proactive send from an Agents SDK handler"),
+                    Fact(title="channel", value="Report the channel this turn arrived on and how it was routed"),
+                    Fact(title="anything else", value="Echo via Agents SDK '[Agent SDK] You said: ...'"),
+                ]
+            ),
+        ],
+    )
+
+
+def task_launcher_card() -> AdaptiveCard:
+    """Card whose button opens a task module via the task/fetch invoke."""
+    return AdaptiveCard(
+        version="1.5",
+        body=[
+            TextBlock(text="📋 Task module demo", weight="Bolder"),
+            TextBlock(
+                text="Press the button to open a task module.",
+                wrap=True,
+            ),
+        ],
+        actions=[
+            SubmitAction(title="Open task module").with_data(OpenDialogData("open_task")),
+        ],
+    )
+
+
+def task_form_card() -> AdaptiveCard:
+    """The form shown inside the task module."""
+    return AdaptiveCard(
+        version="1.5",
+        body=[
+            TextBlock(text="Tell us something:", weight="Bolder"),
+            TextInput(id="note").with_placeholder("Type here…"),
+        ],
+        actions=[SubmitAction(title="Submit")],
+    )

--- a/examples/m365extensions/src/main.py
+++ b/examples/m365extensions/src/main.py
@@ -1,0 +1,357 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import asyncio
+import logging
+import re
+from os import environ, path
+
+from aiohttp import ClientSession, web
+from cards import help_card, task_form_card, task_launcher_card
+from dotenv import load_dotenv
+from microsoft_agents.activity import (
+    ActivityTypes,
+    Channels,
+    load_configuration_from_env,
+)
+from microsoft_agents.authentication.msal import MsalConnectionManager
+from microsoft_agents.hosting.aiohttp import (
+    CloudAdapter,
+    jwt_authorization_middleware,
+    start_agent_process,
+)
+from microsoft_agents.hosting.core import (
+    AgentApplication,
+    MemoryStorage,
+    RouteRank,
+    TurnContext,
+    TurnState,
+)
+from microsoft_agents.hosting.core.app import ApplicationOptions
+from microsoft_teams.api import (
+    MessageActivity,
+    MessageActivityInput,
+    MessageReactionActivity,
+    TaskFetchInvokeActivity,
+    TaskModuleContinueResponse,
+    TaskModuleInvokeResponse,
+    TaskModuleMessageResponse,
+    TaskSubmitInvokeActivity,
+)
+from microsoft_teams.api.clients.api_client import ApiClient
+from microsoft_teams.api.models.account import Account
+from microsoft_teams.api.models.attachment import AdaptiveCardAttachment, card_attachment
+from microsoft_teams.api.models.task_module import CardTaskModuleTaskInfo
+from microsoft_teams.apps import ActivityContext
+from microsoft_teams.m365extensions import is_teams_channel, use_teams_sdk
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("m365extensions-sample")
+
+GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+
+
+def _command(name: str) -> re.Pattern[str]:
+    mention = r"(?:<at\b[^>]*>.*?</at>|@\S+)"
+    return re.compile(
+        rf"\s*(?:{mention}\s*)*{re.escape(name)}[ \t]*(?:\r?\n[\s\S]*)?$",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+
+# ═══════════════════════════════ Bootstrap ═══════════════════════════════
+
+load_dotenv(path.join(path.dirname(path.dirname(__file__)), ".env"))
+agents_sdk_config = load_configuration_from_env(dict(environ))
+
+STORAGE = MemoryStorage()
+CONNECTION_MANAGER = MsalConnectionManager(**agents_sdk_config)
+ADAPTER = CloudAdapter(connection_manager=CONNECTION_MANAGER)
+
+# Auth handlers are configured in .env, not here:
+#   AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__<name>__SETTINGS__AZUREBOTOAUTHCONNECTIONNAME
+AUTH_HANDLER_IDS = tuple(agents_sdk_config.get("AGENTAPPLICATION", {}).get("USERAUTHORIZATION", {}).get("HANDLERS", {}))
+
+AGENT_SDK_APP = AgentApplication[TurnState](
+    options=ApplicationOptions(storage=STORAGE, adapter=ADAPTER),
+    connection_manager=CONNECTION_MANAGER,
+    **agents_sdk_config,
+)
+
+
+def _bypass_rules(context: TurnContext) -> bool:
+    activity = context.activity
+    return activity.type == ActivityTypes.invoke and (activity.name or "").lower().startswith("signin/")
+
+
+TEAMS_APP = use_teams_sdk(AGENT_SDK_APP, CONNECTION_MANAGER, _bypass_rules)
+
+
+@AGENT_SDK_APP.error
+async def _on_error(context: TurnContext, error: Exception):
+    log.exception("Unhandled error: %s", error)
+    await context.send_activity(f"⚠️ {type(error).__name__}: {error}")
+
+
+# ═══════════════════════ Teams SDK routes (teams.py) ═══════════════════════
+
+
+@TEAMS_APP.on_message_pattern(_command("help"))
+async def _help(ctx: ActivityContext[MessageActivity]):
+    await ctx.send(MessageActivityInput().add_card(help_card()))
+
+
+@TEAMS_APP.on_message_pattern(_command("react"))
+async def _react(ctx: ActivityContext[MessageActivity]):
+    response = await ctx.send("React to this message! I'll add 👍 and remove it.")
+    conv_id = ctx.activity.conversation.id
+    try:
+        await ctx.api.conversations.add_reaction(conv_id, response.id, "like")
+        await asyncio.sleep(2)
+        await ctx.api.conversations.delete_reaction(conv_id, response.id, "like")
+    except Exception:
+        log.exception("react: reactions API call failed")
+
+
+@TEAMS_APP.on_message_pattern(_command("quote"))
+async def _quote(ctx: ActivityContext[MessageActivity]):
+    await ctx.reply("Quoting your message!")
+
+
+@TEAMS_APP.on_message_pattern(_command("targeted"))
+async def _targeted(ctx: ActivityContext[MessageActivity]):
+    sender = ctx.activity.from_
+    targeted_msg = MessageActivityInput(text="👁️ This message is only visible to you.").with_recipient(
+        Account(id=sender.id, name=sender.name), is_targeted=True
+    )
+    await ctx.send(targeted_msg)
+
+
+@TEAMS_APP.on_message_pattern(_command("task"))
+async def _task(ctx: ActivityContext[MessageActivity]):
+    """Send a card whose button opens a dialog (task/fetch → task/submit)."""
+    await ctx.send(MessageActivityInput().add_card(task_launcher_card()))
+
+
+@TEAMS_APP.on_dialog_open
+async def _on_task_fetch(
+    ctx: ActivityContext[TaskFetchInvokeActivity],
+) -> TaskModuleInvokeResponse:
+    return TaskModuleInvokeResponse(
+        task=TaskModuleContinueResponse(
+            value=CardTaskModuleTaskInfo(
+                title="Sample Task Module",
+                card=card_attachment(AdaptiveCardAttachment(content=task_form_card())),
+            )
+        )
+    )
+
+
+@TEAMS_APP.on_dialog_submit
+async def _on_task_submit(
+    ctx: ActivityContext[TaskSubmitInvokeActivity],
+) -> TaskModuleInvokeResponse:
+    data = ctx.activity.value.data
+    await ctx.send(f"[Teams SDK] Task module submitted. Data: {data}")
+    return TaskModuleInvokeResponse(task=TaskModuleMessageResponse(value="Done."))
+
+
+@TEAMS_APP.on_message_reaction
+async def _on_message_reaction(ctx: ActivityContext[MessageReactionActivity]):
+    added = [r.type for r in ctx.activity.reactions_added or []]
+    removed = [r.type for r in ctx.activity.reactions_removed or []]
+    await ctx.send(f"[Teams SDK] Reactions: added={added} removed={removed}")
+
+
+# ═════════════════════ Agents SDK routes (AgentApplication) ═════════════════════
+
+
+@AGENT_SDK_APP.message(_command("help"))
+async def _help_non_teams(context: TurnContext, _state: TurnState):
+    await context.send_activity(
+        "[Agent SDK] Commands: help, channel, whoami, mail, signout, agents sdk react, agents sdk proactive.\n"
+    )
+
+
+@AGENT_SDK_APP.message(_command("channel"))
+async def _channel(context: TurnContext, _state: TurnState):
+    via = (
+        "Teams turn with no matching teams.py route → fell through"
+        if is_teams_channel(context.activity)
+        else "non-Teams channel → passed straight through"
+    )
+    await context.send_activity(f"[Agent SDK] channelId={context.activity.channel_id} ({via})")
+
+
+@AGENT_SDK_APP.message(_command("agents sdk react"))
+async def _agents_sdk_react(context: TurnContext, _state: TurnState):
+    if not is_teams_channel(context.activity):
+        await context.send_activity(
+            f"[Agent SDK] 'agents sdk react' needs the Teams reactions API; "
+            f"channelId={context.activity.channel_id} returns 404 for it."
+        )
+        return
+    response = await context.send_activity("[Agent SDK] Adding then removing 👍 via teams.py API client…")
+    conv_id = context.activity.conversation.id
+    api = ApiClient(service_url=context.activity.service_url, options=TEAMS_APP.api.http)
+    try:
+        await api.conversations.add_reaction(conv_id, response.id, "like")
+        await asyncio.sleep(2)
+        await api.conversations.delete_reaction(conv_id, response.id, "like")
+    except Exception:
+        log.exception("agents sdk react: reactions API call failed")
+
+
+@AGENT_SDK_APP.message(_command("agents sdk proactive"))
+async def _agents_sdk_proactive(context: TurnContext, _state: TurnState):
+    conv_id = context.activity.conversation.id
+    api = ApiClient(service_url=context.activity.service_url, options=TEAMS_APP.api.http)
+    bot = context.activity.recipient
+    outgoing = MessageActivityInput().add_text("[Teams SDK] Proactive message triggered from an Agents SDK handler!")
+    # Bypassing teams.py's ActivitySender means nothing populates from_, and Direct Line
+    # rejects the send without it.
+    outgoing.from_ = Account(id=bot.id, name=bot.name)
+    await api.conversations.create_activity(conv_id, outgoing)
+
+
+# ═══════════════════════════ Authentication ═══════════════════════════
+# Both handlers use the same AAD app but different ABS connections, so each holds its own
+# token — signing in for one does not satisfy the other.
+
+
+async def _graph_get(context: TurnContext, handler: str, resource: str):
+    """GET a Graph resource with the token cached for `handler`. None on failure."""
+    token = await AGENT_SDK_APP.auth.get_token(context, handler)
+    if not token or not token.token:
+        await context.send_activity(f"[Agent SDK] No token for the '{handler}' handler.")
+        return None
+
+    headers = {"Authorization": f"Bearer {token.token}"}
+    async with ClientSession() as session:
+        async with session.get(f"{GRAPH_BASE_URL}{resource}", headers=headers) as resp:
+            body = await resp.json()
+            if resp.status != 200:
+                detail = body.get("error", {}).get("message", body)
+                await context.send_activity(f"[Agent SDK] Graph {resource} returned {resp.status}: {detail}")
+                return None
+            return body
+
+
+@AGENT_SDK_APP.message(_command("whoami"), auth_handlers=["graphuser"])
+async def _whoami(context: TurnContext, _state: TurnState):
+    # Sign-in already completed by the time this runs, so get_token reads from cache.
+    me = await _graph_get(context, "graphuser", "/me")
+    if me:
+        await context.send_activity(
+            f"[Agent SDK] {me.get('displayName')} ({me.get('userPrincipalName')})\n"
+            f"Handler 'graphuser' — scope User.Read."
+        )
+
+
+@AGENT_SDK_APP.message(_command("mail"), auth_handlers=["graphmail"])
+async def _mail(context: TurnContext, _state: TurnState):
+    data = await _graph_get(context, "graphmail", "/me/messages?$top=3&$select=subject,receivedDateTime")
+    if data is None:
+        return
+    messages = data.get("value", [])
+    if not messages:
+        await context.send_activity("[Agent SDK] Mailbox is empty.")
+        return
+    lines = "\n".join(f"• {m.get('subject') or '(no subject)'}" for m in messages)
+    await context.send_activity(
+        f"[Agent SDK] Latest {len(messages)} message(s):\n{lines}\nHandler 'graphmail' — scopes User.Read + Mail.Read."
+    )
+
+
+@AGENT_SDK_APP.message(_command("signout"))
+async def _signout(context: TurnContext, _state: TurnState):
+    for handler in AUTH_HANDLER_IDS:
+        await AGENT_SDK_APP.auth.sign_out(context, handler)
+    await context.send_activity(f"[Agent SDK] Signed out of: {', '.join(AUTH_HANDLER_IDS)}.")
+
+
+# Every OAuth card is rendered with the same fixed "Sign in" text, so these callbacks are
+# the only way to tell which connection a prompt belonged to.
+async def _on_sign_in_success(context: TurnContext, _state: TurnState, handler_id: str | None = None):
+    await context.send_activity(f"[Agent SDK] Signed in via '{handler_id}'.")
+
+
+async def _on_sign_in_failure(context: TurnContext, _state: TurnState, handler_id: str | None = None):
+    await context.send_activity(f"[Agent SDK] Sign-in failed for '{handler_id}'.")
+
+
+AGENT_SDK_APP.auth.on_sign_in_success(_on_sign_in_success)
+AGENT_SDK_APP.auth.on_sign_in_failure(_on_sign_in_failure)
+
+
+# Sign-in cannot complete on email: Azure Bot Service flattens cards into a static image,
+# so the button is inert. A started flow would then swallow every later turn before
+# routing, leaving the mailbox silent. These routes outrank the two above and decline, so
+# no flow ever begins.
+#
+# signout is declined here too. Tokens are keyed by (channelId, userId, connectionName),
+# and the email identity (an SMTP address) never holds one, so signing out would always
+# report success for zero work — and could never reach a token held on Teams anyway.
+NO_AUTH_CHANNELS = {Channels.email}
+
+
+def _blocked_auth_selector(name: str):
+    pattern = _command(name)
+
+    def selector(context: TurnContext) -> bool:
+        return (
+            context.activity.type == ActivityTypes.message
+            and context.activity.channel_id in NO_AUTH_CHANNELS
+            and re.fullmatch(pattern, context.activity.text or "") is not None
+        )
+
+    return selector
+
+
+async def _decline_auth(context: TurnContext, _state: TurnState):
+    await context.send_activity(
+        f"[Agent SDK] Sign-in isn't supported on {context.activity.channel_id} — the OAuth "
+        "card renders as a static image here, so it can't be clicked. Tokens are scoped per "
+        "channel, so there is nothing to sign in or out of on this one. "
+        "Try whoami / mail on Teams or Web Chat."
+    )
+
+
+for _name in ("whoami", "mail", "signout"):
+    AGENT_SDK_APP.add_route(_blocked_auth_selector(_name), _decline_auth, rank=RouteRank.FIRST)
+
+
+# ═══════════════════════════ Fallthrough ═══════════════════════════
+
+
+@AGENT_SDK_APP.activity("message", rank=RouteRank.LAST)
+async def _echo(context: TurnContext, _state: TurnState):
+    text = (context.activity.text or "").strip()
+    first_line = next((ln.strip() for ln in text.splitlines() if ln.strip()), "")
+    if first_line != text:
+        text = f"{first_line} […]"
+    await context.send_activity(f"[Agent SDK] ({context.activity.channel_id}) You said: {text}")
+
+
+# ═══════════════════════════ HTTP wiring ═══════════════════════════
+
+
+async def _entry_point(req: web.Request) -> web.Response:
+    response = await start_agent_process(req, req.app["agent_sdk_app"], req.app["adapter"])
+    return response if response is not None else web.Response(status=201)
+
+
+if __name__ == "__main__":
+    APP = web.Application(middlewares=[jwt_authorization_middleware])
+    APP.router.add_post("/api/messages", _entry_point)
+    APP["agent_sdk_app"] = AGENT_SDK_APP
+    APP["adapter"] = ADAPTER
+    APP["agent_configuration"] = CONNECTION_MANAGER.get_default_connection_configuration()
+
+    web.run_app(
+        APP,
+        host=environ.get("HOST", "localhost"),
+        port=int(environ.get("PORT", "3978")),
+    )

--- a/examples/m365extensions/tools/webchat/README.md
+++ b/examples/m365extensions/tools/webchat/README.md
@@ -1,0 +1,37 @@
+# Web Chat / Direct Line harness
+
+A small Direct Line client for exercising the sample on a **non-Teams** channel, so you can
+see the half of the extension that Teams can't show: activities that pass straight
+through to the Agents SDK app.
+
+Nothing here is sample-specific — it drives whichever sample is currently bound to the bot
+registration's endpoint.
+
+## Setup
+
+The bot itself is created with the [Teams CLI](https://microsoft.github.io/teams-sdk/cli/) — see the
+[sample setup](../../README.md#setup). Use `teams app create --azure …` so the bot has an Azure Bot
+resource, which is what exposes the Direct Line channel.
+
+Direct Line is an Azure Bot channel, so its secret is fetched with the Azure CLI (the Teams CLI has
+no Direct Line command). Direct Line is enabled by default on the Azure Bot registration:
+
+```bash
+az bot directline show --name <botName> --resource-group <rg> --with-secrets -o json
+```
+
+Then either export it or drop it in `.env` next to these files (gitignored):
+
+```
+DIRECTLINE_SECRET=<secret>
+```
+
+## Browser UI
+
+```bash
+python tools/webchat/serve.py        # http://localhost:3000
+```
+
+Serves `index.html` plus a `/api/token` endpoint that exchanges the Direct Line *secret* for
+a short-lived *token*, so the secret stays in this process and never reaches the browser.
+Use this when you want to see Adaptive Cards render.

--- a/examples/m365extensions/tools/webchat/index.html
+++ b/examples/m365extensions/tools/webchat/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Teams SDK middleware — Web Chat</title>
+  <title>M365 Extension — Web Chat</title>
   <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
   <style>
     html,

--- a/examples/m365extensions/tools/webchat/index.html
+++ b/examples/m365extensions/tools/webchat/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <title>Teams SDK middleware — Web Chat</title>
+  <script crossorigin="anonymous" src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+  <style>
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+      font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      background: #f5f5f5;
+    }
+
+    header {
+      padding: 12px 16px;
+      background: #5b5fc7;
+      color: #fff;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 600;
+    }
+
+    header p {
+      margin: 4px 0 0;
+      font-size: 12px;
+      opacity: 0.85;
+    }
+
+    #webchat {
+      flex: 1;
+      min-height: 0;
+    }
+
+    #error {
+      display: none;
+      padding: 12px 16px;
+      color: #a80000;
+      background: #fde7e9;
+      font-size: 13px;
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <h1>M365 Extension — Web Chat (Direct Line)</h1>
+    <p>
+      Non-Teams channel: every turn passes straight through to the Agents SDK.
+      Try <code>channel</code>, <code>help</code>, or any text.
+    </p>
+  </header>
+  <div id="error"></div>
+  <div id="webchat" role="main"></div>
+
+  <script>
+    (async function () {
+      const errorEl = document.getElementById('error');
+      try {
+        const res = await fetch('/api/token');
+        if (!res.ok) throw new Error(`token endpoint returned ${res.status}: ${await res.text()}`);
+        const { token } = await res.json();
+        if (!token) throw new Error('token endpoint returned no token');
+
+        window.WebChat.renderWebChat(
+          {
+            directLine: window.WebChat.createDirectLine({ token }),
+            styleOptions: {
+              backgroundColor: '#f5f5f5',
+              bubbleBackground: '#ffffff',
+              bubbleFromUserBackground: '#e8ebfa',
+            },
+          },
+          document.getElementById('webchat')
+        );
+      } catch (err) {
+        errorEl.style.display = 'block';
+        errorEl.textContent =
+          'Web Chat failed to start.\n' +
+          err.message +
+          '\n\nIs tools/webchat/serve.py running, and is DIRECTLINE_SECRET set?';
+      }
+    })();
+  </script>
+</body>
+
+</html>

--- a/examples/m365extensions/tools/webchat/serve.py
+++ b/examples/m365extensions/tools/webchat/serve.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+HERE = Path(__file__).parent
+TOKEN_URL = "https://directline.botframework.com/v3/directline/tokens/generate"
+PORT = int(os.environ.get("PORT", "3000"))
+
+
+def _load_secret() -> str:
+    secret = os.environ.get("DIRECTLINE_SECRET", "")
+    env_file = HERE / ".env"
+    if not secret and env_file.exists():
+        for line in env_file.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("DIRECTLINE_SECRET="):
+                secret = line.split("=", 1)[1].strip()
+                break
+    if not secret:
+        raise SystemExit(
+            "DIRECTLINE_SECRET is not set. Export it, or write it to "
+            f"{env_file} as DIRECTLINE_SECRET=<secret>.\n"
+            "Fetch it with:\n"
+            "  az bot directline show --name <botName> --resource-group <rg> "
+            "--with-secrets -o json"
+        )
+    return secret
+
+
+SECRET = _load_secret()
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send(self, status: int, body: bytes, content_type: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler API
+        if self.path.startswith("/api/token"):
+            req = urllib.request.Request(
+                TOKEN_URL,
+                method="POST",
+                data=b"",
+                headers={"Authorization": f"Bearer {SECRET}"},
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    payload = resp.read()
+            except Exception as exc:  # surface the failure in the browser
+                self._send(502, json.dumps({"error": str(exc)}).encode(), "application/json")
+                return
+            self._send(200, payload, "application/json")
+            return
+
+        if self.path in ("/", "/index.html"):
+            self._send(200, (HERE / "index.html").read_bytes(), "text/html; charset=utf-8")
+            return
+
+        self._send(404, b"not found", "text/plain")
+
+    def log_message(self, fmt: str, *args) -> None:
+        print(f"[webchat] {fmt % args}")
+
+
+if __name__ == "__main__":
+    print(f"[webchat] serving http://localhost:{PORT}  (Ctrl+C to stop)")
+    HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()

--- a/examples/m365extensions/tools/webchat/serve.py
+++ b/examples/m365extensions/tools/webchat/serve.py
@@ -20,7 +20,7 @@ def _load_secret() -> str:
     secret = os.environ.get("DIRECTLINE_SECRET", "")
     env_file = HERE / ".env"
     if not secret and env_file.exists():
-        for line in env_file.read_text().splitlines():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
             line = line.strip()
             if line.startswith("DIRECTLINE_SECRET="):
                 secret = line.split("=", 1)[1].strip()

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -244,11 +244,23 @@ def test_sdk_source_does_not_import_microsoft_otel_or_agents_sdk():
         "microsoft_agents",
     )
 
+    # m365extensions is a deliberate Agents SDK bridge package; it is expected
+    # to depend on the Agents SDK and is therefore exempt from this guard.
+    exempt_packages = {"m365extensions"}
+
+    def _is_exempt(path: Path) -> bool:
+        rel = path.relative_to(packages_dir)
+        return rel.parts[0] in exempt_packages
+
     for source_file in packages_dir.glob("*/src/**/*.py"):
+        if _is_exempt(source_file):
+            continue
         source = source_file.read_text(encoding="utf-8")
         assert not any(forbidden in source for forbidden in forbidden_imports), source_file
 
     for pyproject_file in packages_dir.glob("*/pyproject.toml"):
+        if _is_exempt(pyproject_file):
+            continue
         manifest = pyproject_file.read_text(encoding="utf-8")
         assert "microsoft-opentelemetry" not in manifest
         assert "microsoft-agents" not in manifest

--- a/packages/m365extensions/README.md
+++ b/packages/m365extensions/README.md
@@ -1,0 +1,17 @@
+# Microsoft Teams M365 Extensions
+
+<p>
+    <a href="https://pypi.org/project/microsoft-teams-m365extensions" target="_blank">
+        <img src="https://img.shields.io/pypi/v/microsoft-teams-m365extensions" />
+    </a>
+    <a href="https://pypi.org/project/microsoft-teams-m365extensions" target="_blank">
+        <img src="https://img.shields.io/pypi/dw/microsoft-teams-m365extensions" />
+    </a>
+</p>
+
+This extension package bridges the [Microsoft Teams SDK for Python](https://github.com/microsoft/teams.py) into an [Agents SDK](https://github.com/microsoft/Agents) `AgentApplication`. It installs a middleware that routes Teams turns to a teams.py `App` while letting every other channel — and unmatched Teams turns — fall through to existing Agents SDK handlers.
+
+<a href="https://microsoft.github.io/teams-sdk" target="_blank">
+    <img src="https://img.shields.io/badge/📖 Getting Started-blue?style=for-the-badge" />
+</a>
+

--- a/packages/m365extensions/pyproject.toml
+++ b/packages/m365extensions/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "microsoft-teams-m365extensions"
+dynamic = ["version"]
+description = "Extension package that embeds the Teams SDK inside an M365 Agents Application."
+readme = "README.md"
+repository = "https://github.com/microsoft/teams.py"
+keywords = ["microsoft", "teams", "ai", "bot", "agents", "m365"]
+license = "MIT"
+authors = [{ name = "Microsoft", email = "TeamsAISDKFeedback@microsoft.com" }]
+requires-python = ">=3.11,<4.0"
+dependencies = [
+    "microsoft-agents-activity>=1.3.0",
+    "microsoft-agents-hosting-core>=1.3.0",
+    "microsoft-teams-api",
+    "microsoft-teams-apps",
+]
+
+[project.urls]
+Homepage = "https://github.com/microsoft/teams.py/tree/main/packages/m365extensions/src/microsoft_teams/m365extensions"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling", "hatch-teams-build"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "teams-build"
+
+[tool.hatch.metadata.hooks.teams-build]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/microsoft_teams", "src/microsoft"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src"]
+
+[tool.uv.sources]
+microsoft-teams-api = { workspace = true }
+microsoft-teams-apps = { workspace = true }

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/__init__.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/__init__.py
@@ -1,0 +1,17 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+from .credentials import make_agent_sdk_token_provider
+from .install import use_teams_sdk
+from .middleware import TeamsMiddleware, is_teams_channel
+
+__all__ = [
+    "TeamsMiddleware",
+    "is_teams_channel",
+    "make_agent_sdk_token_provider",
+    "use_teams_sdk",
+]

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/context.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/context.py
@@ -1,0 +1,15 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+
+from microsoft_agents.hosting.core.turn_context import TurnContext
+
+# Internal only: the middleware sets this for the duration of a teams.py-handled
+# turn so ``credentials._select_provider`` can pick the connection that matches
+# the inbound identity. It is deliberately not exposed as a public accessor.
+agent_sdk_context: ContextVar[TurnContext] = ContextVar("teams_sdk.agent_sdk_context")

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/credentials.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/credentials.py
@@ -1,0 +1,88 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Awaitable, Callable, Optional, Union
+
+from microsoft_agents.hosting.core.channel_adapter import ChannelAdapter
+
+from .context import agent_sdk_context
+
+logger = logging.getLogger(__name__)
+
+# Routing key used to select the connection that mints agentic tokens,
+# mirroring the Agents SDK's ``get_token_provider(identity, "agentic")``
+# convention (and the ``CONNECTIONSMAP ... SERVICEURL=agentic`` entry). When no
+# dedicated agentic connection is registered the lookup falls back to the
+# default connection, which is sufficient for the single-connection case.
+_AGENTIC_ROUTING_KEY = "agentic"
+
+
+def make_agent_sdk_token_provider(
+    connection_manager: Any,
+) -> Callable[..., Awaitable[str]]:
+    async def _token(
+        scope: Union[str, list[str]],
+        tenant_id: Optional[str] = None,
+        *,
+        agentic_identity: Optional[Any] = None,
+    ) -> str:
+        scopes = [scope] if isinstance(scope, str) else list(scope)
+
+        agentic_user_id = getattr(agentic_identity, "agentic_user_id", None)
+        if agentic_identity is not None and agentic_user_id:
+            provider = _select_provider(connection_manager, _AGENTIC_ROUTING_KEY)
+            token = await provider.get_agentic_user_token(
+                getattr(agentic_identity, "tenant_id", None) or tenant_id,
+                agentic_identity.agentic_app_id,
+                agentic_user_id,
+                scopes,
+            )
+            if not token:
+                raise RuntimeError(
+                    "Agents SDK connection returned no agentic user token; the "
+                    "connection must be an MSAL provider with agentic support."
+                )
+            return token
+
+        # Non-agentic path: outbound Bot Framework Service token. Strip
+        # ".default" off the first scope to derive the resource_url MSAL wants
+        # — '.default' is appended back internally.
+        first = scopes[0] if scopes else ""
+        resource_url = first[: -len("/.default")] if first.endswith("/.default") else first
+
+        provider = _select_provider(connection_manager, resource_url)
+        result = provider.get_access_token(resource_url, scopes)
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    return _token
+
+
+def _select_provider(connection_manager: Any, service_url: str) -> Any:
+    context = agent_sdk_context.get(None)
+    if context is None:
+        return connection_manager.get_default_connection()
+
+    claims_identity = context.turn_state.get(ChannelAdapter.AGENT_IDENTITY_KEY)
+    if claims_identity is None:
+        return connection_manager.get_default_connection()
+
+    target_url = service_url or (context.activity.service_url or "")
+    if not target_url:
+        return connection_manager.get_default_connection()
+
+    try:
+        return connection_manager.get_token_provider(claims_identity, target_url)
+    except Exception as exc:  # noqa: BLE001 — degrade gracefully on lookup failure
+        logger.debug(
+            "connection lookup failed (%s); using default connection",
+            exc,
+        )
+        return connection_manager.get_default_connection()

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/install.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/install.py
@@ -1,0 +1,38 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from microsoft_agents.hosting.core.app.agent_application import AgentApplication
+from microsoft_agents.hosting.core.authorization.connections import Connections
+from microsoft_agents.hosting.core.turn_context import TurnContext
+from microsoft_teams.apps import App
+
+from .credentials import make_agent_sdk_token_provider
+from .middleware import TeamsMiddleware
+
+
+def use_teams_sdk(
+    app: AgentApplication[Any],
+    connection_manager: Connections,
+    should_bypass_teams: Optional[Callable[[TurnContext], bool]] = None,
+    **teams_app_kwargs: Any,
+) -> App:
+    reserved = {"client_id", "tenant_id", "token"} & teams_app_kwargs.keys()
+    if reserved:
+        raise TypeError(f"use_teams_sdk owns {sorted(reserved)}; remove from teams_app_kwargs.")
+
+    auth = connection_manager.get_default_connection_configuration()
+    teams_app = App(
+        client_id=auth.CLIENT_ID,
+        tenant_id=auth.TENANT_ID,
+        token=make_agent_sdk_token_provider(connection_manager),
+        **teams_app_kwargs,
+    )
+
+    app.adapter.use(TeamsMiddleware(teams_app, should_bypass_teams))
+    return teams_app

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/middleware.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/middleware.py
@@ -75,7 +75,9 @@ class TeamsMiddleware(Middleware):
 
         ctx_token = agent_sdk_context.set(context)
         try:
-            invoke_response = await self._teams_app.activity_processor.process_activity(plugins=self._teams_app.plugins, event=event)
+            invoke_response = await self._teams_app.activity_processor.process_activity(
+                plugins=self._teams_app.plugins, event=event
+            )
         finally:
             agent_sdk_context.reset(ctx_token)
 

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/middleware.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/middleware.py
@@ -75,7 +75,7 @@ class TeamsMiddleware(Middleware):
 
         ctx_token = agent_sdk_context.set(context)
         try:
-            invoke_response = await self._teams_app.activity_processor.process_activity(plugins=[], event=event)
+            invoke_response = await self._teams_app.activity_processor.process_activity(plugins=self._teams_app.plugins, event=event)
         finally:
             agent_sdk_context.reset(ctx_token)
 

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/middleware.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/middleware.py
@@ -1,0 +1,116 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional, cast
+
+from microsoft_agents.activity import Activity, ActivityTypes, InvokeResponse
+from microsoft_agents.hosting.core.middleware_set import Middleware
+from microsoft_agents.hosting.core.turn_context import TurnContext
+from microsoft_teams.api import ActivityTypeAdapter
+from microsoft_teams.apps import App
+from microsoft_teams.apps.events.types import ActivityEvent, CoreActivity
+
+from .context import agent_sdk_context
+from .token import TeamsToken
+
+TEAMS_CHANNEL_ID = "msteams"
+
+
+def is_teams_channel(activity: Activity) -> bool:
+    """True for Teams turns, including sub-channels like ``msteams:COPILOT``."""
+    channel_id: Optional[str] = activity.channel_id
+    if not channel_id:
+        return False
+
+    channel = getattr(channel_id, "channel", None)
+    if channel is None:
+        channel = str(channel_id).split(":", 1)[0]
+    return channel == TEAMS_CHANNEL_ID
+
+
+class TeamsMiddleware(Middleware):
+    def __init__(
+        self,
+        teams_app: App,
+        should_bypass_teams: Optional[Callable[[TurnContext], bool]] = None,
+    ) -> None:
+        self._teams_app = teams_app
+        self._should_bypass_teams = should_bypass_teams
+
+    async def on_turn(
+        self,
+        context: TurnContext,
+        logic: Callable[[TurnContext], Awaitable[None]],
+    ) -> None:
+        activity: Activity = context.activity
+        if not is_teams_channel(activity):
+            await logic(context)
+            return
+
+        # Idempotent — App tracks _initialized internally. Run on every Teams
+        # turn so AgentApplication handlers can safely call into TEAMS_APP
+        # (e.g. ``TEAMS_APP.send`` for proactive sends) even when no teams.py
+        # route matched this turn.
+        await self._teams_app.initialize()
+
+        if self._should_bypass_teams is not None and self._should_bypass_teams(context):
+            await logic(context)
+            return
+
+        core_activity = self._translate_inbound(activity)
+
+        if not self._teams_app.router.select_handlers(core_activity):
+            # No teams.py route matches; let AgentApplication try its handlers.
+            await logic(context)
+            return
+
+        event = ActivityEvent(
+            body=cast(CoreActivity, core_activity),
+            token=TeamsToken.from_activity(activity),
+        )
+
+        ctx_token = agent_sdk_context.set(context)
+        try:
+            invoke_response = await self._teams_app.activity_processor.process_activity(plugins=[], event=event)
+        finally:
+            agent_sdk_context.reset(ctx_token)
+
+        if activity.type == ActivityTypes.invoke:
+            await self._propagate_invoke_response(context, invoke_response)
+
+    @staticmethod
+    def _translate_inbound(activity: Activity):
+        payload: str = activity.model_dump_json(by_alias=True, exclude_none=True)
+        return ActivityTypeAdapter.validate_json(payload)
+
+    @staticmethod
+    async def _propagate_invoke_response(context: TurnContext, invoke_response: object) -> None:
+        if invoke_response is None:
+            return
+
+        status: Any
+        body: Any
+        if isinstance(invoke_response, dict):
+            response = cast("dict[str, Any]", invoke_response)
+            status = response.get("status")
+            body = response.get("body")
+        else:
+            status = getattr(invoke_response, "status", None)
+            body = getattr(invoke_response, "body", None)
+
+        if status is None:
+            return
+
+        if hasattr(body, "model_dump"):
+            body = body.model_dump(mode="json", by_alias=True, exclude_none=True)
+
+        await context.send_activity(
+            Activity(
+                type=ActivityTypes.invoke_response,
+                value=InvokeResponse(status=status, body=body),
+            )
+        )

--- a/packages/m365extensions/src/microsoft_teams/m365extensions/token.py
+++ b/packages/m365extensions/src/microsoft_teams/m365extensions/token.py
@@ -1,0 +1,83 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from microsoft_agents.activity import Activity
+from microsoft_teams.api.auth.caller import CallerIds, CallerType
+from microsoft_teams.api.auth.token import TokenProtocol
+
+
+class TeamsToken(TokenProtocol):
+    """A minimal TokenProtocol synthesized from an Agents SDK Activity."""
+
+    def __init__(
+        self,
+        *,
+        app_id: str,
+        tenant_id: Optional[str],
+        service_url: str,
+        app_display_name: Optional[str] = None,
+    ) -> None:
+        self._app_id = app_id
+        self._tenant_id = tenant_id
+        self._service_url = service_url.rstrip("/") if service_url else ""
+        self._app_display_name = app_display_name
+        # Synthetic expiration ~1h out so is_expired() reports False.
+        self._expiration_ms = int(time.time() * 1000) + 60 * 60 * 1000
+
+    @classmethod
+    def from_activity(cls, activity: Activity) -> "TeamsToken":
+        recipient = getattr(activity, "recipient", None)
+        conversation = getattr(activity, "conversation", None)
+        return cls(
+            app_id=getattr(recipient, "id", "") or "",
+            app_display_name=getattr(recipient, "name", None),
+            tenant_id=getattr(conversation, "tenant_id", None),
+            service_url=getattr(activity, "service_url", "") or "",
+        )
+
+    # ── TokenProtocol surface ──────────────────────────────────────────
+
+    @property
+    def app_id(self) -> str:
+        return self._app_id
+
+    @property
+    def app_display_name(self) -> Optional[str]:
+        return self._app_display_name
+
+    @property
+    def tenant_id(self) -> Optional[str]:
+        return self._tenant_id
+
+    @property
+    def service_url(self) -> str:
+        return self._service_url or "https://smba.trafficmanager.net/teams"
+
+    @property
+    def from_(self) -> CallerType:
+        return "bot" if self._app_id else "azure"
+
+    @property
+    def from_id(self) -> str:
+        if self.from_ == "bot":
+            return f"{CallerIds.BOT}:{self._app_id}"
+        return CallerIds.AZURE
+
+    @property
+    def expiration(self) -> Optional[int]:
+        return self._expiration_ms
+
+    def is_expired(self, buffer_ms: int = 5 * 60 * 1000) -> bool:
+        return self._expiration_ms < (time.time() * 1000) + buffer_ms
+
+    def __str__(self) -> str:
+        # No real JWT is forwarded; a tagged sentinel is more honest than '' and
+        # cannot be mistaken for a signable bearer.
+        return f"teams-sdk-synthetic://app/{self._app_id}"

--- a/packages/m365extensions/tests/test_m365extensions.py
+++ b/packages/m365extensions/tests/test_m365extensions.py
@@ -4,10 +4,15 @@ Licensed under the MIT License.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from microsoft_agents.activity import Activity, ActivityTypes
 from microsoft_teams.api.auth.caller import CallerIds
 from microsoft_teams.m365extensions import is_teams_channel, use_teams_sdk
+from microsoft_teams.m365extensions.context import agent_sdk_context
+from microsoft_teams.m365extensions.credentials import make_agent_sdk_token_provider
+from microsoft_teams.m365extensions.middleware import TeamsMiddleware
 from microsoft_teams.m365extensions.token import TeamsToken
 
 
@@ -90,3 +95,209 @@ class TestUseTeamsSdkGuards:
         # anything off app / connection_manager, so plain objects are enough.
         with pytest.raises(TypeError, match=reserved_kwarg):
             use_teams_sdk(object(), object(), **{reserved_kwarg: "override"})
+
+
+def _teams_activity(activity_type: ActivityTypes = ActivityTypes.message, *, channel_id: str = "msteams") -> Activity:
+    """A minimal inbound Activity the middleware can translate and route."""
+    kwargs: dict[str, object] = dict(
+        type=activity_type,
+        id="act-1",
+        channel_id=channel_id,
+        text="help",
+        recipient={"id": "bot-app-id", "name": "MyBot"},
+        conversation={"id": "conv-1", "tenant_id": "tenant-1"},
+        service_url="https://smba.example.com/teams/",
+        from_property={"id": "user-1"},
+    )
+    if activity_type == ActivityTypes.invoke:
+        kwargs["name"] = "task/fetch"
+        kwargs["value"] = {"data": {}}
+    return Activity(**kwargs)
+
+
+class _FakeContext:
+    """Stands in for an Agents SDK TurnContext across the middleware surface."""
+
+    def __init__(self, activity: Activity) -> None:
+        self.activity = activity
+        self.turn_state: dict[str, object] = {}
+        self.send_activity = AsyncMock()
+
+
+def _fake_app(*, has_route: bool, plugins: list[object], invoke_response: object = None) -> MagicMock:
+    """A teams.py ``App`` double exposing only what ``TeamsMiddleware`` touches."""
+    app = MagicMock()
+    app.initialize = AsyncMock()
+    app.plugins = plugins
+    app.router.select_handlers.return_value = ["handler"] if has_route else []
+    app.activity_processor.process_activity = AsyncMock(return_value=invoke_response)
+    return app
+
+
+class TestTeamsMiddlewareRouting:
+    """``TeamsMiddleware.on_turn`` routes Teams turns and short-circuits the rest."""
+
+    async def test_non_teams_channel_falls_through_untouched(self):
+        app = _fake_app(has_route=True, plugins=["p"])
+        logic = AsyncMock()
+
+        await TeamsMiddleware(app).on_turn(_FakeContext(_teams_activity(channel_id="webchat")), logic)
+
+        logic.assert_awaited_once()
+        # A non-Teams turn must never initialize or invoke the teams.py app.
+        app.initialize.assert_not_called()
+        app.activity_processor.process_activity.assert_not_called()
+
+    async def test_bypass_predicate_falls_through_after_initialize(self):
+        app = _fake_app(has_route=True, plugins=["p"])
+        logic = AsyncMock()
+        mw = TeamsMiddleware(app, should_bypass_teams=lambda _ctx: True)
+
+        await mw.on_turn(_FakeContext(_teams_activity()), logic)
+
+        logic.assert_awaited_once()
+        # initialize runs before the bypass check so proactive sends stay safe...
+        app.initialize.assert_awaited_once()
+        # ...but the bypassed turn is never handled by teams.py.
+        app.activity_processor.process_activity.assert_not_called()
+
+    async def test_no_matching_route_falls_through(self):
+        app = _fake_app(has_route=False, plugins=["p"])
+        logic = AsyncMock()
+
+        await TeamsMiddleware(app).on_turn(_FakeContext(_teams_activity()), logic)
+
+        logic.assert_awaited_once()
+        app.initialize.assert_awaited_once()
+        app.activity_processor.process_activity.assert_not_called()
+
+    async def test_matching_route_is_handled_by_teams_and_short_circuits(self):
+        app = _fake_app(has_route=True, plugins=["p"])
+        logic = AsyncMock()
+
+        await TeamsMiddleware(app).on_turn(_FakeContext(_teams_activity()), logic)
+
+        # A matched Teams route is handled by teams.py, not the host logic.
+        logic.assert_not_called()
+        app.activity_processor.process_activity.assert_awaited_once()
+        # The context var is always reset once the turn completes.
+        assert agent_sdk_context.get(None) is None
+
+    async def test_configured_plugins_are_propagated_to_process_activity(self):
+        # Regression: process_activity was called with plugins=[], which
+        # silently disabled every plugin configured on the embedded App.
+        plugins = [object(), object()]
+        app = _fake_app(has_route=True, plugins=plugins)
+
+        await TeamsMiddleware(app).on_turn(_FakeContext(_teams_activity()), AsyncMock())
+
+        _, kwargs = app.activity_processor.process_activity.await_args
+        assert kwargs["plugins"] is plugins
+
+    async def test_invoke_response_is_propagated_back(self):
+        response = SimpleNamespace(status=200, body={"ok": True})
+        app = _fake_app(has_route=True, plugins=[], invoke_response=response)
+        context = _FakeContext(_teams_activity(ActivityTypes.invoke))
+
+        await TeamsMiddleware(app).on_turn(context, AsyncMock())
+
+        context.send_activity.assert_awaited_once()
+        sent: Activity = context.send_activity.await_args.args[0]
+        assert sent.type == ActivityTypes.invoke_response
+        assert sent.value.status == 200
+        assert sent.value.body == {"ok": True}
+
+    async def test_message_turn_does_not_send_invoke_response(self):
+        app = _fake_app(has_route=True, plugins=[], invoke_response=SimpleNamespace(status=200, body=None))
+        context = _FakeContext(_teams_activity(ActivityTypes.message))
+
+        await TeamsMiddleware(app).on_turn(context, AsyncMock())
+
+        # Only invoke turns carry a response back through the pipeline.
+        context.send_activity.assert_not_called()
+
+
+class TestTokenProviderSelection:
+    """The token provider picks a connection based on the active turn identity."""
+
+    def _connection_manager(self, provider: MagicMock) -> MagicMock:
+        cm = MagicMock()
+        cm.get_default_connection.return_value = provider
+        cm.get_token_provider.return_value = provider
+        return cm
+
+    async def test_no_active_context_uses_default_connection(self):
+        provider = MagicMock()
+        provider.get_access_token.return_value = "tok"
+        cm = self._connection_manager(provider)
+
+        token = await make_agent_sdk_token_provider(cm)("https://graph.microsoft.com/.default")
+
+        assert token == "tok"
+        cm.get_default_connection.assert_called_once()
+        cm.get_token_provider.assert_not_called()
+        # ".default" is stripped to the resource_url MSAL expects.
+        provider.get_access_token.assert_called_once_with(
+            "https://graph.microsoft.com", ["https://graph.microsoft.com/.default"]
+        )
+
+    async def test_identity_context_selects_matching_token_provider(self):
+        provider = MagicMock()
+        provider.get_access_token.return_value = "tok"
+        cm = self._connection_manager(provider)
+
+        context = MagicMock()
+        context.turn_state.get.return_value = "claims-identity"
+        ctx_token = agent_sdk_context.set(context)
+        try:
+            await make_agent_sdk_token_provider(cm)("https://graph.microsoft.com/.default")
+        finally:
+            agent_sdk_context.reset(ctx_token)
+
+        cm.get_token_provider.assert_called_once_with("claims-identity", "https://graph.microsoft.com")
+        cm.get_default_connection.assert_not_called()
+
+    async def test_context_without_identity_uses_default_connection(self):
+        provider = MagicMock()
+        provider.get_access_token.return_value = "tok"
+        cm = self._connection_manager(provider)
+
+        context = MagicMock()
+        context.turn_state.get.return_value = None  # no AgentIdentity on this turn
+        ctx_token = agent_sdk_context.set(context)
+        try:
+            await make_agent_sdk_token_provider(cm)("https://graph.microsoft.com/.default")
+        finally:
+            agent_sdk_context.reset(ctx_token)
+
+        cm.get_default_connection.assert_called_once()
+        cm.get_token_provider.assert_not_called()
+
+    async def test_token_provider_lookup_failure_falls_back_to_default(self):
+        provider = MagicMock()
+        provider.get_access_token.return_value = "tok"
+        cm = self._connection_manager(provider)
+        cm.get_token_provider.side_effect = RuntimeError("lookup failed")
+
+        context = MagicMock()
+        context.turn_state.get.return_value = "claims-identity"
+        ctx_token = agent_sdk_context.set(context)
+        try:
+            token = await make_agent_sdk_token_provider(cm)("https://graph.microsoft.com/.default")
+        finally:
+            agent_sdk_context.reset(ctx_token)
+
+        assert token == "tok"
+        cm.get_default_connection.assert_called_once()
+
+    async def test_awaitable_access_token_is_awaited(self):
+        async def _async_token(*_args: object) -> str:
+            return "async-tok"
+
+        provider = MagicMock()
+        provider.get_access_token.return_value = _async_token()
+        cm = self._connection_manager(provider)
+
+        token = await make_agent_sdk_token_provider(cm)("https://graph.microsoft.com/.default")
+
+        assert token == "async-tok"

--- a/packages/m365extensions/tests/test_m365extensions.py
+++ b/packages/m365extensions/tests/test_m365extensions.py
@@ -1,0 +1,92 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from microsoft_teams.api.auth.caller import CallerIds
+from microsoft_teams.m365extensions import is_teams_channel, use_teams_sdk
+from microsoft_teams.m365extensions.token import TeamsToken
+
+
+class TestIsTeamsChannel:
+    """``is_teams_channel`` classifies inbound activities by channel."""
+
+    def test_plain_msteams_channel_is_teams(self):
+        assert is_teams_channel(SimpleNamespace(channel_id="msteams")) is True
+
+    def test_msteams_subchannel_is_teams(self):
+        # Sub-channels like ``msteams:COPILOT`` must still classify as Teams.
+        assert is_teams_channel(SimpleNamespace(channel_id="msteams:COPILOT")) is True
+
+    def test_channel_id_object_with_channel_attribute(self):
+        # Agents SDK may surface channel_id as an object exposing ``.channel``.
+        channel_id = SimpleNamespace(channel="msteams")
+        assert is_teams_channel(SimpleNamespace(channel_id=channel_id)) is True
+
+    def test_non_teams_channel_is_false(self):
+        assert is_teams_channel(SimpleNamespace(channel_id="webchat")) is False
+
+    def test_missing_channel_id_is_false(self):
+        assert is_teams_channel(SimpleNamespace(channel_id=None)) is False
+
+
+class TestTeamsToken:
+    """``TeamsToken`` projects the fields teams.py consumes off an Activity."""
+
+    def _bot_activity(self):
+        return SimpleNamespace(
+            recipient=SimpleNamespace(id="bot-app-id", name="MyBot"),
+            conversation=SimpleNamespace(tenant_id="tenant-1"),
+            service_url="https://smba.example.com/teams/",
+        )
+
+    def test_projects_bot_fields_from_activity(self):
+        token = TeamsToken.from_activity(self._bot_activity())
+        assert token.app_id == "bot-app-id"
+        assert token.app_display_name == "MyBot"
+        assert token.tenant_id == "tenant-1"
+
+    def test_service_url_trailing_slash_is_stripped(self):
+        token = TeamsToken.from_activity(self._bot_activity())
+        assert token.service_url == "https://smba.example.com/teams"
+
+    def test_bot_caller_classification(self):
+        token = TeamsToken.from_activity(self._bot_activity())
+        assert token.from_ == "bot"
+        assert token.from_id == f"{CallerIds.BOT}:bot-app-id"
+
+    def test_fresh_token_is_not_expired(self):
+        token = TeamsToken.from_activity(self._bot_activity())
+        assert token.is_expired() is False
+        assert token.expiration is not None
+
+    def test_str_is_tagged_sentinel_not_a_bearer(self):
+        token = TeamsToken.from_activity(self._bot_activity())
+        assert str(token) == "teams-sdk-synthetic://app/bot-app-id"
+
+    def test_missing_app_id_classifies_as_azure_with_service_url_fallback(self):
+        activity = SimpleNamespace(
+            recipient=SimpleNamespace(id=""),
+            conversation=SimpleNamespace(tenant_id=None),
+            service_url="",
+        )
+        token = TeamsToken.from_activity(activity)
+        assert token.app_id == ""
+        assert token.from_ == "azure"
+        assert token.from_id == CallerIds.AZURE
+        # Empty service_url falls back to the Bot Framework default endpoint.
+        assert token.service_url == "https://smba.trafficmanager.net/teams"
+
+
+class TestUseTeamsSdkGuards:
+    """``use_teams_sdk`` guards credentials it owns from being overridden."""
+
+    @pytest.mark.parametrize("reserved_kwarg", ["client_id", "tenant_id", "token"])
+    def test_reserved_kwargs_raise_before_touching_connection_manager(self, reserved_kwarg):
+        # Sentinels: the guard must reject reserved kwargs before it reads
+        # anything off app / connection_manager, so plain objects are enough.
+        with pytest.raises(TypeError, match=reserved_kwarg):
+            use_teams_sdk(object(), object(), **{reserved_kwarg: "override"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@
 "microsoft-teams-cards" = { workspace = true }
 "microsoft-teams-graph" = { workspace = true }
 "microsoft-teams-botbuilder" = { workspace = true }
+"microsoft-teams-m365extensions" = { workspace = true }
 "hatch-teams-build" = { path = "tools/hatch-teams-build" }
 
 [tool.uv.workspace]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -12,7 +12,8 @@
       "packages/cards/src",
       "packages/apps/src",
       "packages/graph/src",
-      "packages/botbuilder/src"
+      "packages/botbuilder/src",
+      "packages/m365extensions/src"
    ],
    "typeCheckingMode": "strict",
    "executionEnvironments": [
@@ -28,6 +29,19 @@
       },
       {
          "root": "examples/botbuilder/src",
+         "reportMissingTypeStubs": "none",
+         "reportUnknownMemberType": "none"
+      },
+      {
+         "root": "examples/m365extensions/src",
+         "reportMissingTypeStubs": "none",
+         "reportUnknownMemberType": "none",
+         "reportUnknownArgumentType": "none",
+         "reportUnknownVariableType": "none",
+         "reportUnusedFunction": "none"
+      },
+      {
+         "root": "packages/m365extensions/src",
          "reportMissingTypeStubs": "none",
          "reportUnknownMemberType": "none"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ members = [
     "graph",
     "html-widgets",
     "http-adapters",
+    "m365extensions",
     "mcp-server",
     "meetings",
     "message-extensions",
@@ -31,6 +32,7 @@ members = [
     "microsoft-teams-cards",
     "microsoft-teams-common",
     "microsoft-teams-graph",
+    "microsoft-teams-m365extensions",
     "oauth",
     "proactive-messaging",
     "quoting",
@@ -1542,6 +1544,37 @@ wheels = [
 ]
 
 [[package]]
+name = "m365extensions"
+version = "0.1.0"
+source = { virtual = "examples/m365extensions" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "dotenv" },
+    { name = "microsoft-agents-activity" },
+    { name = "microsoft-agents-authentication-msal" },
+    { name = "microsoft-agents-hosting-aiohttp" },
+    { name = "microsoft-agents-hosting-core" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+    { name = "microsoft-teams-cards" },
+    { name = "microsoft-teams-m365extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.10.0" },
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "microsoft-agents-activity", specifier = ">=1.3.0" },
+    { name = "microsoft-agents-authentication-msal", specifier = ">=1.3.0" },
+    { name = "microsoft-agents-hosting-aiohttp", specifier = ">=1.3.0" },
+    { name = "microsoft-agents-hosting-core", specifier = ">=1.3.0" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
+    { name = "microsoft-teams-cards", editable = "packages/cards" },
+    { name = "microsoft-teams-m365extensions", editable = "packages/m365extensions" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1712,6 +1745,62 @@ dependencies = [
 requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "microsoft-teams-apps", editable = "packages/apps" },
+]
+
+[[package]]
+name = "microsoft-agents-activity"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/37/c6d132590089b52508c17768bfc63fc049380b8735b639eb3f6cfe52b729/microsoft_agents_activity-1.3.0.tar.gz", hash = "sha256:b62f51710343548ca90d5b192ba9a27a31fc9868ed1ccd79a09d5442e74e8690", size = 71931, upload-time = "2026-07-30T23:06:35.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/bf/44438f443e391a081555387ef94077e53775c5b9cb87367d604866b42fdc/microsoft_agents_activity-1.3.0-py3-none-any.whl", hash = "sha256:4c1fe382aa182ba5489d8b72a6d2ba4cc56aa3d17331ef59c86f38f137135d28", size = 146238, upload-time = "2026-07-30T23:06:49.663Z" },
+]
+
+[[package]]
+name = "microsoft-agents-authentication-msal"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "microsoft-agents-hosting-core" },
+    { name = "msal" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/e1/9a6b77c5e2524814e3a91cece17b3203e905f1cca5142484202723a64ebd/microsoft_agents_authentication_msal-1.3.0.tar.gz", hash = "sha256:b86d1d7d850b1cd51eec12daea6c76ac2836b381d50599942ba714136f800647", size = 13704, upload-time = "2026-07-30T23:06:37.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/e7/8fe2f8e0ecc61b0cfffac2536b57350dc9815dc5c776c835a9f462525c54/microsoft_agents_authentication_msal-1.3.0-py3-none-any.whl", hash = "sha256:751bd3ca861387809137b37c23e04f7f6774f2b291061b483320fabf60e0fa12", size = 12310, upload-time = "2026-07-30T23:06:51.878Z" },
+]
+
+[[package]]
+name = "microsoft-agents-hosting-aiohttp"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "microsoft-agents-hosting-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/1a/00027266e259e676d2aceb1952a750619ea8ed80175a978fa407365321d9/microsoft_agents_hosting_aiohttp-1.3.0.tar.gz", hash = "sha256:1a3fdec858d882cdff9945d46d40602a9a3c742c06460ad310b0b6977e66d436", size = 11177, upload-time = "2026-07-30T23:06:39.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/e6/5d4c336c420ce50aa85ea0b6a2f33e73050b9cdec5593cfb332537c4ee1e/microsoft_agents_hosting_aiohttp-1.3.0-py3-none-any.whl", hash = "sha256:d449aa32938555d8da494c862a5a8d6f707834dfa7367f7f3609ceca22c91d3f", size = 10405, upload-time = "2026-07-30T23:06:53.854Z" },
+]
+
+[[package]]
+name = "microsoft-agents-hosting-core"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate" },
+    { name = "microsoft-agents-activity" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "pyjwt" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/ab/6f937cdbf7fdcfb6f38008a753613b992db44deeb8c129bffd48537d06f6/microsoft_agents_hosting_core-1.3.0.tar.gz", hash = "sha256:1be7c5c9a7233ebc2a0a2d59c409dd39bc223eea89515e870ec1517bd3c2d815", size = 140706, upload-time = "2026-07-30T23:06:40.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/35/efd3ca12e5acb8019b9a6d2e156e08771f44fbd3c908f64d65111950a937/microsoft_agents_hosting_core-1.3.0-py3-none-any.whl", hash = "sha256:03bb15624ef33da8ea1f317d1214b88d996240c8f199a6dc8c26c9b3c8a35971", size = 209481, upload-time = "2026-07-30T23:06:55.075Z" },
 ]
 
 [[package]]
@@ -1982,6 +2071,36 @@ requires-dist = [
     { name = "microsoft-teams-common", editable = "packages/common" },
     { name = "msgraph-sdk", specifier = ">=1.30.0,<2.0.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "microsoft-teams-m365extensions"
+source = { editable = "packages/m365extensions" }
+dependencies = [
+    { name = "microsoft-agents-activity" },
+    { name = "microsoft-agents-hosting-core" },
+    { name = "microsoft-teams-api" },
+    { name = "microsoft-teams-apps" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "microsoft-agents-activity", specifier = ">=1.3.0" },
+    { name = "microsoft-agents-hosting-core", specifier = ">=1.3.0" },
+    { name = "microsoft-teams-api", editable = "packages/api" },
+    { name = "microsoft-teams-apps", editable = "packages/apps" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Adds a new **`microsoft-teams-m365extensions`** package — an M365 extension that lets you run the
[Teams SDK for Python](https://github.com/microsoft/teams.py) (teams.py) inside an existing M365 Agents
app. It installs middleware that routes Teams activities to a teams.py `App`, while
every other channel — and any Teams turn with no matching teams.py route — falls through to the host
app's existing handlers. This lets you layer rich Teams-native features (Adaptive Cards, task
modules, reactions, targeted messages) onto an app without rewriting its current message handling.

## What's included

**Package — `packages/m365extensions/`**
- `use_teams_sdk(...)` — one-call setup that builds the teams.py `App` and installs the routing middleware.
- `TeamsMiddleware` / `is_teams_channel` — the middleware and a channel-detection helper.
- Credential/token wiring so teams.py's outbound calls reuse the host app's existing credentials.
- Unit tests (`tests/test_m365extensions.py`).

**Example — `examples/m365extensions/`**
- A runnable sample demonstrating Teams-only features (help card, reactions, quoted replies,
  targeted messages, task modules) alongside pass-through commands handled by the host app.
- `tools/webchat/` — a small Direct Line harness (browser UI + scriptable CLI) for exercising the
  non-Teams path.
- `README.md` + `sample.env` with Teams CLI-based setup.

## How it works

For each Teams turn, the middleware checks whether the teams.py `App` has a matching route. If it
does, teams.py handles the turn and its response flows back through the host pipeline. If not — or
for any non-Teams channel — the turn passes through unchanged to the host app.

## Example snippets

Outlook:
<img width="996" height="297" alt="Screenshot 2026-08-12 at 1 40 23 PM" src="https://github.com/user-attachments/assets/664ea4c4-e560-4984-894d-e7cf740c581e" />

Direct Line/Webchat:
<img width="1660" height="697" alt="Screenshot 2026-08-12 at 1 41 03 PM" src="https://github.com/user-attachments/assets/3a9d4c49-a87d-4abf-816c-5d161395ac3f" />

