### PR TITLE
fix: drop recipient from targeted message update payload

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/activity_send.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_send.py
@@ -40,9 +40,14 @@ async def send_or_update_activity(
     if activity.id:
         activity_id = activity.id
         if is_targeted:
-            res = await scoped_api.conversations.update_targeted_activity(ref.conversation.id, activity_id, activity)
-        else:
-            res = await scoped_api.conversations.update_activity(ref.conversation.id, activity_id, activity)
+            # The recipient of an existing targeted message cannot be edited, so it only selects the
+            # targeted endpoint and is dropped from the outbound payload. The caller still gets the
+            # recipient back on the returned activity.
+            payload = activity.model_copy(update={"recipient": None})
+            res = await scoped_api.conversations.update_targeted_activity(ref.conversation.id, activity_id, payload)
+            return SentActivity.merge(activity, res.model_copy(update={"activity_params": activity}))
+
+        res = await scoped_api.conversations.update_activity(ref.conversation.id, activity_id, activity)
         return SentActivity.merge(activity, res)
 
     if is_targeted:

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -269,9 +269,10 @@ class TestActivityContextSendTargeted:
         assert sent_activity.recipient.is_targeted is True
 
     @pytest.mark.asyncio
-    async def test_targeted_update_preserves_recipient(self) -> None:
+    async def test_targeted_update_drops_recipient_from_payload(self) -> None:
         """
-        When updating a targeted message, the recipient should be preserved.
+        Teams rejects targeted updates that carry a recipient, so the recipient only selects the
+        targeted endpoint and is stripped from the outbound payload.
         """
         incoming_sender = Account(id="user-123", name="Test User")
         ctx, mock_sender = self._create_activity_context(from_account=incoming_sender)
@@ -280,16 +281,23 @@ class TestActivityContextSendTargeted:
         activity = MessageActivityInput(text="Updated text").with_recipient(incoming_sender, is_targeted=True)
         activity.id = "existing-activity-id"  # This makes it an update
 
-        await ctx.send(activity)
+        result = await ctx.send(activity)
 
         ctx.api.conversations.activities.return_value.update_targeted.assert_called_once()
-        sent_activity = ctx.api.conversations.activities.return_value.update_targeted.call_args.args[1]
+        ctx.api.conversations.activities.return_value.create_targeted.assert_not_called()
+        activity_id, sent_activity = ctx.api.conversations.activities.return_value.update_targeted.call_args.args
 
-        # Verify recipient was preserved
-        assert sent_activity.recipient is not None
-        assert sent_activity.recipient.id == incoming_sender.id
-        assert sent_activity.recipient.name == incoming_sender.name
-        assert sent_activity.recipient.is_targeted is True
+        # The targeted endpoint is still chosen, but the wire payload carries no recipient
+        assert activity_id == "existing-activity-id"
+        assert sent_activity.text == "Updated text"
+        assert sent_activity.recipient is None
+        assert "recipient" not in sent_activity.model_dump(by_alias=True, exclude_none=True)
+
+        # The caller still gets the recipient back
+        assert result.activity_params.recipient is not None
+        assert result.activity_params.recipient.id == incoming_sender.id
+        assert result.activity_params.recipient.is_targeted is True
+        mock_sender.send.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_existing_activity_updates(self) -> None:


### PR DESCRIPTION
Ports [microsoft/teams.ts#739](https://github.com/microsoft/teams.ts/pull/739) (fixes [microsoft/teams.ts#738](https://github.com/microsoft/teams.ts/issues/738)) to the Python SDK. Same bug, same root cause, no equivalent issue filed on this repo.

## Why

Updating a targeted message through `ctx.send` fails. Setting `id` on a `MessageActivityInput` that also carries a targeted recipient correctly routes the call to `update_targeted_activity`, but `recipient` is still serialized into the request body, and Teams rejects it:

```text
400 Bad Request
BadArgument: Cannot edit Recipient of Targeted Message
```

The recipient of an existing targeted message cannot be edited, so it must not appear in an update payload. It is only useful for deciding *which* endpoint to call.

## What changed

`send_or_update_activity` in `packages/apps/src/microsoft_teams/apps/activity_send.py` (the Python counterpart of TypeScript's `ActivitySender`) now splits the targeted update out of the shared update path:

- The recipient still selects the targeted endpoint, then is dropped from the outbound payload via `activity.model_copy(update={"recipient": None})`. The client dumps with `exclude_none=True`, so the key disappears from the wire body.
- The returned `SentActivity` still reports the recipient the caller passed in. Without this, `result.activity_params.recipient` would come back `None` after an update, which matches the guarantee the TypeScript fix makes about its own return value.

This covers every send path, since `ctx.send`, `App.send`, and `FunctionContext.send` all funnel through this helper.

Deliberately unchanged: `ConversationActivityClient.update_targeted` still sends whatever it is handed. `examples/targeted-messages` calls that client directly and passes no recipient, so it is unaffected, and this keeps the fix at the same layer as the TypeScript port rather than diverging the two SDKs at the API-client boundary.

## Tests

`test_targeted_update_preserves_recipient` asserted the buggy behavior, so it is replaced by `test_targeted_update_drops_recipient_from_payload`, which checks that the targeted endpoint is still chosen, the payload has no `recipient` (both on the model and in the serialized body), and the caller still gets the recipient back.

Red-green verified rather than assumed: reverting either half of the fix independently fails the new test.

## Validation

- `pytest packages` — **1052 passed**
- `pyright` — 0 errors, 0 warnings
- `ruff check` / `ruff format --check` — clean
