### PR TITLE
feat: add Anthropic support to AI MCP sample

### DIFF
--- a/examples/ai-mcp/README.md
+++ b/examples/ai-mcp/README.md
@@ -1,6 +1,6 @@
 # Teams AI Agent with MCP tools
 
-A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and Azure OpenAI. It streams responses token-by-token, attaches inline citations from MCP search results, asks clarifying questions via Adaptive Cards, and suggests follow-up questions after each reply.
+A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-framework) and either Azure OpenAI or Anthropic Claude. It streams responses token-by-token, attaches inline citations from MCP search results, asks clarifying questions via Adaptive Cards, and suggests follow-up questions after each reply.
 
 ## Features
 
@@ -9,14 +9,14 @@ A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-fram
 - **Conversation memory** — each conversation maintains its own `AgentSession` so the agent remembers context across turns.
 - **AI-generated label + custom feedback** — replies include the Teams "AI-generated" label and thumbs up/down feedback buttons; clicking a reaction opens a custom Adaptive Card form for additional feedback.
 - **Clarification cards** — when the user's request is ambiguous, the agent calls `request_clarification` to present a choice card; the user's selection feeds back into the same session as the next turn.
-- **Dynamic follow-up suggestions** — after each reply a second lightweight OpenAI call generates two contextual follow-up questions shown as suggested-action buttons.
+- **Dynamic follow-up suggestions** — after each reply the selected provider generates two contextual follow-up questions shown as suggested-action buttons.
 - **MCP tools** — remote tool servers: Microsoft Learn docs search (`MCPStreamableHTTPTool`).
 
 ## Prerequisites
 
 - Python >= 3.11
 - UV >= 0.8.11
-- An Azure OpenAI resource with a deployed model
+- An Azure OpenAI deployment or an Anthropic API key
 - A Teams bot registration (App ID + password)
 
 ## Setup
@@ -24,7 +24,7 @@ A Teams bot powered by [agent-framework](https://github.com/microsoft/agent-fram
 Create a `.env` file in `examples/ai-mcp/`:
 
 ```env
-# Azure OpenAI
+AI_PROVIDER=azure-openai
 AZURE_OPENAI_ENDPOINT=https://<your-resource>.openai.azure.com
 AZURE_OPENAI_MODEL=<deployment-name>
 AZURE_OPENAI_API_KEY=<api-key>
@@ -36,6 +36,17 @@ CLIENT_SECRET=<client-secret>
 ```
 
 `AZURE_OPENAI_MODEL` is the **deployment name** of your model, not the base model name.
+
+To use Anthropic instead:
+
+```env
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=<api-key>
+ANTHROPIC_MODEL=<supported-claude-model>
+
+# Optional; defaults to 4096.
+ANTHROPIC_MAX_TOKENS=4096
+```
 
 ### Using a Service Principal for Azure OpenAI instead of an API key
 

--- a/examples/ai-mcp/pyproject.toml
+++ b/examples/ai-mcp/pyproject.toml
@@ -7,8 +7,10 @@ requires-python = ">=3.11,<4.0"
 dependencies = [
     "dotenv>=0.9.9",
     "microsoft-teams-apps",
+    "agent-framework-anthropic==1.0.0b260421",
     "agent-framework-core",
-    "agent-framework-openai"
+    "agent-framework-openai",
+    "mcp==1.28.1"
 ]
 
 [tool.uv.sources]

--- a/examples/ai-mcp/src/agent.py
+++ b/examples/ai-mcp/src/agent.py
@@ -10,7 +10,8 @@ from os import getenv
 from typing import Any, cast
 
 from agent_framework import Agent, FunctionInvocationContext, FunctionMiddleware
-from agent_framework.openai import OpenAIChatClient
+from agent_framework.anthropic import AnthropicChatOptions, AnthropicClient
+from agent_framework.openai import OpenAIChatClient, OpenAIChatOptions
 from dotenv import find_dotenv, load_dotenv
 from local_tools import tools as local_tools
 from mcp_tools import mcp_tools
@@ -72,12 +73,6 @@ def _require_env(name: str) -> str:
     return value
 
 
-client = OpenAIChatClient(
-    model=_require_env("AZURE_OPENAI_MODEL"),
-    azure_endpoint=_require_env("AZURE_OPENAI_ENDPOINT"),
-    api_key=_require_env("AZURE_OPENAI_API_KEY"),
-)
-
 INSTRUCTIONS = """\
 You are a helpful Teams assistant that can search Microsoft Learn (Teams, Python, Microsoft Graph, Azure) \
 and explain bot concepts (streaming, Adaptive Cards, citations, feedback).
@@ -91,9 +86,34 @@ with a short question and 2-4 candidate interpretations rather than guessing.
 """
 
 tool_logger = AgentMiddleware()
-agent = Agent(
-    client=client,
-    instructions=INSTRUCTIONS,
-    tools=[*local_tools, *mcp_tools],
-    middleware=[tool_logger],
-)
+provider = getenv("AI_PROVIDER", "azure-openai").strip().lower()
+client: AnthropicClient | OpenAIChatClient
+agent: Agent[AnthropicChatOptions] | Agent[OpenAIChatOptions]
+
+if provider == "anthropic":
+    client = AnthropicClient(
+        api_key=_require_env("ANTHROPIC_API_KEY"),
+        model=_require_env("ANTHROPIC_MODEL"),
+    )
+    anthropic_options: AnthropicChatOptions = {"max_tokens": int(getenv("ANTHROPIC_MAX_TOKENS", "4096"))}
+    agent = Agent(
+        client=client,
+        instructions=INSTRUCTIONS,
+        tools=[*local_tools, *mcp_tools],
+        middleware=[tool_logger],
+        default_options=anthropic_options,
+    )
+elif provider == "azure-openai":
+    client = OpenAIChatClient(
+        model=_require_env("AZURE_OPENAI_MODEL"),
+        azure_endpoint=_require_env("AZURE_OPENAI_ENDPOINT"),
+        api_key=_require_env("AZURE_OPENAI_API_KEY"),
+    )
+    agent = Agent(
+        client=client,
+        instructions=INSTRUCTIONS,
+        tools=[*local_tools, *mcp_tools],
+        middleware=[tool_logger],
+    )
+else:
+    raise ValueError(f"Unsupported AI_PROVIDER {provider!r}. Use 'azure-openai' or 'anthropic'.")

--- a/examples/ai-mcp/src/main.py
+++ b/examples/ai-mcp/src/main.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 
 from agent import agent, client, tool_logger
 from agent_framework import AgentSession, ChatResponse, Message
+from agent_framework.openai import OpenAIChatClient, OpenAIChatOptions
 from local_tools import CLARIFICATION_INPUT_ID, CLARIFICATION_VERB, pending_cards
 from microsoft_teams.api import (
     AdaptiveCardActionMessageResponse,
@@ -33,6 +34,7 @@ from microsoft_teams.api import (
 )
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.cards import AdaptiveCard, SubmitAction, TextBlock, TextInput
+from pydantic import BaseModel, Field
 
 logging.basicConfig(level=getenv("LOG_LEVEL", "INFO").upper())
 logger = logging.getLogger(__name__)
@@ -50,20 +52,37 @@ _FOLLOW_UPS_PROMPT = (
 )
 
 
+class FollowUps(BaseModel):
+    follow_ups: list[str] = Field(alias="followUps", min_length=2, max_length=2)
+
+
 async def _generate_follow_ups(last_user_text: str, last_ai_text: str) -> list[CardAction]:
     """Generate 2 dynamic follow-up suggestions with the selected provider."""
     try:
+        messages = [
+            Message(
+                "user",
+                contents=[
+                    f"{_FOLLOW_UPS_PROMPT}\n\n"
+                    f"Last user message: {last_user_text}\n"
+                    f"Last assistant response: {last_ai_text}"
+                ],
+            )
+        ]
+
+        if isinstance(client, OpenAIChatClient):
+            options: OpenAIChatOptions[FollowUps] = {
+                "max_tokens": 200,
+                "response_format": FollowUps,
+            }
+            response = await client.get_response(messages, options=options)
+            questions = FollowUps.model_validate_json(response.text).follow_ups
+            return [
+                CardAction(type=CardActionType.IM_BACK, title=question, value=question) for question in questions[:2]
+            ]
+
         response: ChatResponse[Any] = await client.get_response(
-            [
-                Message(
-                    "user",
-                    contents=[
-                        f"{_FOLLOW_UPS_PROMPT}\n\n"
-                        f"Last user message: {last_user_text}\n"
-                        f"Last assistant response: {last_ai_text}"
-                    ],
-                )
-            ],
+            messages,
             options={"max_tokens": 200},
         )
         content = response.text or "{}"

--- a/examples/ai-mcp/src/main.py
+++ b/examples/ai-mcp/src/main.py
@@ -8,9 +8,10 @@ import json
 import logging
 import re
 from os import getenv
+from typing import Any, cast
 
-from agent import agent, tool_logger
-from agent_framework import AgentSession
+from agent import agent, client, tool_logger
+from agent_framework import AgentSession, ChatResponse, Message
 from local_tools import CLARIFICATION_INPUT_ID, CLARIFICATION_VERB, pending_cards
 from microsoft_teams.api import (
     AdaptiveCardActionMessageResponse,
@@ -32,7 +33,6 @@ from microsoft_teams.api import (
 )
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.cards import AdaptiveCard, SubmitAction, TextBlock, TextInput
-from openai import AsyncAzureOpenAI
 
 logging.basicConfig(level=getenv("LOG_LEVEL", "INFO").upper())
 logger = logging.getLogger(__name__)
@@ -43,67 +43,40 @@ app = App()
 # Per-conversation sessions preserve message history across turns.
 _sessions: dict[str, AgentSession] = {}
 
-# Raw OpenAI client used only for follow-up generation (separate from agent_framework).
-_openai_client: AsyncAzureOpenAI | None = None
-
-
-def _get_openai_client() -> AsyncAzureOpenAI:
-    global _openai_client
-    if _openai_client is None:
-        _openai_client = AsyncAzureOpenAI(
-            azure_endpoint=getenv("AZURE_OPENAI_ENDPOINT", ""),
-            api_key=getenv("AZURE_OPENAI_API_KEY", ""),
-            api_version="2024-08-01-preview",
-        )
-    return _openai_client
-
-
 _FOLLOW_UPS_PROMPT = (
     "Based on the conversation so far, suggest exactly 2 short follow-up questions the user might want to ask next. "
     'Respond with JSON: {"followUps": ["question 1", "question 2"]}. '
     "Keep each question under 60 characters."
 )
 
-_FOLLOW_UPS_SCHEMA = {
-    "type": "json_schema",
-    "json_schema": {
-        "name": "follow_ups",
-        "schema": {
-            "type": "object",
-            "properties": {
-                "followUps": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "minItems": 2,
-                    "maxItems": 2,
-                },
-            },
-            "required": ["followUps"],
-            "additionalProperties": False,
-        },
-        "strict": True,
-    },
-}
-
 
 async def _generate_follow_ups(last_user_text: str, last_ai_text: str) -> list[CardAction]:
-    """Generate 2 dynamic follow-up suggestions via a lightweight OpenAI call."""
+    """Generate 2 dynamic follow-up suggestions with the selected provider."""
     try:
-        client = _get_openai_client()
-        model = getenv("AZURE_OPENAI_MODEL", "")
-        completion = await client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": _FOLLOW_UPS_PROMPT},
-                {"role": "user", "content": last_user_text},
-                {"role": "assistant", "content": last_ai_text},
+        response: ChatResponse[Any] = await client.get_response(
+            [
+                Message(
+                    "user",
+                    contents=[
+                        f"{_FOLLOW_UPS_PROMPT}\n\n"
+                        f"Last user message: {last_user_text}\n"
+                        f"Last assistant response: {last_ai_text}"
+                    ],
+                )
             ],
-            response_format=_FOLLOW_UPS_SCHEMA,  # type: ignore[arg-type]
-            max_tokens=200,
+            options={"max_tokens": 200},
         )
-        content = completion.choices[0].message.content or "{}"
-        data = json.loads(content)
-        return [CardAction(type=CardActionType.IM_BACK, title=q, value=q) for q in data.get("followUps", [])[:2]]
+        content = response.text or "{}"
+        match = re.search(r"\{[\s\S]*\}", content)
+        data = cast("dict[str, Any]", json.loads(match.group(0) if match else "{}"))
+        follow_ups = data.get("followUps", [])
+        if not isinstance(follow_ups, list):
+            return []
+        return [
+            CardAction(type=CardActionType.IM_BACK, title=question, value=question)
+            for question in cast("list[Any]", follow_ups)[:2]
+            if isinstance(question, str)
+        ]
     except Exception as exc:
         logger.warning("follow-up generation failed: %s", exc)
         return []
@@ -232,5 +205,10 @@ async def handle_feedback(ctx: ActivityContext[MessageSubmitActionInvokeActivity
     logger.info("feedback: %s | %s", reaction, feedback)
 
 
+async def main() -> None:
+    async with agent:
+        await app.start()
+
+
 if __name__ == "__main__":
-    asyncio.run(app.start())
+    asyncio.run(main())

--- a/uv.lock
+++ b/uv.lock
@@ -113,6 +113,19 @@ http-server = [
 ]
 
 [[package]]
+name = "agent-framework-anthropic"
+version = "1.0.0b260421"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agent-framework-core" },
+    { name = "anthropic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/e9/c1376a55e6b7319f081d928acb4032bfe6d446a49a42cbbabb49925b6284/agent_framework_anthropic-1.0.0b260421.tar.gz", hash = "sha256:17a36861ad17cf7bfa905ce3d7b83ffd42a35c49cea85ba5fa284d540b23acde", size = 18326, upload-time = "2026-04-21T06:29:17.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/d4/d299a687284c3bb5b2748a2e9953402d8979a6a3f99c3c05beb58fdba4ff/agent_framework_anthropic-1.0.0b260421-py3-none-any.whl", hash = "sha256:907df866c1c26ac1c86ebd048c0de95616e2fcdd250b7ffd7faf839f3496e699", size = 21092, upload-time = "2026-04-21T06:29:09.725Z" },
+]
+
+[[package]]
 name = "agent-framework-core"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -160,17 +173,21 @@ name = "ai-agentframework"
 version = "0.1.0"
 source = { virtual = "examples/ai-mcp" }
 dependencies = [
+    { name = "agent-framework-anthropic" },
     { name = "agent-framework-core" },
     { name = "agent-framework-openai" },
     { name = "dotenv" },
+    { name = "mcp" },
     { name = "microsoft-teams-apps" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "agent-framework-anthropic", specifier = "==1.0.0b260421" },
     { name = "agent-framework-core" },
     { name = "agent-framework-openai" },
     { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "mcp", specifier = "==1.28.1" },
     { name = "microsoft-teams-apps", editable = "packages/apps" },
 ]
 
@@ -330,6 +347,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/63/791e14ef5a8ecb485cef5b5d058c7ca3ad6c50a2f94cf4cea5231c6b7c16/anthropic-0.80.0.tar.gz", hash = "sha256:ef042586673fdcab2a6ffd381aa5f9a1bcce38ffe73c07fe70bd56d12b8124ba", size = 533291, upload-time = "2026-02-17T19:26:26.717Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/4b/665f29338f51d0c2f9e04b276ea54cc1e957ae5c521a0ad868aa80abc608/anthropic-0.80.0-py3-none-any.whl", hash = "sha256:dad0e40ec371ee686e9ffb2e0cb461a0ed51447fa100927fb5d39b174c286d6f", size = 453667, upload-time = "2026-02-17T19:26:29.961Z" },
 ]
 
 [[package]]
@@ -931,6 +967,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- select Azure OpenAI or Anthropic Claude through `AI_PROVIDER`
- add the compatible Agent Framework Anthropic connector and MCP runtime dependencies
- reuse the selected provider for follow-up generation
- manage the Agent/MCP lifecycle during application startup and shutdown
- preserve Teams streaming, sessions, citations, cards, feedback, and tools

## Validation
- Ruff formatting and linting
- Pyright on modified sample files
- UV lockfile validation
- sample startup with Microsoft Learn MCP
- live Claude + MCP request with streamed text and citations
- live Claude follow-up generation

## Related PRs
- TypeScript: https://github.com/microsoft/teams.ts/pull/726
- C#: https://github.com/microsoft/teams.net/pull/650
- Documentation: https://github.com/microsoft/teams-sdk/pull/2957
