### PR TITLE
feat(oauth): route sign-in callbacks on turn state

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -459,6 +459,15 @@ class App(ActivityHandlerMixin):
         Returns:
             The registered ``OAuthFlow``.
 
+        Notes:
+            Enable per-turn state with ``App(state=True)`` (or ``StateOptions``)
+            to record pending connection hints. Connection-less verify-state
+            callbacks probe hinted flows first, then the remaining registered
+            flows and legacy default connection. Sign-in failures use pending
+            silent-SSO hints for attribution and notify registered flows as a
+            fallback. Token-exchange callbacks carry their connection name and
+            route correctly without state.
+
         Raises:
             ValueError: if a flow for this connection is already registered
                 (connection names are case-insensitive).

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -149,6 +149,7 @@ class App(ActivityHandlerMixin):
             fetch_user_token=self.options.fetch_user_token,
             agent365_baggage_options=self.options.telemetry.get("agent365") if self.options.telemetry else None,
             state_loader=self._state_loader,
+            oauth_registry=self._oauth_registry,
         )
         self.event_manager = EventManager(self._events)
         self.activity_processor.event_manager = self.event_manager

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -461,24 +461,56 @@ class App(ActivityHandlerMixin):
             The registered ``OAuthFlow``.
 
         Notes:
-            Enable per-turn state with ``App(state=True)`` (or ``StateOptions``)
-            to record pending connection hints. Connection-less verify-state
-            callbacks probe hinted flows first, then the remaining registered
-            flows and legacy default connection. Sign-in failures use pending
-            silent-SSO hints for attribution and notify registered flows as a
-            fallback. Token-exchange callbacks carry their connection name and
-            route correctly without state.
+            Registering a flow turns on per-turn state automatically when the
+            ``state`` option was omitted, because connection-less callbacks need
+            somewhere to record which connection a sign-in started on. Pass
+            ``state=True`` or a ``StateOptions`` to choose the storage yourself,
+            or ``state=False`` to opt out — an explicit choice is never
+            overridden. With state off, pending hints fall back to a bounded
+            process-local cache, so a callback handled by another instance
+            cannot be attributed.
+
+            Connection-less verify-state callbacks probe hinted flows first,
+            then the remaining registered flows and legacy default connection.
+            Sign-in failures use pending silent-SSO hints for attribution and
+            notify registered flows as a fallback. Token-exchange callbacks
+            carry their connection name and route correctly without state.
 
         Raises:
             ValueError: if a flow for this connection is already registered
                 (connection names are case-insensitive).
         """
-        return self._oauth_registry.add(
+        flow = self._oauth_registry.add(
             OAuthFlow(
                 connection_name,
                 oauth_card_text=oauth_card_text,
                 sign_in_button_text=sign_in_button_text,
             )
+        )
+        # Only after the registry accepts it: a rejected duplicate must not be
+        # able to switch state on as a side effect.
+        self._enable_state_for_oauth_if_unset()
+        return flow
+
+    def _enable_state_for_oauth_if_unset(self) -> None:
+        """Turn on per-turn state for OAuth when the app did not say either way.
+
+        A registered flow needs durable pending attribution to route
+        connection-less ``signin/verifyState`` and ``signin/failure`` callbacks,
+        so state defaults on once a flow exists — matching the C# and TypeScript
+        SDKs. ``options.state`` still records what the caller passed: ``None``
+        means "unset", and anything else, including ``False``, is an explicit
+        decision this leaves alone. An already-resolved loader is also left
+        alone, so registering a second flow does not rebuild it.
+        """
+        if self.options.state is not None or self._state_loader is not None:
+            return
+
+        self._state_loader = create_state_loader(True, self.storage)
+        self.activity_processor.state_loader = self._state_loader
+        logger.debug(
+            "Enabled per-turn state because an OAuth flow was registered and no state option was set. "
+            "Pass state=False to opt out, or state=True/StateOptions to choose the storage."
         )
 
     def get_oauth_flow(self, connection_name: str) -> OAuthFlow:

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -186,6 +186,26 @@ class OauthHandlers:
         logs the failure details and emits an error event so developers are
         notified rather than having the failure silently swallowed.
 
+        **Connection attribution.** A ``signin/failure`` callback does not carry a
+        connection name, so the failed connection is recovered from the pending
+        sign-in recorded when the flow started — durable state when state is
+        enabled, otherwise a short-lived process-local cache. Three outcomes:
+
+            - No flows registered (legacy mode): the default connection is the only
+              connection there is, so it is reported as the failed one.
+            - A pending sign-in resolves: that flow is reported, and only its
+              failure handlers run.
+            - Flows are registered but nothing resolves — most commonly because the
+              callback reached a different process than the one that started the
+              sign-in, and state is not enabled to bridge them. The failed
+              connection is genuinely unknown, so the global
+              ``SignInFailureEvent.connection_name`` is ``None`` and telemetry omits
+              the connection attribute rather than blaming the default. As a
+              last resort **every** registered flow's failure handlers are notified,
+              each with its own connection name, so no listener silently misses a
+              failure that may have been theirs. Enable state to make attribution
+              reliable across processes.
+
         Known failure codes (sent by the Teams client):
             - ``installappfailed``: Failed to install the app in the user's personal
               scope (non-silent).
@@ -209,7 +229,17 @@ class OauthHandlers:
             ctx, sso_only=True
         )
         target_flow = pending_flows[0] if pending_flows else None
-        connection_name = target_flow.connection_name if target_flow is not None else self.default_connection_name
+        registered_flows = list(self.oauth_registry.values())
+        if target_flow is not None:
+            connection_name = target_flow.connection_name
+        elif registered_flows:
+            # Registered flows exist but nothing attributed this callback, so the
+            # failed connection is genuinely unknown. Naming the default here would
+            # blame a connection that may not have been involved at all.
+            connection_name = None
+        else:
+            # Legacy mode: the default connection is the only one there is.
+            connection_name = self.default_connection_name
         result = APP_OAUTH_RESULTS.notified
         started_at = perf_counter()
         try:
@@ -218,7 +248,8 @@ class OauthHandlers:
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
+                if connection_name is not None:
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.signin_failure)
                 failure = activity.value
                 if failure.code:
@@ -251,7 +282,7 @@ class OauthHandlers:
                 await self.event_emitter.emit_async("sign_in_failure", event)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                callback_flows = [target_flow] if target_flow is not None else list(self.oauth_registry.values())
+                callback_flows = [target_flow] if target_flow is not None else registered_flows
                 for flow in callback_flows:
                     flow_event = (
                         event

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -30,7 +30,7 @@ from .diagnostics._constants import (
 )
 from .diagnostics._helpers import get_tracer, record_exception, record_oauth_error, record_oauth_operation
 from .events import ErrorEvent, EventType, SignInEvent, SignInFailureEvent
-from .oauth_flow import OAuthFlowRegistry
+from .oauth_flow import OAuthFlow, OAuthFlowRegistry
 from .routing import ActivityContext
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,10 @@ class OauthHandlers:
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.token_exchange)
 
-                if connection_name != self.default_connection_name and connection_name not in self.oauth_registry:
+                flow = self.oauth_registry.get(connection_name)
+                event_connection_name = flow.connection_name if flow is not None else connection_name
+
+                if connection_name.lower() != self.default_connection_name.lower() and flow is None:
                     logger.warning(
                         f"Sign-in token exchange invoked with connection name '{connection_name}', "
                         f"but it is neither the default connection '{self.default_connection_name}' "
@@ -87,13 +90,6 @@ class OauthHandlers:
                             ),
                         )
                     )
-                    ctx.is_signed_in = True
-                    ctx.user_token = token.token
-                    self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
-                    result = APP_OAUTH_RESULTS.success
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    return None
                 except Exception as e:
                     if isinstance(e, HTTPStatusError):
                         status = e.response.status_code
@@ -102,7 +98,10 @@ class OauthHandlers:
                                 f"Error exchanging token for user {activity.from_.id} in "
                                 f"conversation {activity.conversation.id}: {e}"
                             )
-                            self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
+                            await self.event_emitter.emit_async(
+                                "error",
+                                ErrorEvent(error=e, context={"activity": activity}),
+                            )
                             error_type = APP_OAUTH_ERROR_TYPES.http_error
                             span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                             record_exception(span, e)
@@ -121,7 +120,10 @@ class OauthHandlers:
                             f"Unable to exchange token for user {activity.from_.id} in "
                             f"conversation {activity.conversation.id}: {e}"
                         )
-                        self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
+                        await self.event_emitter.emit_async(
+                            "error",
+                            ErrorEvent(error=e, context={"activity": activity}),
+                        )
                         error_type = APP_OAUTH_ERROR_TYPES.exception
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                         record_exception(span, e)
@@ -138,6 +140,24 @@ class OauthHandlers:
                             failure_detail=str(e) or "unable to exchange token...",
                         ),
                     )
+
+                ctx.is_signed_in = True
+                ctx.user_token = token.token
+                self.oauth_registry._clear_pending(  # pyright: ignore[reportPrivateUsage]
+                    ctx, event_connection_name
+                )
+                event = SignInEvent(
+                    activity_ctx=ctx,
+                    token_response=token,
+                    connection_name=event_connection_name,
+                )
+                result = APP_OAUTH_RESULTS.success
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                await self.event_emitter.emit_async("sign_in", event)
+                if flow is not None:
+                    await flow._invoke_signin_handlers(event)  # pyright: ignore[reportPrivateUsage]
+                return None
         finally:
             record_oauth_operation(
                 connection_name,
@@ -177,7 +197,11 @@ class OauthHandlers:
         """
         activity = ctx.activity
         next_handler = ctx.next
-        connection_name = self.default_connection_name
+        pending_flows = self.oauth_registry._pending_flows(  # pyright: ignore[reportPrivateUsage]
+            ctx, sso_only=True
+        )
+        target_flow = pending_flows[0] if pending_flows else None
+        connection_name = target_flow.connection_name if target_flow is not None else self.default_connection_name
         result = APP_OAUTH_RESULTS.notified
         started_at = perf_counter()
         try:
@@ -199,24 +223,41 @@ class OauthHandlers:
                     f"registration has 'Expose an API' configured with the correct "
                     f"Application ID URI matching your OAuth connection's Token Exchange URL."
                 )
-                self.event_emitter.emit(
+                if target_flow is not None:
+                    self.oauth_registry._mark_sso_consumed(  # pyright: ignore[reportPrivateUsage]
+                        ctx, target_flow.connection_name
+                    )
+                await self.event_emitter.emit_async(
                     "error",
                     ErrorEvent(
                         error=Exception(f"Sign-in failure: {failure.code} — {failure.message}"),
                         context={"activity": activity},
                     ),
                 )
-                self.event_emitter.emit(
-                    "sign_in_failure",
-                    SignInFailureEvent(
-                        activity_ctx=ctx,
-                        connection_name=connection_name,
-                        code=failure.code,
-                        message=failure.message,
-                    ),
+                event = SignInFailureEvent(
+                    activity_ctx=ctx,
+                    connection_name=connection_name,
+                    code=failure.code,
+                    message=failure.message,
                 )
+                await self.event_emitter.emit_async("sign_in_failure", event)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                callback_flows = [target_flow] if target_flow is not None else list(self.oauth_registry.values())
+                for flow in callback_flows:
+                    flow_event = (
+                        event
+                        if target_flow is not None
+                        else SignInFailureEvent(
+                            activity_ctx=ctx,
+                            connection_name=flow.connection_name,
+                            code=failure.code,
+                            message=failure.message,
+                        )
+                    )
+                    await flow._invoke_signin_failure_handlers(  # pyright: ignore[reportPrivateUsage]
+                        flow_event
+                    )
                 return None
         finally:
             record_oauth_operation(
@@ -236,7 +277,36 @@ class OauthHandlers:
         activity = ctx.activity
         api = ctx.api
         next_handler = ctx.next
-        connection_name = self.default_connection_name
+        pending_flows = self.oauth_registry._pending_flows(ctx)  # pyright: ignore[reportPrivateUsage]
+        candidates: list[tuple[str, Optional[OAuthFlow]]] = []
+        seen_connections: set[str] = set()
+        for flow in [*pending_flows, *self.oauth_registry.values()]:
+            key = flow.connection_name.lower()
+            if key in seen_connections:
+                continue
+            seen_connections.add(key)
+            candidates.append((flow.connection_name, flow))
+
+        default_flow = self.oauth_registry.get(self.default_connection_name)
+        default_connection_name = (
+            default_flow.connection_name if default_flow is not None else self.default_connection_name
+        )
+        if default_connection_name.lower() not in seen_connections:
+            candidates.append((default_connection_name, default_flow))
+
+        connection_name = candidates[0][0]
+        if len(candidates) > 1:
+            # ``signin/verifyState`` carries no connection name, so unhinted callbacks are
+            # resolved by probing the Token Service once per candidate until one returns a
+            # token. Hinted flows come first, so the normal path costs a single call; the
+            # fan-out below is the fallback for missing/stale hints (state disabled, expired
+            # sign-in, restarted storage). It is intentionally uncapped: dropping candidates
+            # would turn a slow sign-in into a silently failed one.
+            logger.debug(
+                "Probing %d OAuth connection(s) for connection-less verify-state callback: %s",
+                len(candidates),
+                ", ".join(name for name, _ in candidates),
+            )
         result = APP_OAUTH_RESULTS.failure
         started_at = perf_counter()
         try:
@@ -263,35 +333,38 @@ class OauthHandlers:
                     f"{activity.conversation.id} with state {activity.value.state}"
                 )
 
-                try:
-                    token = await api.users.get_token(
-                        GetUserTokenParams(
-                            connection_name=connection_name,
-                            user_id=activity.from_.id,
-                            channel_id=activity.channel_id,
-                            code=activity.value.state,
+                for candidate_connection_name, flow in candidates:
+                    # Deliberately rebind the outer name: the ``finally`` block below records
+                    # telemetry against the connection that was probed last, which is the one
+                    # the outcome (success, 412, or exhausted candidates) actually belongs to.
+                    connection_name = candidate_connection_name
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
+                    try:
+                        token = await api.users.get_token(
+                            GetUserTokenParams(
+                                connection_name=connection_name,
+                                user_id=activity.from_.id,
+                                channel_id=activity.channel_id,
+                                code=activity.value.state,
+                            )
                         )
-                    )
-                    ctx.is_signed_in = True
-                    ctx.user_token = token.token
-                    self.event_emitter.emit("sign_in", SignInEvent(activity_ctx=ctx, token_response=token))
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
-                    logger.debug(
-                        f"Sign-in state verified for user {activity.from_.id} in conversation "
-                        f"{activity.conversation.id}"
-                    )
-                    result = APP_OAUTH_RESULTS.success
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    return None
-                except Exception as e:
-                    logger.error(
-                        f"Error verifying sign-in state for user {activity.from_.id} in conversation"
-                        f"{activity.conversation.id}: {e}"
-                    )
-                    if isinstance(e, HTTPStatusError):
+                    except HTTPStatusError as e:
                         status = e.response.status_code
-                        if status not in (404, 400, 412):
-                            self.event_emitter.emit("error", ErrorEvent(error=e, context={"activity": activity}))
+                        if status == 404:
+                            logger.debug(
+                                f"No token found for OAuth connection '{connection_name}' while verifying "
+                                f"state for user {activity.from_.id} in conversation {activity.conversation.id}."
+                            )
+                            continue
+                        logger.error(
+                            f"Error verifying sign-in state for user {activity.from_.id} in conversation"
+                            f"{activity.conversation.id}: {e}"
+                        )
+                        if status not in (400, 412):
+                            await self.event_emitter.emit_async(
+                                "error",
+                                ErrorEvent(error=e, context={"activity": activity}),
+                            )
                             error_type = APP_OAUTH_ERROR_TYPES.http_error
                             span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                             record_exception(span, e)
@@ -301,17 +374,50 @@ class OauthHandlers:
                             span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                             return InvokeResponse(status=status)
                         result = APP_OAUTH_RESULTS.failure
-                    else:
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                        return InvokeResponse(status=412)
+                    except Exception as e:
+                        logger.error(
+                            f"Error verifying sign-in state for user {activity.from_.id} in conversation"
+                            f"{activity.conversation.id}: {e}"
+                        )
                         error_type = APP_OAUTH_ERROR_TYPES.exception
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                         record_exception(span, e)
                         record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
                         result = APP_OAUTH_RESULTS.failure
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    return InvokeResponse(
-                        status=412,
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                        return InvokeResponse(status=412)
+
+                    ctx.is_signed_in = True
+                    ctx.user_token = token.token
+                    self.oauth_registry._clear_pending(  # pyright: ignore[reportPrivateUsage]
+                        ctx, connection_name
                     )
+                    event = SignInEvent(
+                        activity_ctx=ctx,
+                        token_response=token,
+                        connection_name=connection_name,
+                    )
+                    result = APP_OAUTH_RESULTS.success
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    await self.event_emitter.emit_async("sign_in", event)
+                    if flow is not None:
+                        await flow._invoke_signin_handlers(  # pyright: ignore[reportPrivateUsage]
+                            event
+                        )
+                    logger.debug(
+                        f"Sign-in state verified for user {activity.from_.id} in conversation "
+                        f"{activity.conversation.id}"
+                    )
+                    return None
+
+                span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                return InvokeResponse(status=412)
         finally:
             record_oauth_operation(
                 connection_name,

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -382,6 +382,10 @@ class OauthHandlers:
                             f"Error verifying sign-in state for user {activity.from_.id} in conversation"
                             f"{activity.conversation.id}: {e}"
                         )
+                        await self.event_emitter.emit_async(
+                            "error",
+                            ErrorEvent(error=e, context={"activity": activity}),
+                        )
                         error_type = APP_OAUTH_ERROR_TYPES.exception
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                         record_exception(span, e)

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -30,6 +30,7 @@ from .diagnostics._constants import (
 )
 from .diagnostics._helpers import get_tracer, record_exception, record_oauth_error, record_oauth_operation
 from .events import ErrorEvent, EventType, SignInEvent, SignInFailureEvent
+from .oauth_connection import connection_lookup_key
 from .oauth_flow import OAuthFlow, OAuthFlowRegistry
 from .routing import ActivityContext
 
@@ -71,7 +72,10 @@ class OauthHandlers:
                 flow = self.oauth_registry.get(connection_name)
                 event_connection_name = flow.connection_name if flow is not None else connection_name
 
-                if connection_name.lower() != self.default_connection_name.lower() and flow is None:
+                if (
+                    connection_lookup_key(connection_name) != connection_lookup_key(self.default_connection_name)
+                    and flow is None
+                ):
                     logger.warning(
                         f"Sign-in token exchange invoked with connection name '{connection_name}', "
                         f"but it is neither the default connection '{self.default_connection_name}' "
@@ -90,45 +94,33 @@ class OauthHandlers:
                             ),
                         )
                     )
-                except Exception as e:
-                    if isinstance(e, HTTPStatusError):
-                        status = e.response.status_code
-                        if status not in (404, 400, 412):
-                            logger.error(
-                                f"Error exchanging token for user {activity.from_.id} in "
-                                f"conversation {activity.conversation.id}: {e}"
-                            )
-                            await self.event_emitter.emit_async(
-                                "error",
-                                ErrorEvent(error=e, context={"activity": activity}),
-                            )
-                            error_type = APP_OAUTH_ERROR_TYPES.http_error
-                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
-                            record_exception(span, e)
-                            record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.token_exchange, error_type)
-                            status = status or 500
-                            result = APP_OAUTH_RESULTS.failure
-                            span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
-                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                            return InvokeResponse(status=status)
-                        logger.info(
-                            f"Unable to exchange token for user {activity.from_.id} in "
-                            f"conversation {activity.conversation.id}: {e}"
-                        )
-                    else:
+                except HTTPStatusError as e:
+                    status = e.response.status_code
+                    if status not in (404, 400, 412):
                         logger.error(
-                            f"Unable to exchange token for user {activity.from_.id} in "
+                            f"Error exchanging token for user {activity.from_.id} in "
                             f"conversation {activity.conversation.id}: {e}"
                         )
                         await self.event_emitter.emit_async(
                             "error",
                             ErrorEvent(error=e, context={"activity": activity}),
                         )
-                        error_type = APP_OAUTH_ERROR_TYPES.exception
+                        error_type = APP_OAUTH_ERROR_TYPES.http_error
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                         record_exception(span, e)
                         record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.token_exchange, error_type)
+                        status = status or 500
+                        result = APP_OAUTH_RESULTS.failure
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                        return InvokeResponse(status=status)
 
+                    # An expected miss: the Token Service has nothing to exchange.
+                    # Teams reads the 412 as "fall back to the sign-in button".
+                    logger.info(
+                        f"Unable to exchange token for user {activity.from_.id} in "
+                        f"conversation {activity.conversation.id}: {e}"
+                    )
                     result = APP_OAUTH_RESULTS.failure
                     span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
                     span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
@@ -140,6 +132,22 @@ class OauthHandlers:
                             failure_detail=str(e) or "unable to exchange token...",
                         ),
                     )
+                except Exception as e:
+                    # Not a Token Service rejection - a transport fault or a bug.
+                    # Reporting it as 412 would tell Teams the exchange merely
+                    # missed and hide a real outage, so it propagates instead and
+                    # the app's own error handling reports it exactly once.
+                    logger.error(
+                        f"Unable to exchange token for user {activity.from_.id} in "
+                        f"conversation {activity.conversation.id}: {e}"
+                    )
+                    error_type = APP_OAUTH_ERROR_TYPES.exception
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                    record_exception(span, e)
+                    record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.token_exchange, error_type)
+                    result = APP_OAUTH_RESULTS.failure
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    raise
 
                 ctx.is_signed_in = True
                 ctx.user_token = token.token
@@ -281,8 +289,8 @@ class OauthHandlers:
         candidates: list[tuple[str, Optional[OAuthFlow]]] = []
         seen_connections: set[str] = set()
         for flow in [*pending_flows, *self.oauth_registry.values()]:
-            key = flow.connection_name.lower()
-            if key in seen_connections:
+            key = connection_lookup_key(flow.connection_name)
+            if key is None or key in seen_connections:
                 continue
             seen_connections.add(key)
             candidates.append((flow.connection_name, flow))
@@ -291,7 +299,7 @@ class OauthHandlers:
         default_connection_name = (
             default_flow.connection_name if default_flow is not None else self.default_connection_name
         )
-        if default_connection_name.lower() not in seen_connections:
+        if connection_lookup_key(default_connection_name) not in seen_connections:
             candidates.append((default_connection_name, default_flow))
 
         connection_name = candidates[0][0]
@@ -350,34 +358,17 @@ class OauthHandlers:
                         )
                     except HTTPStatusError as e:
                         status = e.response.status_code
-                        if status == 404:
+                        if status in (400, 404, 412):
+                            # An expected miss. ``signin/verifyState`` carries no
+                            # connection name, so the Token Service rejecting this
+                            # code only rules out this candidate - it is not a failed
+                            # sign-in until every candidate has been ruled out.
                             logger.debug(
-                                f"No token found for OAuth connection '{connection_name}' while verifying "
-                                f"state for user {activity.from_.id} in conversation {activity.conversation.id}."
+                                f"OAuth connection '{connection_name}' did not accept the verify-state code "
+                                f"for user {activity.from_.id} in conversation "
+                                f"{activity.conversation.id} (HTTP {status})."
                             )
                             continue
-                        logger.error(
-                            f"Error verifying sign-in state for user {activity.from_.id} in conversation"
-                            f"{activity.conversation.id}: {e}"
-                        )
-                        if status not in (400, 412):
-                            await self.event_emitter.emit_async(
-                                "error",
-                                ErrorEvent(error=e, context={"activity": activity}),
-                            )
-                            error_type = APP_OAUTH_ERROR_TYPES.http_error
-                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
-                            record_exception(span, e)
-                            record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
-                            status = status or 500
-                            span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
-                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                            return InvokeResponse(status=status)
-                        result = APP_OAUTH_RESULTS.failure
-                        span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
-                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                        return InvokeResponse(status=412)
-                    except Exception as e:
                         logger.error(
                             f"Error verifying sign-in state for user {activity.from_.id} in conversation"
                             f"{activity.conversation.id}: {e}"
@@ -386,14 +377,30 @@ class OauthHandlers:
                             "error",
                             ErrorEvent(error=e, context={"activity": activity}),
                         )
+                        error_type = APP_OAUTH_ERROR_TYPES.http_error
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                        record_exception(span, e)
+                        record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
+                        status = status or 500
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                        return InvokeResponse(status=status)
+                    except Exception as e:
+                        # A transport fault or a bug, not a Token Service verdict.
+                        # It propagates so the app's error handling reports it once
+                        # rather than being flattened into a 412 that reads as an
+                        # ordinary failed sign-in.
+                        logger.error(
+                            f"Error verifying sign-in state for user {activity.from_.id} in conversation"
+                            f"{activity.conversation.id}: {e}"
+                        )
                         error_type = APP_OAUTH_ERROR_TYPES.exception
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
                         record_exception(span, e)
                         record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
                         result = APP_OAUTH_RESULTS.failure
-                        span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                        return InvokeResponse(status=412)
+                        raise
 
                     ctx.is_signed_in = True
                     ctx.user_token = token.token
@@ -419,9 +426,12 @@ class OauthHandlers:
                     )
                     return None
 
-                span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 412)
+                # Every candidate missed, so the user holds no token on any of them.
+                # That is "nothing to verify" (404), not a precondition failure.
+                result = APP_OAUTH_RESULTS.no_token
+                span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 404)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                return InvokeResponse(status=412)
+                return InvokeResponse(status=404)
         finally:
             record_oauth_operation(
                 connection_name,

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -43,6 +43,7 @@ from .diagnostics._helpers import (
     record_turn_duration,
 )
 from .events import ActivityEvent, ActivityResponseEvent, ActivitySentEvent, ErrorEvent
+from .oauth_flow import OAuthFlowRegistry
 from .plugins import PluginActivityEvent, PluginBase, StreamCancelledError
 from .routing.activity_context import ActivityContext
 from .routing.router import ActivityHandler, ActivityRouter
@@ -76,6 +77,7 @@ class ActivityProcessor:
         fetch_user_token: bool = True,
         agent365_baggage_options: Agent365BaggageOptions | bool | None = None,
         state_loader: Optional[TurnStateLoader] = None,
+        oauth_registry: Optional[OAuthFlowRegistry] = None,
     ) -> None:
         self.router = router
         self.id = id
@@ -89,6 +91,7 @@ class ActivityProcessor:
         self.fetch_user_token = fetch_user_token
         self.agent365_baggage_options = agent365_baggage_options
         self.state_loader = state_loader
+        self.oauth_registry = oauth_registry
 
         # This will be set after the EventManager is initialized due to
         # a circular dependency
@@ -163,6 +166,7 @@ class ActivityProcessor:
             self.default_connection_name,
             app_token=lambda: self.get_app_graph_token(tenant_id),
             cloud=self.cloud,
+            oauth_connection_names=list(self.oauth_registry) if self.oauth_registry is not None else None,
         )
 
         send = activityCtx.send

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
@@ -3,6 +3,8 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+from typing import Optional
+
 from opentelemetry import metrics, trace
 from opentelemetry.metrics import Counter, Histogram, Meter
 from opentelemetry.trace import Span, Status, StatusCode, Tracer
@@ -113,12 +115,20 @@ def record_oauth_error(connection_name: str, operation: str, error_type: str) ->
     )
 
 
-def record_oauth_operation(connection_name: str, operation: str, result: str, duration_ms: float) -> None:
+def record_oauth_operation(connection_name: Optional[str], operation: str, result: str, duration_ms: float) -> None:
+    """Record an OAuth operation.
+
+    ``connection_name`` is optional because a ``signin/failure`` callback cannot
+    always be attributed to a connection. When it is ``None`` the connection
+    attribute is omitted rather than guessed, so queries never see an unrelated
+    connection blamed for the failure.
+    """
     attributes = {
-        APP_ATTRIBUTE_NAMES.oauth_connection: connection_name,
         APP_ATTRIBUTE_NAMES.oauth_operation: operation,
         APP_ATTRIBUTE_NAMES.oauth_result: result,
     }
+    if connection_name is not None:
+        attributes[APP_ATTRIBUTE_NAMES.oauth_connection] = connection_name
     get_oauth_operations_counter().add(1, attributes)
     get_oauth_operation_duration_histogram().record(duration_ms, attributes)
 

--- a/packages/apps/src/microsoft_teams/apps/oauth_connection.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_connection.py
@@ -1,0 +1,54 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Any, Optional
+
+# One definition of what an OAuth connection name is, shared by the registry, the
+# pending-state keys and the callback handlers so they can never disagree about
+# whether two spellings mean the same connection.
+#
+# Names are compared case-insensitively but stored with the casing the app
+# registered, because that casing is what the Token Service and the Azure Bot
+# configuration display. Surrounding whitespace is never significant: it is
+# almost always a copy-paste artefact from the portal, and treating "graph" and
+# "graph " as different connections silently breaks routing.
+#
+# ``lower()`` rather than ``casefold()`` is deliberate. It matches the existing
+# stored keys and the other SDKs, so a name that round-tripped through another
+# implementation still resolves here.
+
+
+def normalize_connection_name(connection_name: str) -> str:
+    """Return the connection name with surrounding whitespace removed.
+
+    Args:
+        connection_name: The name as supplied by the app.
+
+    Returns:
+        The trimmed name, preserving its original casing.
+
+    Raises:
+        ValueError: if it is empty or only whitespace. A blank connection name
+            cannot address anything, so accepting one only defers the failure
+            to a confusing Token Service error later.
+    """
+    normalized = connection_name.strip()
+    if not normalized:
+        raise ValueError("OAuth connection name must not be blank.")
+    return normalized
+
+
+def connection_lookup_key(connection_name: Any) -> Optional[str]:
+    """Return the case-insensitive key for a connection name, or ``None``.
+
+    Lookups are deliberately lenient where registration is strict: a blank or
+    non-string name simply matches nothing, so ``Mapping`` semantics such as
+    ``registry.get(name)`` returning ``None`` and ``name in registry`` being
+    ``False`` keep working instead of raising.
+    """
+    if not isinstance(connection_name, str):
+        return None
+    normalized = connection_name.strip()
+    return normalized.lower() if normalized else None

--- a/packages/apps/src/microsoft_teams/apps/oauth_flow.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_flow.py
@@ -3,10 +3,11 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import inspect
 import logging
 from collections import OrderedDict
 from dataclasses import replace
-from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional, Tuple
+from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 from .events import SignInEvent, SignInFailureEvent
 from .oauth_connection import connection_lookup_key, normalize_connection_name
@@ -19,8 +20,47 @@ from .routing import ActivityContext, SignInOptions
 
 logger = logging.getLogger(__name__)
 
-SignInHandler = Callable[[SignInEvent], Awaitable[None]]
-SignInFailureHandler = Callable[[SignInFailureEvent], Awaitable[None]]
+SignInHandler = Union[
+    Callable[[SignInEvent], None],
+    Callable[[SignInEvent], Awaitable[None]],
+]
+SignInFailureHandler = Union[
+    Callable[[SignInFailureEvent], None],
+    Callable[[SignInFailureEvent], Awaitable[None]],
+]
+
+# Bound to the aliases above so the decorators hand back the exact function type
+# they were given instead of widening it to the union.
+SignInHandlerT = TypeVar("SignInHandlerT", bound=SignInHandler)
+SignInFailureHandlerT = TypeVar("SignInFailureHandlerT", bound=SignInFailureHandler)
+
+
+async def _dispatch_handlers(
+    handlers: Sequence[Callable[[Any], Union[None, Awaitable[None]]]],
+    event: Any,
+    connection_name: str,
+    kind: str,
+) -> None:
+    """Run each handler in registration order, one fully completed before the next.
+
+    Handlers may be sync or async, so the result is awaited only when it is
+    actually awaitable. A raising handler is logged and skipped rather than
+    propagated: it is a listener, and one broken listener must not hide the
+    remaining ones or turn a successful callback into a failed invoke response.
+    """
+    for handler in tuple(handlers):
+        try:
+            result = handler(event)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.exception(
+                "%s handler %r failed for connection %r; continuing with later handlers.",
+                kind,
+                getattr(handler, "__name__", handler),
+                connection_name,
+            )
+
 
 DEFAULT_OAUTH_CARD_TEXT = SignInOptions().oauth_card_text
 DEFAULT_SIGN_IN_BUTTON_TEXT = SignInOptions().sign_in_button_text
@@ -53,23 +93,41 @@ class OAuthFlow:
 
     # -- handler registration -------------------------------------------------
 
-    def on_signin(self, func: SignInHandler) -> SignInHandler:
-        """Register a handler for a successful sign-in on this connection."""
+    def on_signin(self, func: SignInHandlerT) -> SignInHandlerT:
+        """Register a handler for a successful sign-in on this connection.
+
+        The handler may be synchronous or asynchronous, and may be registered more
+        than once. Handlers run in registration order and are isolated from one
+        another: if one raises, the error is logged and the rest still run.
+        """
         self._on_signin.append(func)
         return func
 
-    def on_signin_failure(self, func: SignInFailureHandler) -> SignInFailureHandler:
-        """Register a handler for a failed silent-SSO attempt on this connection."""
+    def on_signin_failure(self, func: SignInFailureHandlerT) -> SignInFailureHandlerT:
+        """Register a handler for a failed silent-SSO attempt on this connection.
+
+        The handler may be synchronous or asynchronous, and may be registered more
+        than once. Handlers run in registration order and are isolated from one
+        another: if one raises, the error is logged and the rest still run.
+
+        A ``signin/failure`` callback carries no connection name, so the app matches
+        it against the pending sign-in recorded when the flow started. That record
+        lives in durable state when state is enabled, and otherwise in a short-lived
+        process-local cache. If neither resolves — most commonly because the callback
+        reached a different process than the one that started the sign-in — the
+        failure cannot be attributed, and **every** registered flow's failure
+        handlers are notified rather than none. Handlers that must act on only their
+        own connection should enable state, which makes attribution reliable across
+        processes.
+        """
         self._on_signin_failure.append(func)
         return func
 
     async def _invoke_signin_handlers(self, event: SignInEvent) -> None:
-        for handler in tuple(self._on_signin):
-            await handler(event)
+        await _dispatch_handlers(self._on_signin, event, self.connection_name, "on_signin")
 
     async def _invoke_signin_failure_handlers(self, event: SignInFailureEvent) -> None:
-        for handler in tuple(self._on_signin_failure):
-            await handler(event)
+        await _dispatch_handlers(self._on_signin_failure, event, self.connection_name, "on_signin_failure")
 
     # -- operations -----------------------------------------------------------
 

--- a/packages/apps/src/microsoft_teams/apps/oauth_flow.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_flow.py
@@ -6,9 +6,10 @@ Licensed under the MIT License.
 import logging
 from collections import OrderedDict
 from dataclasses import replace
-from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional
+from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional, Tuple
 
 from .events import SignInEvent, SignInFailureEvent
+from .oauth_connection import connection_lookup_key, normalize_connection_name
 from .oauth_state import (
     clear_pending_oauth_sign_in,
     get_pending_oauth_sign_ins,
@@ -38,11 +39,11 @@ class OAuthFlow:
         oauth_card_text: str = DEFAULT_OAUTH_CARD_TEXT,
         sign_in_button_text: str = DEFAULT_SIGN_IN_BUTTON_TEXT,
     ) -> None:
-        self.connection_name = connection_name
+        self.connection_name = normalize_connection_name(connection_name)
         self._defaults = SignInOptions(
             oauth_card_text=oauth_card_text,
             sign_in_button_text=sign_in_button_text,
-            connection_name=connection_name,
+            connection_name=self.connection_name,
         )
         self._on_signin: List[SignInHandler] = []
         self._on_signin_failure: List[SignInFailureHandler] = []
@@ -113,7 +114,12 @@ class OAuthFlowRegistry(Mapping[str, OAuthFlow]):
         self._flows: "OrderedDict[str, OAuthFlow]" = OrderedDict()
 
     def __getitem__(self, connection_name: str) -> OAuthFlow:
-        return self._flows[connection_name.lower()]
+        key = connection_lookup_key(connection_name)
+        if key is None:
+            # Blank or non-string names address nothing. Raising ``KeyError``
+            # rather than ``ValueError`` keeps ``.get()`` and ``in`` working.
+            raise KeyError(connection_name)
+        return self._flows[key]
 
     def __iter__(self) -> Iterator[str]:
         return (flow.connection_name for flow in self._flows.values())
@@ -123,7 +129,7 @@ class OAuthFlowRegistry(Mapping[str, OAuthFlow]):
 
     def add(self, flow: OAuthFlow) -> OAuthFlow:
         """Register a flow. Raises ``ValueError`` if the connection already exists."""
-        key = flow.connection_name.lower()
+        key = normalize_connection_name(flow.connection_name).lower()
         if key in self._flows:
             raise ValueError(
                 f"An OAuth flow for connection '{flow.connection_name}' is already "
@@ -133,8 +139,9 @@ class OAuthFlowRegistry(Mapping[str, OAuthFlow]):
         return flow
 
     def _pending_flows(self, ctx: ActivityContext[Any], *, sso_only: bool = False) -> List[OAuthFlow]:
+        conversation_id, user_id = _pending_scope(ctx)
         flows: List[OAuthFlow] = []
-        for pending in get_pending_oauth_sign_ins(ctx.state):
+        for pending in get_pending_oauth_sign_ins(ctx.state, conversation_id, user_id):
             if sso_only and not pending.sso_offered:
                 continue
             flow = self.get(pending.connection_name)
@@ -145,13 +152,22 @@ class OAuthFlowRegistry(Mapping[str, OAuthFlow]):
                     "Discarding pending OAuth sign-in state for connection '%s': no registered OAuth flow.",
                     pending.connection_name,
                 )
-                clear_pending_oauth_sign_in(ctx.state, pending.connection_name)
+                clear_pending_oauth_sign_in(ctx.state, pending.connection_name, conversation_id, user_id)
                 continue
             flows.append(flow)
         return flows
 
     def _clear_pending(self, ctx: ActivityContext[Any], connection_name: Optional[str] = None) -> None:
-        clear_pending_oauth_sign_in(ctx.state, connection_name)
+        conversation_id, user_id = _pending_scope(ctx)
+        clear_pending_oauth_sign_in(ctx.state, connection_name, conversation_id, user_id)
 
     def _mark_sso_consumed(self, ctx: ActivityContext[Any], connection_name: str) -> None:
-        mark_pending_oauth_sso_consumed(ctx.state, connection_name)
+        conversation_id, user_id = _pending_scope(ctx)
+        mark_pending_oauth_sso_consumed(ctx.state, connection_name, conversation_id, user_id)
+
+
+def _pending_scope(ctx: ActivityContext[Any]) -> Tuple[Optional[str], Optional[str]]:
+    """Conversation and user identifiers used to scope process-local pending hints."""
+    conversation = getattr(ctx.activity, "conversation", None)
+    sender = getattr(ctx.activity, "from_", None)
+    return getattr(conversation, "id", None), getattr(sender, "id", None)

--- a/packages/apps/src/microsoft_teams/apps/oauth_flow.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_flow.py
@@ -9,6 +9,11 @@ from dataclasses import replace
 from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional
 
 from .events import SignInEvent, SignInFailureEvent
+from .oauth_state import (
+    clear_pending_oauth_sign_in,
+    get_pending_oauth_sign_ins,
+    mark_pending_oauth_sso_consumed,
+)
 from .routing import ActivityContext, SignInOptions
 
 logger = logging.getLogger(__name__)
@@ -57,6 +62,14 @@ class OAuthFlow:
         self._on_signin_failure.append(func)
         return func
 
+    async def _invoke_signin_handlers(self, event: SignInEvent) -> None:
+        for handler in tuple(self._on_signin):
+            await handler(event)
+
+    async def _invoke_signin_failure_handlers(self, event: SignInFailureEvent) -> None:
+        for handler in tuple(self._on_signin_failure):
+            await handler(event)
+
     # -- operations -----------------------------------------------------------
 
     async def sign_in(self, ctx: ActivityContext[Any], options: Optional[SignInOptions] = None) -> Optional[str]:
@@ -66,7 +79,12 @@ class OAuthFlow:
         OAuth card and returns ``None``. If the caller passes their own
         ``SignInOptions`` their card text wins, but the connection name is
         always forced to this flow's — you cannot accidentally sign in on the
-        wrong connection through a flow object.
+        wrong connection through a flow object. When per-turn state is enabled,
+        a pending hint is recorded so connection-less verify-state callbacks
+        probe likely flows first and silent-SSO failures can be attributed to
+        this flow. Without state, verify-state probes the registered flows and
+        legacy default connection, while failures use the registered-flow
+        fallback.
         """
         base = self._defaults if options is None else options
         return await ctx.sign_in(replace(base, connection_name=self.connection_name))
@@ -113,3 +131,27 @@ class OAuthFlowRegistry(Mapping[str, OAuthFlow]):
             )
         self._flows[key] = flow
         return flow
+
+    def _pending_flows(self, ctx: ActivityContext[Any], *, sso_only: bool = False) -> List[OAuthFlow]:
+        flows: List[OAuthFlow] = []
+        for pending in get_pending_oauth_sign_ins(ctx.state):
+            if sso_only and not pending.sso_offered:
+                continue
+            flow = self.get(pending.connection_name)
+            if flow is None:
+                # Expected whenever ``ctx.sign_in()`` was used without registering a flow
+                # (the legacy default-connection app), so this is not a warning.
+                logger.debug(
+                    "Discarding pending OAuth sign-in state for connection '%s': no registered OAuth flow.",
+                    pending.connection_name,
+                )
+                clear_pending_oauth_sign_in(ctx.state, pending.connection_name)
+                continue
+            flows.append(flow)
+        return flows
+
+    def _clear_pending(self, ctx: ActivityContext[Any], connection_name: Optional[str] = None) -> None:
+        clear_pending_oauth_sign_in(ctx.state, connection_name)
+
+    def _mark_sso_consumed(self, ctx: ActivityContext[Any], connection_name: str) -> None:
+        mark_pending_oauth_sso_consumed(ctx.state, connection_name)

--- a/packages/apps/src/microsoft_teams/apps/oauth_pending_local.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_pending_local.py
@@ -1,0 +1,128 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import threading
+from collections import OrderedDict
+from time import time
+from typing import List, Optional, Tuple
+
+from .oauth_connection import connection_lookup_key
+
+# Process-local fallback for pending sign-in attribution.
+#
+# When per-turn state is enabled the pending hints live in user state and survive
+# restarts and multi-instance deployments. Apps that have not enabled state still
+# deserve accurate routing for the common single-instance case, so a sign-in
+# started here is remembered in memory just long enough for its callback to come
+# back. This mirrors the TypeScript and .NET fallback.
+#
+# Deliberate limits:
+#   * It is a fallback, never a cache. State, when available, always wins, and
+#     nothing here causes state to be enabled.
+#   * A callback handled by a different process finds nothing and falls back to
+#     the existing probing/fan-out behaviour, which is why this can stay small.
+#   * Entries are scoped to conversation *and* user, so two users signing in to
+#     the same connection in the same conversation never see each other's hints.
+
+_TTL_SECONDS = 300.0
+_MAX_ENTRIES = 1000
+
+# (conversation_id, user_id, connection key) -> (original name, created_at, sso_offered)
+_Key = Tuple[str, str, str]
+_Entry = Tuple[str, float, bool]
+
+_entries: "OrderedDict[_Key, _Entry]" = OrderedDict()
+_lock = threading.Lock()
+
+
+def record(
+    conversation_id: str,
+    user_id: str,
+    connection_name: str,
+    *,
+    sso_offered: bool,
+) -> None:
+    """Remember a sign-in that is awaiting its callback."""
+    key = _key(conversation_id, user_id, connection_name)
+    if key is None:
+        return
+
+    with _lock:
+        _prune(time())
+        # Re-inserting at the end keeps insertion order equal to age order, which
+        # is what makes the oldest-first eviction below deterministic.
+        _entries.pop(key, None)
+        _entries[key] = (connection_name.strip(), time(), sso_offered)
+        while len(_entries) > _MAX_ENTRIES:
+            _entries.popitem(last=False)
+
+
+def entries(conversation_id: str, user_id: str) -> List[_Entry]:
+    """Unexpired hints for this conversation and user, newest first."""
+    if not conversation_id or not user_id:
+        return []
+
+    now = time()
+    with _lock:
+        _prune(now)
+        found = [entry for (conv, user, _), entry in _entries.items() if conv == conversation_id and user == user_id]
+    return sorted(found, key=lambda entry: (-entry[1], entry[0].lower()))
+
+
+def clear(conversation_id: str, user_id: str, connection_name: Optional[str] = None) -> None:
+    """Drop one connection's hint, or every hint for this conversation and user."""
+    if not conversation_id or not user_id:
+        return
+
+    target = connection_lookup_key(connection_name) if connection_name is not None else None
+    if connection_name is not None and target is None:
+        return
+
+    with _lock:
+        for key in [
+            key
+            for key in _entries
+            if key[0] == conversation_id and key[1] == user_id and (target is None or key[2] == target)
+        ]:
+            _entries.pop(key, None)
+
+
+def replace(conversation_id: str, user_id: str, restored: List[_Entry]) -> None:
+    """Restore an exact prior set of hints, preserving their timestamps."""
+    if not conversation_id or not user_id:
+        return
+
+    clear(conversation_id, user_id)
+    with _lock:
+        for name, created_at, sso_offered in restored:
+            connection_key = connection_lookup_key(name)
+            if connection_key is None:
+                continue
+            _entries[(conversation_id, user_id, connection_key)] = (name.strip(), created_at, sso_offered)
+
+
+def mark_sso_consumed(conversation_id: str, user_id: str, connection_name: str) -> None:
+    """Retire a hint's silent-SSO marker, keeping it available for routing."""
+    key = _key(conversation_id, user_id, connection_name)
+    if key is None:
+        return
+
+    with _lock:
+        existing = _entries.get(key)
+        if existing is not None:
+            _entries[key] = (existing[0], existing[1], False)
+
+
+def _key(conversation_id: str, user_id: str, connection_name: str) -> Optional[_Key]:
+    if not conversation_id or not user_id:
+        return None
+    connection_key = connection_lookup_key(connection_name)
+    return None if connection_key is None else (conversation_id, user_id, connection_key)
+
+
+def _prune(now: float) -> None:
+    """Drop expired entries. Callers must hold ``_lock``."""
+    for key in [key for key, (_, created_at, _) in _entries.items() if now - created_at >= _TTL_SECONDS]:
+        _entries.pop(key, None)

--- a/packages/apps/src/microsoft_teams/apps/oauth_state.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_state.py
@@ -1,0 +1,203 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import logging
+from dataclasses import dataclass, replace
+from math import isfinite
+from time import time
+from typing import Any, Dict, List, Optional, cast
+
+from .state import TurnStateContainer
+
+logger = logging.getLogger(__name__)
+
+_PENDING_OAUTH_STATE_KEY = "__oauth:pending"
+_PENDING_OAUTH_STATE_VERSION = 1
+_PENDING_OAUTH_MAX_AGE_SECONDS = 5 * 60
+_PENDING_OAUTH_MAX_CLOCK_SKEW_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class PendingOAuthSignIn:
+    connection_name: str
+    created_at: float
+    sso_offered: bool
+
+
+def record_pending_oauth_sign_in(
+    state: Optional[TurnStateContainer],
+    connection_name: str,
+    *,
+    sso_offered: bool,
+) -> None:
+    if state is None or state.user is None:
+        return
+
+    pending = [
+        hint for hint in get_pending_oauth_sign_ins(state) if hint.connection_name.lower() != connection_name.lower()
+    ]
+    pending.append(
+        PendingOAuthSignIn(
+            connection_name=connection_name,
+            created_at=time(),
+            sso_offered=sso_offered,
+        )
+    )
+    _write_pending_oauth_sign_ins(state, pending)
+
+
+def get_pending_oauth_sign_ins(state: Optional[TurnStateContainer]) -> List[PendingOAuthSignIn]:
+    if state is None or state.user is None:
+        return []
+
+    raw = state.user.get(_PENDING_OAUTH_STATE_KEY)
+    if raw is None:
+        return []
+    if not isinstance(raw, dict):
+        _discard_malformed(state)
+        return []
+
+    value = cast(Dict[str, Any], raw)
+    raw_hints = value.get("hints")
+    if value.get("version") != _PENDING_OAUTH_STATE_VERSION or not isinstance(raw_hints, list):
+        _discard_malformed(state)
+        return []
+
+    now = time()
+    pending: List[PendingOAuthSignIn] = []
+    seen: set[str] = set()
+    stale_found = False
+    for raw_hint in reversed(cast(List[Any], raw_hints)):
+        hint = _parse_hint(raw_hint)
+        if hint is None:
+            _discard_malformed(state)
+            return []
+        if hint.created_at > now + _PENDING_OAUTH_MAX_CLOCK_SKEW_SECONDS:
+            _discard_malformed(state)
+            return []
+        if now - hint.created_at > _PENDING_OAUTH_MAX_AGE_SECONDS:
+            stale_found = True
+            continue
+        key = hint.connection_name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        pending.append(hint)
+
+    # Iteration above was newest-first, so this is already the order callers want.
+    pending.sort(key=lambda hint: hint.created_at, reverse=True)
+    if stale_found:
+        logger.warning("Discarding stale pending OAuth sign-in state.")
+        _write_pending_oauth_sign_ins(state, pending)
+    return pending
+
+
+def clear_pending_oauth_sign_in(
+    state: Optional[TurnStateContainer],
+    connection_name: Optional[str] = None,
+) -> None:
+    if state is None or state.user is None:
+        return
+    if connection_name is None:
+        state.user.pop(_PENDING_OAUTH_STATE_KEY, None)
+        return
+
+    pending = [
+        hint for hint in get_pending_oauth_sign_ins(state) if hint.connection_name.lower() != connection_name.lower()
+    ]
+    _write_pending_oauth_sign_ins(state, pending)
+
+
+def mark_pending_oauth_sso_consumed(
+    state: Optional[TurnStateContainer],
+    connection_name: str,
+) -> None:
+    """Retire a hint's silent-SSO marker while keeping it for callback routing.
+
+    Teams renders the sign-in button on the same OAuth card after a silent-SSO
+    failure, so the sign-in is still pending even though its SSO attempt is
+    spent. Dropping ``sso_offered`` stops the hint from re-attributing later
+    ``signin/failure`` callbacks while a follow-up ``signin/verifyState`` can
+    still be routed to the right connection. ``created_at`` is preserved so the
+    hint expires on its original schedule.
+    """
+    if state is None or state.user is None:
+        return
+
+    pending = get_pending_oauth_sign_ins(state)
+    updated = [
+        replace(hint, sso_offered=False) if hint.connection_name.lower() == connection_name.lower() else hint
+        for hint in pending
+    ]
+    if updated != pending:
+        _write_pending_oauth_sign_ins(state, updated)
+
+
+def replace_pending_oauth_sign_ins(
+    state: Optional[TurnStateContainer],
+    pending: List[PendingOAuthSignIn],
+) -> None:
+    if state is not None:
+        _write_pending_oauth_sign_ins(state, pending)
+
+
+def _parse_hint(raw: Any) -> Optional[PendingOAuthSignIn]:
+    if not isinstance(raw, dict):
+        return None
+
+    value = cast(Dict[str, Any], raw)
+    connection_name = value.get("connection_name")
+    created_at = value.get("created_at")
+    sso_offered = value.get("sso_offered")
+    if (
+        not isinstance(connection_name, str)
+        or not connection_name
+        or isinstance(created_at, bool)
+        or not isinstance(created_at, (int, float))
+        or not isinstance(sso_offered, bool)
+    ):
+        return None
+
+    try:
+        normalized_created_at = float(created_at)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    if not isfinite(normalized_created_at):
+        return None
+
+    return PendingOAuthSignIn(
+        connection_name=connection_name,
+        created_at=normalized_created_at,
+        sso_offered=sso_offered,
+    )
+
+
+def _write_pending_oauth_sign_ins(
+    state: TurnStateContainer,
+    pending: List[PendingOAuthSignIn],
+) -> None:
+    if state.user is None:
+        return
+    if not pending:
+        state.user.pop(_PENDING_OAUTH_STATE_KEY, None)
+        return
+
+    state.user[_PENDING_OAUTH_STATE_KEY] = {
+        "version": _PENDING_OAUTH_STATE_VERSION,
+        "hints": [
+            {
+                "connection_name": hint.connection_name,
+                "created_at": hint.created_at,
+                "sso_offered": hint.sso_offered,
+            }
+            for hint in pending
+        ],
+    }
+
+
+def _discard_malformed(state: TurnStateContainer) -> None:
+    logger.warning("Discarding malformed pending OAuth sign-in state.")
+    if state.user is not None:
+        state.user.pop(_PENDING_OAUTH_STATE_KEY, None)

--- a/packages/apps/src/microsoft_teams/apps/oauth_state.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_state.py
@@ -35,16 +35,19 @@ def record_pending_oauth_sign_in(
     if state is None or state.user is None:
         return
 
-    pending = [
-        hint for hint in get_pending_oauth_sign_ins(state) if hint.connection_name.lower() != connection_name.lower()
+    existing = [
+        hint
+        for hint in get_pending_oauth_sign_ins(state)
+        if hint.connection_name.lower() != connection_name.lower()
     ]
-    pending.append(
+    pending = [
         PendingOAuthSignIn(
             connection_name=connection_name,
             created_at=time(),
             sso_offered=sso_offered,
-        )
-    )
+        ),
+        *existing,
+    ]
     _write_pending_oauth_sign_ins(state, pending)
 
 

--- a/packages/apps/src/microsoft_teams/apps/oauth_state.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_state.py
@@ -13,6 +13,11 @@ from .state import TurnStateContainer
 
 logger = logging.getLogger(__name__)
 
+# Reserved user-state key holding the pending sign-in hints used to attribute
+# connection-less OAuth callbacks. The stored document is
+# ``{"version": 1, "hints": [{"connection_name", "created_at", "sso_offered"}, ...]}``
+# with at most one hint per connection (compared case-insensitively) and hints
+# ordered newest-first. Treat it as private; app code should not read or write it.
 _PENDING_OAUTH_STATE_KEY = "__oauth:pending"
 _PENDING_OAUTH_STATE_VERSION = 1
 _PENDING_OAUTH_MAX_AGE_SECONDS = 5 * 60
@@ -36,9 +41,7 @@ def record_pending_oauth_sign_in(
         return
 
     existing = [
-        hint
-        for hint in get_pending_oauth_sign_ins(state)
-        if hint.connection_name.lower() != connection_name.lower()
+        hint for hint in get_pending_oauth_sign_ins(state) if hint.connection_name.lower() != connection_name.lower()
     ]
     pending = [
         PendingOAuthSignIn(
@@ -72,7 +75,7 @@ def get_pending_oauth_sign_ins(state: Optional[TurnStateContainer]) -> List[Pend
     pending: List[PendingOAuthSignIn] = []
     seen: set[str] = set()
     stale_found = False
-    for raw_hint in reversed(cast(List[Any], raw_hints)):
+    for raw_hint in cast(List[Any], raw_hints):
         hint = _parse_hint(raw_hint)
         if hint is None:
             _discard_malformed(state)
@@ -89,7 +92,9 @@ def get_pending_oauth_sign_ins(state: Optional[TurnStateContainer]) -> List[Pend
         seen.add(key)
         pending.append(hint)
 
-    # Iteration above was newest-first, so this is already the order callers want.
+    # Hints are stored newest-first, so ``seen`` already keeps the freshest entry per
+    # connection. Sort anyway so callers can rely on the ordering even if the stored
+    # document was written by a different version or edited by hand.
     pending.sort(key=lambda hint: hint.created_at, reverse=True)
     if stale_found:
         logger.warning("Discarding stale pending OAuth sign-in state.")
@@ -187,6 +192,10 @@ def _write_pending_oauth_sign_ins(
         state.user.pop(_PENDING_OAUTH_STATE_KEY, None)
         return
 
+    # Every mutation funnels through here, so normalizing the order once keeps the
+    # stored ``hints`` list newest-first no matter which caller wrote it. The sort is
+    # stable, so hints sharing a ``created_at`` keep the order they were inserted in.
+    ordered = sorted(pending, key=lambda hint: hint.created_at, reverse=True)
     state.user[_PENDING_OAUTH_STATE_KEY] = {
         "version": _PENDING_OAUTH_STATE_VERSION,
         "hints": [
@@ -195,7 +204,7 @@ def _write_pending_oauth_sign_ins(
                 "created_at": hint.created_at,
                 "sso_offered": hint.sso_offered,
             }
-            for hint in pending
+            for hint in ordered
         ],
     }
 

--- a/packages/apps/src/microsoft_teams/apps/oauth_state.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_state.py
@@ -5,21 +5,30 @@ Licensed under the MIT License.
 
 import logging
 from dataclasses import dataclass, replace
-from math import isfinite
+from datetime import datetime, timezone
 from time import time
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, Iterator, List, Mapping, MutableMapping, Optional, Tuple
 
 from .state import TurnStateContainer
 
 logger = logging.getLogger(__name__)
 
-# Reserved user-state key holding the pending sign-in hints used to attribute
-# connection-less OAuth callbacks. The stored document is
-# ``{"version": 1, "hints": [{"connection_name", "created_at", "sso_offered"}, ...]}``
-# with at most one hint per connection (compared case-insensitively) and hints
-# ordered newest-first. Treat it as private; app code should not read or write it.
-_PENDING_OAUTH_STATE_KEY = "__oauth:pending"
-_PENDING_OAUTH_STATE_VERSION = 1
+# Reserved user-state keys recording the sign-ins that are still awaiting a
+# callback, used to attribute callbacks that do not name their connection:
+#
+#   ``__oauth:pending:{connection}``      written whenever a sign-in card is sent
+#   ``__oauth:pending:sso:{connection}``  also written when that card offered silent SSO
+#
+# Each holds an ISO 8601 UTC timestamp. Key layout and value format mirror the C#
+# SDK (``OAuthFlow.cs``) so all three SDKs describe this state identically; the
+# in-memory representation below stays Pythonic and converts at the boundary.
+#
+# Connection names are stored verbatim to preserve the casing the app registered,
+# while lookups compare case-insensitively. Treat these keys as private: they are
+# an implementation detail and app code should neither read nor write them.
+_PENDING_OAUTH_KEY_PREFIX = "__oauth:pending:"
+_SSO_MARKER_INFIX = "sso:"
+_PENDING_OAUTH_SSO_KEY_PREFIX = f"{_PENDING_OAUTH_KEY_PREFIX}{_SSO_MARKER_INFIX}"
 _PENDING_OAUTH_MAX_AGE_SECONDS = 5 * 60
 _PENDING_OAUTH_MAX_CLOCK_SKEW_SECONDS = 60
 
@@ -40,66 +49,29 @@ def record_pending_oauth_sign_in(
     if state is None or state.user is None:
         return
 
-    existing = [
-        hint for hint in get_pending_oauth_sign_ins(state) if hint.connection_name.lower() != connection_name.lower()
-    ]
-    pending = [
-        PendingOAuthSignIn(
-            connection_name=connection_name,
-            created_at=time(),
-            sso_offered=sso_offered,
-        ),
-        *existing,
-    ]
-    _write_pending_oauth_sign_ins(state, pending)
+    # Reading prunes expired and malformed markers, so a long-lived user state
+    # cannot accumulate entries for sign-ins that were never completed.
+    _read_markers(state)
+    # Drop any earlier attempt for this connection first: the stored casing may
+    # differ from the caller's, and only the newest attempt should survive.
+    _remove_connection(state, connection_name)
+
+    stamp = _format_timestamp(time())
+    state.user[_pending_key(connection_name)] = stamp
+    if sso_offered:
+        state.user[_sso_key(connection_name)] = stamp
 
 
 def get_pending_oauth_sign_ins(state: Optional[TurnStateContainer]) -> List[PendingOAuthSignIn]:
     if state is None or state.user is None:
         return []
 
-    raw = state.user.get(_PENDING_OAUTH_STATE_KEY)
-    if raw is None:
-        return []
-    if not isinstance(raw, dict):
-        _discard_malformed(state)
-        return []
-
-    value = cast(Dict[str, Any], raw)
-    raw_hints = value.get("hints")
-    if value.get("version") != _PENDING_OAUTH_STATE_VERSION or not isinstance(raw_hints, list):
-        _discard_malformed(state)
-        return []
-
-    now = time()
-    pending: List[PendingOAuthSignIn] = []
-    seen: set[str] = set()
-    stale_found = False
-    for raw_hint in cast(List[Any], raw_hints):
-        hint = _parse_hint(raw_hint)
-        if hint is None:
-            _discard_malformed(state)
-            return []
-        if hint.created_at > now + _PENDING_OAUTH_MAX_CLOCK_SKEW_SECONDS:
-            _discard_malformed(state)
-            return []
-        if now - hint.created_at > _PENDING_OAUTH_MAX_AGE_SECONDS:
-            stale_found = True
-            continue
-        key = hint.connection_name.lower()
-        if key in seen:
-            continue
-        seen.add(key)
-        pending.append(hint)
-
-    # Hints are stored newest-first, so ``seen`` already keeps the freshest entry per
-    # connection. Sort anyway so callers can rely on the ordering even if the stored
-    # document was written by a different version or edited by hand.
-    pending.sort(key=lambda hint: hint.created_at, reverse=True)
-    if stale_found:
-        logger.warning("Discarding stale pending OAuth sign-in state.")
-        _write_pending_oauth_sign_ins(state, pending)
-    return pending
+    # Newest first, so callers can attribute a callback to the most recent attempt.
+    # Connection name breaks ties to keep the order independent of storage order.
+    return sorted(
+        _read_markers(state).values(),
+        key=lambda hint: (-hint.created_at, hint.connection_name.lower()),
+    )
 
 
 def clear_pending_oauth_sign_in(
@@ -109,13 +81,11 @@ def clear_pending_oauth_sign_in(
     if state is None or state.user is None:
         return
     if connection_name is None:
-        state.user.pop(_PENDING_OAUTH_STATE_KEY, None)
+        for key in [key for key in state.user if key.startswith(_PENDING_OAUTH_KEY_PREFIX)]:
+            state.user.pop(key, None)
         return
 
-    pending = [
-        hint for hint in get_pending_oauth_sign_ins(state) if hint.connection_name.lower() != connection_name.lower()
-    ]
-    _write_pending_oauth_sign_ins(state, pending)
+    _remove_connection(state, connection_name)
 
 
 def mark_pending_oauth_sso_consumed(
@@ -134,82 +104,149 @@ def mark_pending_oauth_sso_consumed(
     if state is None or state.user is None:
         return
 
-    pending = get_pending_oauth_sign_ins(state)
-    updated = [
-        replace(hint, sso_offered=False) if hint.connection_name.lower() == connection_name.lower() else hint
-        for hint in pending
-    ]
-    if updated != pending:
-        _write_pending_oauth_sign_ins(state, updated)
+    target = connection_name.lower()
+    for key, name, is_sso_marker in _iter_markers(state.user):
+        if is_sso_marker and name.lower() == target:
+            state.user.pop(key, None)
 
 
 def replace_pending_oauth_sign_ins(
     state: Optional[TurnStateContainer],
     pending: List[PendingOAuthSignIn],
 ) -> None:
-    if state is not None:
-        _write_pending_oauth_sign_ins(state, pending)
-
-
-def _parse_hint(raw: Any) -> Optional[PendingOAuthSignIn]:
-    if not isinstance(raw, dict):
-        return None
-
-    value = cast(Dict[str, Any], raw)
-    connection_name = value.get("connection_name")
-    created_at = value.get("created_at")
-    sso_offered = value.get("sso_offered")
-    if (
-        not isinstance(connection_name, str)
-        or not connection_name
-        or isinstance(created_at, bool)
-        or not isinstance(created_at, (int, float))
-        or not isinstance(sso_offered, bool)
-    ):
-        return None
-
-    try:
-        normalized_created_at = float(created_at)
-    except (OverflowError, TypeError, ValueError):
-        return None
-    if not isfinite(normalized_created_at):
-        return None
-
-    return PendingOAuthSignIn(
-        connection_name=connection_name,
-        created_at=normalized_created_at,
-        sso_offered=sso_offered,
-    )
-
-
-def _write_pending_oauth_sign_ins(
-    state: TurnStateContainer,
-    pending: List[PendingOAuthSignIn],
-) -> None:
-    if state.user is None:
-        return
-    if not pending:
-        state.user.pop(_PENDING_OAUTH_STATE_KEY, None)
+    if state is None or state.user is None:
         return
 
-    # Every mutation funnels through here, so normalizing the order once keeps the
-    # stored ``hints`` list newest-first no matter which caller wrote it. The sort is
-    # stable, so hints sharing a ``created_at`` keep the order they were inserted in.
-    ordered = sorted(pending, key=lambda hint: hint.created_at, reverse=True)
-    state.user[_PENDING_OAUTH_STATE_KEY] = {
-        "version": _PENDING_OAUTH_STATE_VERSION,
-        "hints": [
-            {
-                "connection_name": hint.connection_name,
-                "created_at": hint.created_at,
-                "sso_offered": hint.sso_offered,
-            }
-            for hint in ordered
-        ],
+    clear_pending_oauth_sign_in(state)
+    for hint in pending:
+        stamp = _format_timestamp(hint.created_at)
+        state.user[_pending_key(hint.connection_name)] = stamp
+        if hint.sso_offered:
+            state.user[_sso_key(hint.connection_name)] = stamp
+
+
+def _pending_key(connection_name: str) -> str:
+    return f"{_PENDING_OAUTH_KEY_PREFIX}{connection_name}"
+
+
+def _sso_key(connection_name: str) -> str:
+    return f"{_PENDING_OAUTH_SSO_KEY_PREFIX}{connection_name}"
+
+
+def _iter_markers(user: Mapping[str, Any]) -> Iterator[Tuple[str, str, bool]]:
+    """Yield ``(key, connection_name, is_sso_marker)`` for every pending marker.
+
+    ``sso:`` is a legal start to a connection name, so ``__oauth:pending:sso:x``
+    only counts as the SSO marker for ``x`` when ``x``'s own marker is present;
+    otherwise it is the marker for a connection literally named ``sso:x``. The
+    two are indistinguishable only when connections ``x`` and ``sso:x`` are both
+    registered and ``x`` offered SSO, which the C# layout cannot express either.
+    """
+    keys = [key for key in user if key.startswith(_PENDING_OAUTH_KEY_PREFIX)]
+    present = set(keys)
+    for key in keys:
+        name = key[len(_PENDING_OAUTH_KEY_PREFIX) :]
+        if name.startswith(_SSO_MARKER_INFIX):
+            owner = name[len(_SSO_MARKER_INFIX) :]
+            if _pending_key(owner) in present:
+                yield key, owner, True
+                continue
+        yield key, name, False
+
+
+def _read_markers(state: TurnStateContainer) -> Dict[str, PendingOAuthSignIn]:
+    """Parse live markers into hints keyed by lowercased connection name.
+
+    Malformed, future-dated and expired markers are dropped from state as they
+    are encountered, so a single bad key never invalidates the others.
+    """
+    user = state.user
+    if user is None:
+        return {}
+
+    now = time()
+    hints: Dict[str, PendingOAuthSignIn] = {}
+    sso_owners: Dict[str, str] = {}
+    for key, name, is_sso_marker in list(_iter_markers(user)):
+        if key not in user:
+            # Already discarded while resolving a duplicate.
+            continue
+        created_at = _parse_timestamp(user.get(key))
+        if created_at is None:
+            logger.warning("Discarding malformed pending OAuth sign-in state at '%s'.", key)
+            user.pop(key, None)
+            continue
+        if created_at - now > _PENDING_OAUTH_MAX_CLOCK_SKEW_SECONDS:
+            logger.warning("Discarding pending OAuth sign-in state at '%s' dated in the future.", key)
+            user.pop(key, None)
+            continue
+        if now - created_at > _PENDING_OAUTH_MAX_AGE_SECONDS:
+            logger.warning("Discarding stale pending OAuth sign-in state at '%s'.", key)
+            user.pop(key, None)
+            continue
+
+        if is_sso_marker:
+            sso_owners[name.lower()] = name
+            continue
+
+        candidate = PendingOAuthSignIn(connection_name=name, created_at=created_at, sso_offered=False)
+        existing = hints.get(name.lower())
+        if existing is None:
+            hints[name.lower()] = candidate
+            continue
+        # Two keys differing only in case, which we never write but another SDK
+        # might. Keep the newer attempt so the choice is deterministic, and drop
+        # the loser's keys rather than leaving them to linger until they expire.
+        # ``sso_offered`` ends up true if either casing offered SSO.
+        loser, winner = (existing, candidate) if candidate.created_at >= existing.created_at else (candidate, existing)
+        _discard_marker(user, loser.connection_name)
+        hints[name.lower()] = winner
+
+    # An SSO marker must not outlive the sign-in it describes.
+    for lowered, owner in sso_owners.items():
+        if lowered not in hints:
+            user.pop(_sso_key(owner), None)
+
+    return {
+        lowered: replace(hint, sso_offered=True) if lowered in sso_owners else hint for lowered, hint in hints.items()
     }
 
 
-def _discard_malformed(state: TurnStateContainer) -> None:
-    logger.warning("Discarding malformed pending OAuth sign-in state.")
-    if state.user is not None:
-        state.user.pop(_PENDING_OAUTH_STATE_KEY, None)
+def _discard_marker(user: MutableMapping[str, Any], connection_name: str) -> None:
+    user.pop(_pending_key(connection_name), None)
+    user.pop(_sso_key(connection_name), None)
+
+
+def _remove_connection(state: TurnStateContainer, connection_name: str) -> None:
+    user = state.user
+    if user is None:
+        return
+
+    target = connection_name.lower()
+    for key, name, _ in list(_iter_markers(user)):
+        if name.lower() == target:
+            user.pop(key, None)
+
+
+def _format_timestamp(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def _parse_timestamp(raw: Any) -> Optional[float]:
+    """Parse a stored ISO 8601 timestamp, tolerating every shape C# emits.
+
+    ``datetime.fromisoformat`` accepts arbitrary fractional-second precision and
+    a ``Z`` suffix from Python 3.11 on, which covers .NET's ``DateTimeOffset``
+    serialization. A value carrying no offset is read as UTC; forcing the result
+    to be timezone-aware also makes ``timestamp()`` pure arithmetic, so it can
+    neither raise nor return a non-finite value for any parseable input.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()

--- a/packages/apps/src/microsoft_teams/apps/oauth_state.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_state.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from time import time
 from typing import Any, Dict, Iterator, List, Mapping, MutableMapping, Optional, Tuple
 
+from . import oauth_pending_local
+from .oauth_connection import connection_lookup_key
 from .state import TurnStateContainer
 
 logger = logging.getLogger(__name__)
@@ -43,8 +45,16 @@ def record_pending_oauth_sign_in(
     connection_name: str,
     *,
     sso_offered: bool,
+    conversation_id: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> None:
     if state is None or state.user is None:
+        oauth_pending_local.record(
+            conversation_id or "",
+            user_id or "",
+            connection_name,
+            sso_offered=sso_offered,
+        )
         return
 
     # Reading prunes expired and malformed markers, so a long-lived user state
@@ -60,9 +70,16 @@ def record_pending_oauth_sign_in(
         state.user[_sso_key(connection_name)] = stamp
 
 
-def get_pending_oauth_sign_ins(state: Optional[TurnStateContainer]) -> List[PendingOAuthSignIn]:
+def get_pending_oauth_sign_ins(
+    state: Optional[TurnStateContainer],
+    conversation_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> List[PendingOAuthSignIn]:
     if state is None or state.user is None:
-        return []
+        return [
+            PendingOAuthSignIn(connection_name=name, created_at=created_at, sso_offered=sso_offered)
+            for name, created_at, sso_offered in oauth_pending_local.entries(conversation_id or "", user_id or "")
+        ]
 
     # Newest first, so callers can attribute a callback to the most recent attempt.
     # Connection name breaks ties to keep the order independent of storage order.
@@ -75,8 +92,11 @@ def get_pending_oauth_sign_ins(state: Optional[TurnStateContainer]) -> List[Pend
 def clear_pending_oauth_sign_in(
     state: Optional[TurnStateContainer],
     connection_name: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> None:
     if state is None or state.user is None:
+        oauth_pending_local.clear(conversation_id or "", user_id or "", connection_name)
         return
     if connection_name is None:
         for key in [key for key in state.user if key.startswith(_PENDING_OAUTH_KEY_PREFIX)]:
@@ -89,6 +109,8 @@ def clear_pending_oauth_sign_in(
 def mark_pending_oauth_sso_consumed(
     state: Optional[TurnStateContainer],
     connection_name: str,
+    conversation_id: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> None:
     """Retire a hint's silent-SSO marker while keeping it for callback routing.
 
@@ -100,19 +122,27 @@ def mark_pending_oauth_sso_consumed(
     hint expires on its original schedule.
     """
     if state is None or state.user is None:
+        oauth_pending_local.mark_sso_consumed(conversation_id or "", user_id or "", connection_name)
         return
 
-    target = connection_name.lower()
+    target = connection_lookup_key(connection_name)
     for key, name, is_sso_marker in _iter_markers(state.user):
-        if is_sso_marker and name.lower() == target:
+        if is_sso_marker and connection_lookup_key(name) == target:
             state.user.pop(key, None)
 
 
 def replace_pending_oauth_sign_ins(
     state: Optional[TurnStateContainer],
     pending: List[PendingOAuthSignIn],
+    conversation_id: Optional[str] = None,
+    user_id: Optional[str] = None,
 ) -> None:
     if state is None or state.user is None:
+        oauth_pending_local.replace(
+            conversation_id or "",
+            user_id or "",
+            [(hint.connection_name, hint.created_at, hint.sso_offered) for hint in pending],
+        )
         return
 
     clear_pending_oauth_sign_in(state)
@@ -124,11 +154,13 @@ def replace_pending_oauth_sign_ins(
 
 
 def _pending_key(connection_name: str) -> str:
-    return f"{_PENDING_OAUTH_KEY_PREFIX}{connection_name}"
+    # Trim at the storage boundary so a stray space cannot create a second,
+    # unreachable marker for a connection that already has one.
+    return f"{_PENDING_OAUTH_KEY_PREFIX}{connection_name.strip()}"
 
 
 def _sso_key(connection_name: str) -> str:
-    return f"{_PENDING_OAUTH_SSO_KEY_PREFIX}{connection_name}"
+    return f"{_PENDING_OAUTH_SSO_KEY_PREFIX}{connection_name.strip()}"
 
 
 def _iter_markers(user: Mapping[str, Any]) -> Iterator[Tuple[str, str, bool]]:
@@ -220,9 +252,9 @@ def _remove_connection(state: TurnStateContainer, connection_name: str) -> None:
     if user is None:
         return
 
-    target = connection_name.lower()
+    target = connection_lookup_key(connection_name)
     for key, name, _ in list(_iter_markers(user)):
-        if name.lower() == target:
+        if connection_lookup_key(name) == target:
             user.pop(key, None)
 
 

--- a/packages/apps/src/microsoft_teams/apps/oauth_state.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_state.py
@@ -19,9 +19,7 @@ logger = logging.getLogger(__name__)
 #   ``__oauth:pending:{connection}``      written whenever a sign-in card is sent
 #   ``__oauth:pending:sso:{connection}``  also written when that card offered silent SSO
 #
-# Each holds an ISO 8601 UTC timestamp. Key layout and value format mirror the C#
-# SDK (``OAuthFlow.cs``) so all three SDKs describe this state identically; the
-# in-memory representation below stays Pythonic and converts at the boundary.
+# Each holds an ISO 8601 UTC timestamp.
 #
 # Connection names are stored verbatim to preserve the casing the app registered,
 # while lookups compare case-insensitively. Treat these keys as private: they are
@@ -140,7 +138,7 @@ def _iter_markers(user: Mapping[str, Any]) -> Iterator[Tuple[str, str, bool]]:
     only counts as the SSO marker for ``x`` when ``x``'s own marker is present;
     otherwise it is the marker for a connection literally named ``sso:x``. The
     two are indistinguishable only when connections ``x`` and ``sso:x`` are both
-    registered and ``x`` offered SSO, which the C# layout cannot express either.
+    registered and ``x`` offered SSO.
     """
     keys = [key for key in user if key.startswith(_PENDING_OAUTH_KEY_PREFIX)]
     present = set(keys)
@@ -233,7 +231,7 @@ def _format_timestamp(epoch_seconds: float) -> str:
 
 
 def _parse_timestamp(raw: Any) -> Optional[float]:
-    """Parse a stored ISO 8601 timestamp, tolerating every shape C# emits.
+    """Parse a stored ISO 8601 timestamp.
 
     ``datetime.fromisoformat`` accepts arbitrary fractional-second precision and
     a ``Z`` suffix from Python 3.11 on, which covers .NET's ``DateTimeOffset``

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -96,7 +96,13 @@ class AppOptions(TypedDict, total=False):
     default). Pass a ``StateOptions`` to configure the
     key prefix or a dedicated ``Storage`` backend. When enabled, handlers
     read/write ``ctx.state.conversation`` and ``ctx.state.user``; when off,
-    ``ctx.state`` is ``None``."""
+    ``ctx.state`` is ``None``.
+
+    Omitting this option leaves the decision open: registering an OAuth flow with
+    ``add_oauth_flow`` then enables state automatically, because connection-less
+    ``signin/verifyState`` and ``signin/failure`` callbacks need durable pending
+    attribution to reach the right flow. Pass ``state=False`` to opt out
+    explicitly — an explicit value is never overridden."""
     dangerously_allow_unauthenticated_requests: Optional[bool]
     """
     Whether to accept incoming requests without JWT validation.
@@ -194,7 +200,11 @@ class InternalAppOptions:
     storage: Optional[Storage[str, Any]] = None
     state: Optional[Union[bool, StateOptions]] = None
     """Per-turn state opt-in. ``None``/``False`` disables it; ``True`` enables it on
-    the app's shared storage; a ``StateOptions`` configures the key prefix or backend."""
+    the app's shared storage; a ``StateOptions`` configures the key prefix or backend.
+
+    ``None`` means "unset" rather than "off": registering an OAuth flow with
+    ``add_oauth_flow`` turns state on, since connection-less callbacks need durable
+    pending attribution. ``False`` is an explicit opt-out and is never overridden."""
     service_url: Optional[str] = None
     """
     Base Service URL for BotBackend.

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -46,6 +46,11 @@ from microsoft_teams.common.http.client_token import Token
 from ..activity_send import send_or_update_activity
 from ..files import FilesAccessor
 from ..http_stream import HttpStream
+from ..oauth_state import (
+    get_pending_oauth_sign_ins,
+    record_pending_oauth_sign_in,
+    replace_pending_oauth_sign_ins,
+)
 from ..plugins.streamer import StreamerProtocol
 from ..state import TurnStateContainer
 from ..utils import create_graph_client
@@ -397,7 +402,33 @@ class ActivityContext(Generic[T]):
             )
         )
 
-        await self.send(payload, self.conversation_ref)
+        previous_pending = get_pending_oauth_sign_ins(self.state)
+        try:
+            record_pending_oauth_sign_in(
+                self.state,
+                connection_name,
+                sso_offered=not is_channel and resource.token_exchange_resource is not None,
+            )
+            if self.state is not None:
+                await self.state._save()  # pyright: ignore[reportPrivateUsage]
+            await self.send(payload, self.conversation_ref)
+        except Exception:
+            # Best-effort rollback: the card never went out, so the pending hint must not
+            # linger and mis-route a later callback. A failure here must not replace the
+            # error the caller actually needs to see.
+            try:
+                replace_pending_oauth_sign_ins(self.state, previous_pending)
+                if self.state is not None:
+                    if self.state.user is not None:
+                        self.state.user._mark_dirty()  # pyright: ignore[reportPrivateUsage]
+                    await self.state._save()  # pyright: ignore[reportPrivateUsage]
+            except Exception:
+                self.logger.warning(
+                    "Failed to roll back pending OAuth sign-in state for connection '%s'.",
+                    connection_name,
+                    exc_info=True,
+                )
+            raise
 
         return None
 

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -8,7 +8,18 @@ import json
 import logging
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Generic, List, Optional, TypeGuard, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    List,
+    Optional,
+    Sequence,
+    TypeGuard,
+    TypeVar,
+)
 
 from httpx import HTTPStatusError
 from microsoft_teams.api import (
@@ -46,6 +57,7 @@ from microsoft_teams.common.http.client_token import Token
 from ..activity_send import send_or_update_activity
 from ..files import FilesAccessor
 from ..http_stream import HttpStream
+from ..oauth_connection import connection_lookup_key, normalize_connection_name
 from ..oauth_state import (
     get_pending_oauth_sign_ins,
     record_pending_oauth_sign_in,
@@ -99,6 +111,7 @@ class ActivityContext(Generic[T]):
         connection_name: str,
         app_token: Token,
         cloud: CloudEnvironment = PUBLIC,
+        oauth_connection_names: Optional[Sequence[str]] = None,
     ):
         self.activity = activity
         self.app_id = app_id
@@ -112,6 +125,10 @@ class ActivityContext(Generic[T]):
         self.cloud = cloud
         self.state: Optional[TurnStateContainer] = None
         self._app_token = app_token
+        # Connection names of the app's registered OAuth flows, in registration
+        # order. Names rather than the registry itself: the registry imports this
+        # module, so holding it here would be circular.
+        self._oauth_connection_names: List[str] = list(oauth_connection_names or [])
         self._stream: Optional[StreamerProtocol] = None
         self._files: Optional[FilesAccessor] = None
 
@@ -342,7 +359,7 @@ class ActivityContext(Generic[T]):
         signin_opts = options or DEFAULT_SIGNIN_OPTIONS
         oauth_card_text = signin_opts.oauth_card_text
         sign_in_button_text = signin_opts.sign_in_button_text
-        connection_name = signin_opts.connection_name or self.connection_name
+        connection_name = normalize_connection_name(signin_opts.connection_name or self.connection_name)
         try:
             # Try to get existing token
             token_params = GetUserTokenParams(
@@ -352,9 +369,13 @@ class ActivityContext(Generic[T]):
             )
             res = await self.api.users.get_token(token_params)
             return res.token
-        except Exception:
-            # Token not available, continue with OAuth flow
-            pass
+        except HTTPStatusError as e:
+            # 404 is the Token Service saying "no token cached", which is the only
+            # reason to fall through to a sign-in card. Anything else - a bad
+            # request, an expired exchange, an outage - is a real failure and must
+            # not be silently redecorated as "user needs to sign in".
+            if e.response.status_code != 404:
+                raise
 
         # Create token exchange state
         token_exchange_state = TokenExchangeState(
@@ -382,32 +403,48 @@ class ActivityContext(Generic[T]):
         if is_group:
             recipient.is_targeted = True
 
-        payload = MessageActivityInput(recipient=recipient).add_attachments(
-            card_attachment(
-                attachment=OAuthCardAttachment(
-                    content=OAuthCard(
-                        text=oauth_card_text,
-                        connection_name=connection_name,
-                        token_exchange_resource=None if is_channel else resource.token_exchange_resource,
-                        token_post_resource=resource.token_post_resource,
-                        buttons=[
-                            CardAction(
-                                type=CardActionType.SIGN_IN,
-                                title=sign_in_button_text,
-                                value=resource.sign_in_link,
-                            )
-                        ],
-                    )
-                ),
+        token_exchange_resource = None if is_channel else resource.token_exchange_resource
+        payload: ActivityParams
+        if signin_opts.override_sign_in_activity is not None:
+            payload = signin_opts.override_sign_in_activity(
+                token_exchange_resource,
+                resource.token_post_resource,
+                resource.sign_in_link,
             )
-        )
+            # A caller-built activity replaces the card, not the group-chat
+            # targeting rule, so the requesting user is still the recipient
+            # unless the override deliberately chose one.
+            if is_group and hasattr(payload, "recipient") and getattr(payload, "recipient", None) is None:
+                payload.recipient = recipient
+        else:
+            payload = MessageActivityInput(recipient=recipient).add_attachments(
+                card_attachment(
+                    attachment=OAuthCardAttachment(
+                        content=OAuthCard(
+                            text=oauth_card_text,
+                            connection_name=connection_name,
+                            token_exchange_resource=token_exchange_resource,
+                            token_post_resource=resource.token_post_resource,
+                            buttons=[
+                                CardAction(
+                                    type=CardActionType.SIGN_IN,
+                                    title=sign_in_button_text,
+                                    value=resource.sign_in_link,
+                                )
+                            ],
+                        )
+                    ),
+                )
+            )
 
-        previous_pending = get_pending_oauth_sign_ins(self.state)
+        previous_pending = get_pending_oauth_sign_ins(self.state, self.activity.conversation.id, self.activity.from_.id)
         try:
             record_pending_oauth_sign_in(
                 self.state,
                 connection_name,
-                sso_offered=not is_channel and resource.token_exchange_resource is not None,
+                sso_offered=token_exchange_resource is not None,
+                conversation_id=self.activity.conversation.id,
+                user_id=self.activity.from_.id,
             )
             if self.state is not None:
                 await self.state._save()  # pyright: ignore[reportPrivateUsage]
@@ -417,7 +454,12 @@ class ActivityContext(Generic[T]):
             # linger and mis-route a later callback. A failure here must not replace the
             # error the caller actually needs to see.
             try:
-                replace_pending_oauth_sign_ins(self.state, previous_pending)
+                replace_pending_oauth_sign_ins(
+                    self.state,
+                    previous_pending,
+                    self.activity.conversation.id,
+                    self.activity.from_.id,
+                )
                 if self.state is not None:
                     if self.state.user is not None:
                         self.state.user._mark_dirty()  # pyright: ignore[reportPrivateUsage]
@@ -441,18 +483,20 @@ class ActivityContext(Generic[T]):
         Args:
             connection_name: The connection to sign out of. Defaults to the
                 app's default connection.
+
+        Raises:
+            HTTPStatusError: if the Token Service rejects the request. A failed
+                sign-out leaves the token in place, so callers must be able to
+                see that it did not happen.
         """
-        connection_name = connection_name or self.connection_name
-        try:
-            sign_out_params = SignOutUserParams(
-                channel_id=self.activity.channel_id,
-                user_id=self.activity.from_.id,
-                connection_name=connection_name,
-            )
-            await self.api.users.sign_out(sign_out_params)
-            self.logger.debug(f"User {self.activity.from_.id} signed out of '{connection_name}'.")
-        except Exception as e:
-            self.logger.error(f"Failed to sign out user: {e}")
+        connection_name = normalize_connection_name(connection_name or self.connection_name)
+        sign_out_params = SignOutUserParams(
+            channel_id=self.activity.channel_id,
+            user_id=self.activity.from_.id,
+            connection_name=connection_name,
+        )
+        await self.api.users.sign_out(sign_out_params)
+        self.logger.debug(f"User {self.activity.from_.id} signed out of '{connection_name}'.")
 
     async def get_user_token(self, connection_name: Optional[str] = None) -> Optional[str]:
         """
@@ -493,10 +537,56 @@ class ActivityContext(Generic[T]):
         A single Token Service call returns the status for all connections, so
         the developer never needs to enumerate connection names manually.
         Service failures propagate rather than being reported as signed out.
+
+        The bulk call reports only connections the Token Service knows about, and
+        it can lag a token that was just written. Any registered OAuth flow that
+        comes back missing or ``has_token=False`` is therefore re-checked with a
+        direct per-connection lookup, so a freshly signed-in flow is never
+        reported as signed out. Connections that are not registered are passed
+        through untouched, and a non-404 lookup failure propagates.
         """
-        return await self.api.users.get_token_status(
+        statuses = await self.api.users.get_token_status(
             GetUserTokenStatusParams(
                 channel_id=self.activity.channel_id,
                 user_id=self.activity.from_.id,
             )
         )
+        if not self._oauth_connection_names:
+            return statuses
+
+        registered = {
+            key: name
+            for name, key in ((name, connection_lookup_key(name)) for name in self._oauth_connection_names)
+            if key is not None
+        }
+
+        corrected: List[TokenStatus] = []
+        resolved: set[str] = set()
+        for status in statuses:
+            key = connection_lookup_key(status.connection_name)
+            if key is not None:
+                resolved.add(key)
+            if key is None or key not in registered or status.has_token:
+                corrected.append(status)
+                continue
+            # Only reached when the bulk call said False, so a direct hit is a
+            # correction and a direct miss confirms the original answer.
+            if await self.get_user_token(registered[key]) is not None:
+                corrected.append(status.model_copy(update={"has_token": True}))
+            else:
+                corrected.append(status)
+
+        # Registered flows the bulk call omitted entirely.
+        for key, name in registered.items():
+            if key in resolved:
+                continue
+            corrected.append(
+                TokenStatus(
+                    channel_id=self.activity.channel_id,
+                    connection_name=name,
+                    has_token=await self.get_user_token(name) is not None,
+                    service_provider_display_name="",
+                )
+            )
+
+        return corrected

--- a/packages/apps/src/microsoft_teams/apps/state/container.py
+++ b/packages/apps/src/microsoft_teams/apps/state/container.py
@@ -11,6 +11,7 @@ from typing import Awaitable, Callable, Optional
 from .turn_state import TurnState
 
 _Deleter = Callable[[], Awaitable[None]]
+_Saver = Callable[["TurnStateContainer"], Awaitable[None]]
 
 
 @dataclass(kw_only=True)
@@ -34,6 +35,7 @@ class TurnStateContainer:
     user: Optional[TurnState] = None
     user_id: Optional[str] = None
     _deleter: Optional[_Deleter] = field(default=None, repr=False, compare=False)
+    _saver: Optional[_Saver] = field(default=None, repr=False, compare=False)
 
     def seal(self) -> None:
         """Seal every scope so post-turn access raises."""
@@ -56,3 +58,7 @@ class TurnStateContainer:
         if self.user is not None:
             self.user.clear()
             self.user.mark_clean()
+
+    async def _save(self) -> None:
+        if self._saver is not None:
+            await self._saver(self)

--- a/packages/apps/src/microsoft_teams/apps/state/container.py
+++ b/packages/apps/src/microsoft_teams/apps/state/container.py
@@ -5,7 +5,6 @@ Licensed under the MIT License.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Optional
 
 from .turn_state import TurnState
@@ -14,7 +13,6 @@ _Deleter = Callable[[], Awaitable[None]]
 _Saver = Callable[["TurnStateContainer"], Awaitable[None]]
 
 
-@dataclass(kw_only=True)
 class TurnStateContainer:
     """The state scopes loaded for one turn, together with the identity they
     were loaded for.
@@ -24,18 +22,69 @@ class TurnStateContainer:
 
     ``conversation_id``/``user_id`` record the identity this container was loaded
     for. The loader reads them back off the container when saving, so a save can
-    never be told to persist under a different key than it was loaded from.
+    never be told to persist under a different key than it was loaded from. That
+    guarantee is why they are read-only properties: rebinding either one mid-turn
+    would redirect the save to a different conversation or user while the scopes
+    still hold the original identity's data.
 
-    Fields are keyword-only so the public constructor is not tied to positional
-    order and can evolve without breaking callers.
+    Only the identity is bound. ``conversation``/``user`` and the injected
+    deleter/saver remain ordinary mutable attributes, and the ``TurnState`` scopes
+    stay mutable for the whole turn, which is how ``seal()`` and ``delete()`` work.
+
+    Constructor arguments are keyword-only so the public constructor is not tied to
+    positional order and can evolve without breaking callers.
     """
 
     conversation: TurnState
-    conversation_id: str
-    user: Optional[TurnState] = None
-    user_id: Optional[str] = None
-    _deleter: Optional[_Deleter] = field(default=None, repr=False, compare=False)
-    _saver: Optional[_Saver] = field(default=None, repr=False, compare=False)
+    user: Optional[TurnState]
+    _deleter: Optional[_Deleter]
+    _saver: Optional[_Saver]
+
+    def __init__(
+        self,
+        *,
+        conversation: TurnState,
+        conversation_id: str,
+        user: Optional[TurnState] = None,
+        user_id: Optional[str] = None,
+        _deleter: Optional[_Deleter] = None,
+        _saver: Optional[_Saver] = None,
+    ) -> None:
+        self._conversation_id = conversation_id
+        self._user_id = user_id
+        self.conversation = conversation
+        self.user = user
+        self._deleter = _deleter
+        self._saver = _saver
+
+    @property
+    def conversation_id(self) -> str:
+        """Conversation this container was loaded for. Fixed at construction."""
+        return self._conversation_id
+
+    @property
+    def user_id(self) -> Optional[str]:
+        """User this container was loaded for, if any. Fixed at construction."""
+        return self._user_id
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__qualname__}(conversation={self.conversation!r}, "
+            f"conversation_id={self._conversation_id!r}, "
+            f"user={self.user!r}, user_id={self._user_id!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        # Matches the __eq__ the dataclass used to generate: same four fields,
+        # injected hooks excluded, and instances of other classes rejected.
+        if not isinstance(other, TurnStateContainer) or other.__class__ is not self.__class__:
+            return NotImplemented
+        return (self.conversation, self._conversation_id, self.user, self._user_id) == (
+            other.conversation,
+            other._conversation_id,
+            other.user,
+            other._user_id,
+        )
 
     def seal(self) -> None:
         """Seal every scope so post-turn access raises."""

--- a/packages/apps/src/microsoft_teams/apps/state/loader.py
+++ b/packages/apps/src/microsoft_teams/apps/state/loader.py
@@ -63,6 +63,7 @@ class TurnStateLoader:
             conversation_id=conversation_id,
             user_id=user_id,
             _deleter=_delete,
+            _saver=self.save,
         )
 
     async def save(self, container: TurnStateContainer) -> None:

--- a/packages/apps/src/microsoft_teams/apps/state/turn_state.py
+++ b/packages/apps/src/microsoft_teams/apps/state/turn_state.py
@@ -65,6 +65,9 @@ class TurnState(MutableMapping[str, Any]):
         if fingerprint is not None:
             self._baseline = fingerprint
 
+    def _mark_dirty(self) -> None:
+        self._baseline = None
+
     def to_dict(self) -> Dict[str, Any]:
         """Return a shallow copy of the raw contents (used for serialization).
 

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -703,7 +703,7 @@ class TestActivityContextSignIn:
         assert sent_payload.recipient is not None
         assert sent_payload.recipient.is_targeted is not True
         assert ctx.state.user is not None
-        # Two keys per connection with ISO 8601 values: the layout shared with the C# SDK.
+        # Two keys per connection with ISO 8601 values.
         # No SSO was offered here, so only the base marker is written.
         pending = ctx.state.user["__oauth:pending:test-connection"]
         assert "__oauth:pending:sso:test-connection" not in ctx.state.user

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -11,7 +11,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from httpx import HTTPStatusError, Request, Response
+from httpx import ConnectError, HTTPStatusError, Request, Response
 from microsoft_teams.api import (
     Account,
     ConversationAccount,
@@ -21,13 +21,14 @@ from microsoft_teams.api import (
     SentActivity,
     TargetedMessageInfoEntity,
     TokenExchangeResource,
+    TokenStatus,
 )
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.api.models.entity import QuotedReplyData, QuotedReplyEntity
 from microsoft_teams.apps import TurnState, TurnStateContainer
 from microsoft_teams.apps.oauth_state import get_pending_oauth_sign_ins
-from microsoft_teams.apps.routing.activity_context import ActivityContext
+from microsoft_teams.apps.routing.activity_context import ActivityContext, SignInOptions
 from microsoft_teams.apps.state import TurnStateLoader
 from microsoft_teams.common import LocalStorage
 
@@ -36,6 +37,7 @@ def _create_activity_context(
     is_signed_in: bool = False,
     user_token: str | None = None,
     activity: Any = None,
+    oauth_connection_names: list[str] | None = None,
 ) -> tuple[ActivityContext[Any], MagicMock]:
     mock_activity = activity if activity is not None else MagicMock()
 
@@ -110,6 +112,7 @@ def _create_activity_context(
         connection_name="test-connection",
         app_token=MagicMock(),
         cloud=PUBLIC,
+        oauth_connection_names=oauth_connection_names,
     )
     return ctx, mock_activity_sender
 
@@ -668,7 +671,7 @@ class TestActivityContextSignIn:
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
         loader = TurnStateLoader(LocalStorage())
         ctx.state = await loader.load("test-conversation", "user-001")
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
 
         resource_response = MagicMock()
         resource_response.token_exchange_resource = None
@@ -730,7 +733,7 @@ class TestActivityContextSignIn:
         ctx.state.user["__oauth:pending:existing-connection"] = previous
         await loader.save(ctx.state)
 
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
         resource_response = MagicMock(
             token_exchange_resource=None,
             token_post_resource=None,
@@ -775,7 +778,7 @@ class TestActivityContextSignIn:
         await loader.save(ctx.state)
         storage.async_set = AsyncMock(side_effect=[RuntimeError("save failed"), None])
 
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
         resource_response = MagicMock(
             token_exchange_resource=None,
             token_post_resource=None,
@@ -822,7 +825,7 @@ class TestActivityContextSignIn:
         ctx.state.user["__oauth:pending:existing-connection"] = pending_iso(time.time())
         await loader.save(ctx.state)
 
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
         resource_response = MagicMock(
             token_exchange_resource=None,
             token_post_resource=None,
@@ -864,7 +867,7 @@ class TestActivityContextSignIn:
             user=TurnState(),
             user_id="user-001",
         )
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
         ctx.api.conversations.create = AsyncMock()
 
         resource_response = MagicMock()
@@ -914,7 +917,7 @@ class TestActivityContextSignIn:
         mock_activity.conversation.conversation_type = "channel"
 
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
         ctx.api.conversations.create = AsyncMock()
 
         resource_response = MagicMock()
@@ -957,7 +960,7 @@ class TestActivityContextSignIn:
         )
 
         ctx, _ = _create_activity_context(activity=mock_activity)
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
 
         resource_response = MagicMock()
         resource_response.token_exchange_resource = None
@@ -1002,7 +1005,7 @@ class TestActivityContextSignIn:
         ctx, _ = _create_activity_context(activity=mock_activity)
         loader = TurnStateLoader(LocalStorage())
         ctx.state = await loader.load("test-conversation", "user-001")
-        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
 
         resource_response = MagicMock()
         resource_response.token_exchange_resource = None
@@ -1058,22 +1061,21 @@ class TestActivityContextSignOut:
             assert "user-success" in logged
 
     @pytest.mark.asyncio
-    async def test_sign_out_logs_error_and_does_not_raise_on_failure(self) -> None:
-        """sign_out logs the error but does not propagate exceptions."""
+    async def test_sign_out_propagates_token_service_failure(self) -> None:
+        """sign_out surfaces Token Service failures instead of swallowing them.
+
+        A failed sign-out leaves the token in place. Logging and returning would
+        tell the caller the user is signed out when they are not.
+        """
         mock_activity = MagicMock()
         mock_activity.channel_id = "msteams"
         mock_activity.from_.id = "user-003"
 
         ctx, _ = _create_activity_context(activity=mock_activity)
-        ctx.api.users.sign_out = AsyncMock(side_effect=Exception("API failure"))
+        ctx.api.users.sign_out = AsyncMock(side_effect=_http_status_error(500))
 
-        with patch.object(ctx.logger, "error") as mock_log_error:
-            # Should not raise
+        with pytest.raises(HTTPStatusError):
             await ctx.sign_out()
-
-            mock_log_error.assert_called_once()
-            logged_message = mock_log_error.call_args[0][0]
-            assert "Failed to sign out user" in logged_message
 
 
 class TestActivityContextTokenHelpers:
@@ -1315,3 +1317,324 @@ class TestActivityContextPromptPreview:
 
         sent_activity = mock_sender.send.call_args[0][0]
         assert sent_activity.entities is None
+
+
+class TestSignInCachedTokenErrorPrecedence:
+    """sign_in only falls back to a card when the Token Service says 404."""
+
+    @staticmethod
+    def _context() -> tuple[ActivityContext[Any], MagicMock]:
+        activity = MessageActivity(
+            id="activity-id",
+            channel_id="msteams",
+            from_=Account(id="user-001"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id="test-conversation", is_group=False),
+        )
+        ctx, sender = _create_activity_context(activity=activity)
+        resource = MagicMock()
+        resource.token_exchange_resource = None
+        resource.token_post_resource = None
+        resource.sign_in_link = "https://login.example.com"
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource)
+        return ctx, sender
+
+    @pytest.mark.asyncio
+    async def test_404_falls_back_to_the_oauth_card(self) -> None:
+        """404 is the only "user has no token yet" answer."""
+        ctx, sender = self._context()
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
+
+        assert await ctx.sign_in() is None
+        sender.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [400, 401, 412, 429, 500, 503])
+    async def test_other_http_statuses_propagate(self, status_code: int) -> None:
+        """A rejected request or an outage is not a signed-out user.
+
+        Swallowing these showed the user a sign-in card during an incident and
+        hid the real cause from the developer.
+        """
+        ctx, sender = self._context()
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(status_code))
+
+        with pytest.raises(HTTPStatusError):
+            await ctx.sign_in()
+        sender.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_propagates(self) -> None:
+        """A connection error never reached the Token Service at all."""
+        ctx, sender = self._context()
+        ctx.api.users.get_token = AsyncMock(side_effect=ConnectError("connection refused"))
+
+        with pytest.raises(ConnectError):
+            await ctx.sign_in()
+        sender.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_programming_error_propagates(self) -> None:
+        """A bug in the token path must not be reported as "please sign in"."""
+        ctx, sender = self._context()
+        ctx.api.users.get_token = AsyncMock(side_effect=TypeError("bad argument"))
+
+        with pytest.raises(TypeError):
+            await ctx.sign_in()
+        sender.send.assert_not_awaited()
+
+
+class TestSignInOverrideActivity:
+    """SignInOptions.override_sign_in_activity replaces the default OAuth card."""
+
+    @staticmethod
+    def _context(is_group: bool = False, conversation_type: str | None = None):
+        activity = MessageActivity(
+            id="activity-id",
+            channel_id="msteams",
+            from_=Account(id="user-001"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(
+                id="test-conversation",
+                is_group=is_group,
+                conversation_type=conversation_type,
+            ),
+        )
+        ctx, sender = _create_activity_context(activity=activity)
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
+        resource = MagicMock()
+        resource.token_exchange_resource = TokenExchangeResource(id="exchange-id")
+        resource.token_post_resource = None
+        resource.sign_in_link = "https://login.example.com"
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource)
+        return ctx, sender
+
+    @pytest.mark.asyncio
+    async def test_override_activity_is_sent_instead_of_the_card(self) -> None:
+        """Red-green: before this change the option was read by nothing at all."""
+        ctx, sender = self._context()
+        override = MessageActivityInput(text="custom sign-in prompt")
+
+        assert await ctx.sign_in(SignInOptions(override_sign_in_activity=lambda *_: override)) is None
+
+        sent = sender.send.call_args[0][0]
+        assert sent is override
+        assert sent.attachments is None
+
+    @pytest.mark.asyncio
+    async def test_override_receives_the_sign_in_resource(self) -> None:
+        """The callback needs the resource to build its own sign-in affordance."""
+        ctx, _ = self._context()
+        seen: list[Any] = []
+
+        def build(exchange_resource, post_resource, link):
+            seen.append((exchange_resource, post_resource, link))
+            return MessageActivityInput(text="custom")
+
+        await ctx.sign_in(SignInOptions(override_sign_in_activity=build))
+
+        assert len(seen) == 1
+        exchange_resource, _, link = seen[0]
+        assert exchange_resource is not None and exchange_resource.id == "exchange-id"
+        assert link == "https://login.example.com"
+
+    @pytest.mark.asyncio
+    async def test_override_in_a_channel_gets_no_exchange_resource(self) -> None:
+        """Channels cannot exchange silently, so the override must not offer it."""
+        ctx, _ = self._context(is_group=True, conversation_type="channel")
+        seen: list[Any] = []
+
+        def build(exchange_resource, post_resource, link):
+            seen.append(exchange_resource)
+            return MessageActivityInput(text="custom")
+
+        await ctx.sign_in(SignInOptions(override_sign_in_activity=build))
+
+        assert seen == [None]
+
+    @pytest.mark.asyncio
+    async def test_override_is_targeted_in_group_conversations(self) -> None:
+        """An override replaces the card, not the group-chat privacy rule."""
+        ctx, _ = self._context(is_group=True)
+
+        await ctx.sign_in(SignInOptions(override_sign_in_activity=lambda *_: MessageActivityInput(text="custom")))
+
+        ctx.api.conversations.create_targeted_activity.assert_called_once()
+        sent = ctx.api.conversations.create_targeted_activity.call_args.args[1]
+        assert sent.recipient is not None
+        assert sent.recipient.id == "user-001"
+        assert sent.recipient.is_targeted is True
+
+    @pytest.mark.asyncio
+    async def test_override_keeps_its_own_recipient(self) -> None:
+        """An explicit recipient is the caller's decision and is left alone.
+
+        It is also not silently promoted to a targeted message: targeting follows
+        ``recipient.is_targeted``, which the override did not set.
+        """
+        ctx, sender = self._context(is_group=True)
+        chosen = Account(id="someone-else")
+
+        await ctx.sign_in(
+            SignInOptions(override_sign_in_activity=lambda *_: MessageActivityInput(text="custom", recipient=chosen))
+        )
+
+        ctx.api.conversations.create_targeted_activity.assert_not_called()
+        assert sender.send.call_args[0][0].recipient.id == "someone-else"
+
+    @pytest.mark.asyncio
+    async def test_override_still_records_pending_attribution(self) -> None:
+        """Routing the callback must not depend on which activity was sent."""
+        loader = TurnStateLoader(LocalStorage())
+        ctx, _ = self._context()
+        ctx.state = await loader.load("test-conversation", "user-001")
+
+        await ctx.sign_in(
+            SignInOptions(
+                connection_name="graph",
+                override_sign_in_activity=lambda *_: MessageActivityInput(text="custom"),
+            )
+        )
+
+        pending = get_pending_oauth_sign_ins(ctx.state)
+        assert [hint.connection_name for hint in pending] == ["graph"]
+        assert pending[0].sso_offered is True
+
+    @pytest.mark.asyncio
+    async def test_override_send_failure_rolls_back_pending(self) -> None:
+        """A card that never went out must not leave a hint that mis-routes."""
+        loader = TurnStateLoader(LocalStorage())
+        ctx, sender = self._context()
+        ctx.state = await loader.load("test-conversation", "user-001")
+        sender.send.side_effect = RuntimeError("send failed")
+
+        with pytest.raises(RuntimeError, match="send failed"):
+            await ctx.sign_in(
+                SignInOptions(
+                    connection_name="graph",
+                    override_sign_in_activity=lambda *_: MessageActivityInput(text="custom"),
+                )
+            )
+
+        assert get_pending_oauth_sign_ins(ctx.state) == []
+
+
+class TestGetTokenStatusRegistryAware:
+    """get_token_status corrects the bulk call for registered flows."""
+
+    @staticmethod
+    def _context(connection_names: list[str] | None = None):
+        activity = MagicMock()
+        activity.channel_id = "msteams"
+        activity.from_.id = "user-1"
+        return _create_activity_context(activity=activity, oauth_connection_names=connection_names)[0]
+
+    @staticmethod
+    def _status(connection_name: str, has_token: bool) -> TokenStatus:
+        return TokenStatus(
+            channel_id="msteams",
+            connection_name=connection_name,
+            has_token=has_token,
+            service_provider_display_name="Contoso",
+        )
+
+    @pytest.mark.asyncio
+    async def test_without_registered_flows_the_bulk_result_is_returned_verbatim(self) -> None:
+        """Legacy single-connection apps see exactly what the service said."""
+        ctx = self._context()
+        statuses = [self._status("legacy", False)]
+        ctx.api.users.get_token_status = AsyncMock(return_value=statuses)
+        ctx.api.users.get_token = AsyncMock(side_effect=AssertionError("must not probe"))
+
+        assert await ctx.get_token_status() is statuses
+
+    @pytest.mark.asyncio
+    async def test_false_status_for_a_registered_flow_is_corrected(self) -> None:
+        """The bulk call can lag a token that was just written.
+
+        Red-green: without the per-flow lookup this reports has_token=False for a
+        connection the user is demonstrably signed in to.
+        """
+        ctx = self._context(["graph"])
+        ctx.api.users.get_token_status = AsyncMock(return_value=[self._status("graph", False)])
+        ctx.api.users.get_token = AsyncMock(return_value=MagicMock(token="a-token"))
+
+        result = await ctx.get_token_status()
+
+        assert [(s.connection_name, s.has_token) for s in result] == [("graph", True)]
+
+    @pytest.mark.asyncio
+    async def test_a_genuine_miss_stays_false(self) -> None:
+        """A confirmed absence is not rewritten."""
+        ctx = self._context(["graph"])
+        ctx.api.users.get_token_status = AsyncMock(return_value=[self._status("graph", False)])
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
+
+        result = await ctx.get_token_status()
+
+        assert [(s.connection_name, s.has_token) for s in result] == [("graph", False)]
+
+    @pytest.mark.asyncio
+    async def test_a_registered_flow_missing_from_the_bulk_result_is_added(self) -> None:
+        """The service only lists connections it knows; a flow may be absent."""
+        ctx = self._context(["graph"])
+        ctx.api.users.get_token_status = AsyncMock(return_value=[self._status("legacy", True)])
+        ctx.api.users.get_token = AsyncMock(return_value=MagicMock(token="a-token"))
+
+        result = await ctx.get_token_status()
+
+        assert [(s.connection_name, s.has_token) for s in result] == [("legacy", True), ("graph", True)]
+
+    @pytest.mark.asyncio
+    async def test_unregistered_connections_are_passed_through_untouched(self) -> None:
+        """Only registered flows are re-checked; everything else is verbatim."""
+        ctx = self._context(["graph"])
+        legacy = self._status("legacy", False)
+        ctx.api.users.get_token_status = AsyncMock(return_value=[legacy, self._status("graph", True)])
+        probes: list[str] = []
+
+        async def probe(params):
+            probes.append(params.connection_name)
+            return MagicMock(token="a-token")
+
+        ctx.api.users.get_token = AsyncMock(side_effect=probe)
+
+        result = await ctx.get_token_status()
+
+        assert result[0] is legacy
+        assert probes == []
+
+    @pytest.mark.asyncio
+    async def test_registry_casing_is_matched_case_insensitively(self) -> None:
+        """The service may echo a different casing than the app registered."""
+        ctx = self._context(["Graph"])
+        ctx.api.users.get_token_status = AsyncMock(return_value=[self._status("GRAPH", False)])
+        ctx.api.users.get_token = AsyncMock(return_value=MagicMock(token="a-token"))
+
+        result = await ctx.get_token_status()
+
+        # Corrected in place: one row, keeping the service's own casing.
+        assert [(s.connection_name, s.has_token) for s in result] == [("GRAPH", True)]
+
+    @pytest.mark.asyncio
+    async def test_order_and_shape_are_preserved(self) -> None:
+        """Existing rows keep their order; additions go on the end."""
+        ctx = self._context(["b", "missing"])
+        ctx.api.users.get_token_status = AsyncMock(
+            return_value=[self._status("a", True), self._status("b", True), self._status("c", False)]
+        )
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
+
+        result = await ctx.get_token_status()
+
+        assert [s.connection_name for s in result] == ["a", "b", "c", "missing"]
+
+    @pytest.mark.asyncio
+    async def test_non_404_lookup_failure_propagates(self) -> None:
+        """An outage during the correction is not silently reported as False."""
+        ctx = self._context(["graph"])
+        ctx.api.users.get_token_status = AsyncMock(return_value=[self._status("graph", False)])
+        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(503))
+
+        with pytest.raises(HTTPStatusError):
+            await ctx.get_token_status()

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -1003,6 +1003,54 @@ class TestActivityContextSignIn:
         token_get_params = ctx.api.users.get_token.call_args[0][0]
         assert token_get_params.connection_name == "custom-connection"
 
+    @pytest.mark.asyncio
+    async def test_sign_in_stores_pending_hints_newest_first(self) -> None:
+        """The stored hints document keeps the most recent sign-in first."""
+        from microsoft_teams.apps.routing.activity_context import SignInOptions
+
+        mock_activity = MessageActivity(
+            id="activity-id",
+            channel_id="msteams",
+            from_=Account(id="user-001"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id="test-conversation", is_group=False),
+        )
+
+        ctx, _ = _create_activity_context(activity=mock_activity)
+        loader = TurnStateLoader(LocalStorage())
+        ctx.state = await loader.load("test-conversation", "user-001")
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+
+        resource_response = MagicMock()
+        resource_response.token_exchange_resource = None
+        resource_response.token_post_resource = None
+        resource_response.sign_in_link = "https://login.example.com"
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+        ):
+            await ctx.sign_in()
+            await ctx.sign_in(options=SignInOptions(connection_name="second-connection"))
+
+        assert ctx.state.user is not None
+        hints = ctx.state.user["__oauth:pending"]["hints"]
+        assert [hint["connection_name"] for hint in hints] == ["second-connection", "test-connection"]
+        assert hints[0]["created_at"] >= hints[1]["created_at"]
+
+        reloaded = await loader.load("test-conversation", "user-001")
+        assert reloaded.user is not None
+        assert [hint["connection_name"] for hint in reloaded.user["__oauth:pending"]["hints"]] == [
+            "second-connection",
+            "test-connection",
+        ]
+
 
 class TestActivityContextSignOut:
     """Tests for ActivityContext.sign_out()."""

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 # pyright: basic
 
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,11 +19,15 @@ from microsoft_teams.api import (
     MessageActivityInput,
     SentActivity,
     TargetedMessageInfoEntity,
+    TokenExchangeResource,
 )
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.api.models.entity import QuotedReplyData, QuotedReplyEntity
+from microsoft_teams.apps import TurnState, TurnStateContainer
 from microsoft_teams.apps.routing.activity_context import ActivityContext
+from microsoft_teams.apps.state import TurnStateLoader
+from microsoft_teams.common import LocalStorage
 
 
 def _create_activity_context(
@@ -654,6 +659,8 @@ class TestActivityContextSignIn:
         )
 
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        loader = TurnStateLoader(LocalStorage())
+        ctx.state = await loader.load("test-conversation", "user-001")
         ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
 
         resource_response = MagicMock()
@@ -664,6 +671,14 @@ class TestActivityContextSignIn:
 
         token_state = MagicMock()
         token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+
+        async def send_after_hint_persisted(activity):
+            persisted = await loader.load("test-conversation", "user-001")
+            assert persisted.user is not None
+            assert persisted.user["__oauth:pending"]["hints"][0]["connection_name"] == "test-connection"
+            return SentActivity(id="sent-activity-id", activity_params=activity)
+
+        mock_sender.send.side_effect = send_after_hint_persisted
         with (
             patch(
                 "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
@@ -680,6 +695,175 @@ class TestActivityContextSignIn:
         sent_payload = mock_sender.send.call_args.args[0]
         assert sent_payload.recipient is not None
         assert sent_payload.recipient.is_targeted is not True
+        assert ctx.state.user is not None
+        pending = ctx.state.user["__oauth:pending"]
+        assert pending["version"] == 1
+        assert pending["hints"][0]["connection_name"] == "test-connection"
+        assert pending["hints"][0]["sso_offered"] is False
+        assert isinstance(pending["hints"][0]["created_at"], float)
+
+        reloaded = await loader.load("test-conversation", "user-001")
+        assert reloaded.user is not None
+        assert reloaded.user["__oauth:pending"] == pending
+
+    @pytest.mark.asyncio
+    async def test_sign_in_restores_persisted_hints_when_card_send_fails(self) -> None:
+        mock_activity = MessageActivity(
+            id="activity-id",
+            channel_id="msteams",
+            from_=Account(id="user-001"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id="test-conversation", is_group=False),
+        )
+        ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        loader = TurnStateLoader(LocalStorage())
+        ctx.state = await loader.load("test-conversation", "user-001")
+        assert ctx.state.user is not None
+        previous = {
+            "version": 1,
+            "hints": [
+                {
+                    "connection_name": "existing-connection",
+                    "created_at": time.time(),
+                    "sso_offered": False,
+                }
+            ],
+        }
+        ctx.state.user["__oauth:pending"] = previous
+        await loader.save(ctx.state)
+
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        resource_response = MagicMock(
+            token_exchange_resource=None,
+            token_post_resource=None,
+            sign_in_link="https://login.example.com",
+        )
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+        mock_sender.send.side_effect = RuntimeError("send failed")
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+            pytest.raises(RuntimeError, match="send failed"),
+        ):
+            await ctx.sign_in()
+
+        reloaded = await loader.load("test-conversation", "user-001")
+        assert reloaded.user is not None
+        assert reloaded.user["__oauth:pending"] == previous
+
+    @pytest.mark.asyncio
+    async def test_sign_in_restores_hint_when_pre_send_persistence_fails(self) -> None:
+        mock_activity = MessageActivity(
+            id="activity-id",
+            channel_id="msteams",
+            from_=Account(id="user-001"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id="test-conversation", is_group=False),
+        )
+        ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        storage = LocalStorage()
+        loader = TurnStateLoader(storage)
+        ctx.state = await loader.load("test-conversation", "user-001")
+        assert ctx.state.user is not None
+        previous = {
+            "version": 1,
+            "hints": [
+                {
+                    "connection_name": "existing-connection",
+                    "created_at": time.time(),
+                    "sso_offered": False,
+                }
+            ],
+        }
+        ctx.state.user["__oauth:pending"] = previous
+        await loader.save(ctx.state)
+        storage.async_set = AsyncMock(side_effect=[RuntimeError("save failed"), None])
+
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        resource_response = MagicMock(
+            token_exchange_resource=None,
+            token_post_resource=None,
+            sign_in_link="https://login.example.com",
+        )
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+            pytest.raises(RuntimeError, match="save failed"),
+        ):
+            await ctx.sign_in()
+
+        mock_sender.send.assert_not_called()
+        assert storage.async_set.await_count == 2
+        assert ctx.state.user["__oauth:pending"] == previous
+        await loader.save(ctx.state)
+        assert storage.async_set.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_sign_in_rollback_failure_does_not_mask_original_error(self) -> None:
+        mock_activity = MessageActivity(
+            id="activity-id",
+            channel_id="msteams",
+            from_=Account(id="user-001"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id="test-conversation", is_group=False),
+        )
+        ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        storage = LocalStorage()
+        loader = TurnStateLoader(storage)
+        ctx.state = await loader.load("test-conversation", "user-001")
+        ctx.logger = MagicMock()
+        assert ctx.state.user is not None
+        # A pre-existing hint means the rollback is a write (not a delete), so the
+        # patched ``async_set`` below is what fails.
+        ctx.state.user["__oauth:pending"] = {
+            "version": 1,
+            "hints": [
+                {
+                    "connection_name": "existing-connection",
+                    "created_at": time.time(),
+                    "sso_offered": False,
+                }
+            ],
+        }
+        await loader.save(ctx.state)
+
+        ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
+        resource_response = MagicMock(
+            token_exchange_resource=None,
+            token_post_resource=None,
+            sign_in_link="https://login.example.com",
+        )
+        ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
+        mock_sender.send.side_effect = RuntimeError("send failed")
+        # First write (the pre-send flush) succeeds; the rollback write blows up.
+        storage.async_set = AsyncMock(side_effect=[None, RuntimeError("rollback save failed")])
+
+        token_state = MagicMock()
+        token_state.model_dump = MagicMock(return_value={"connection_name": "test-connection"})
+        with (
+            patch(
+                "microsoft_teams.apps.routing.activity_context.TokenExchangeState",
+                return_value=token_state,
+            ),
+            patch("microsoft_teams.apps.routing.activity_context.GetBotSignInResourceParams"),
+            pytest.raises(RuntimeError, match="send failed"),
+        ):
+            await ctx.sign_in()
+
+        ctx.logger.warning.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_sign_in_group_chat_sends_targeted_card(self) -> None:
@@ -692,11 +876,21 @@ class TestActivityContextSignIn:
         mock_activity.conversation.conversation_type = "groupChat"
 
         ctx, mock_sender = _create_activity_context(activity=mock_activity)
+        ctx.state = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="test-conversation",
+            user=TurnState(),
+            user_id="user-001",
+        )
         ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
         ctx.api.conversations.create = AsyncMock()
 
         resource_response = MagicMock()
-        resource_response.token_exchange_resource = None
+        resource_response.token_exchange_resource = TokenExchangeResource(
+            id="exchange-id",
+            uri="api://resource",
+            provider_id="provider",
+        )
         resource_response.token_post_resource = None
         resource_response.sign_in_link = "https://login.example.com"
         ctx.api._bots.sign_in.get_resource = AsyncMock(return_value=resource_response)
@@ -722,6 +916,9 @@ class TestActivityContextSignIn:
         assert sent_payload.recipient.is_targeted is True
         # SSO token exchange remains available in group chats.
         assert sent_payload.attachments[0].content.token_exchange_resource is resource_response.token_exchange_resource
+        assert ctx.state.user is not None
+        pending = ctx.state.user["__oauth:pending"]
+        assert pending["hints"][0]["sso_offered"] is True
 
     @pytest.mark.asyncio
     async def test_sign_in_channel_targets_and_omits_token_exchange(self) -> None:

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -6,6 +6,7 @@ Licensed under the MIT License.
 # pyright: basic
 
 import time
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,6 +26,7 @@ from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.api.models.entity import QuotedReplyData, QuotedReplyEntity
 from microsoft_teams.apps import TurnState, TurnStateContainer
+from microsoft_teams.apps.oauth_state import get_pending_oauth_sign_ins
 from microsoft_teams.apps.routing.activity_context import ActivityContext
 from microsoft_teams.apps.state import TurnStateLoader
 from microsoft_teams.common import LocalStorage
@@ -117,6 +119,11 @@ def _http_status_error(status_code: int) -> HTTPStatusError:
     request = Request("GET", "https://token.example/api/usertoken/GetToken")
     response = Response(status_code, request=request)
     return HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
+
+
+def pending_iso(epoch_seconds: float) -> str:
+    """Render a pending sign-in timestamp the way it is stored on the wire."""
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
 
 
 class TestActivityContextSendTargeted:
@@ -675,7 +682,7 @@ class TestActivityContextSignIn:
         async def send_after_hint_persisted(activity):
             persisted = await loader.load("test-conversation", "user-001")
             assert persisted.user is not None
-            assert persisted.user["__oauth:pending"]["hints"][0]["connection_name"] == "test-connection"
+            assert "__oauth:pending:test-connection" in persisted.user
             return SentActivity(id="sent-activity-id", activity_params=activity)
 
         mock_sender.send.side_effect = send_after_hint_persisted
@@ -696,15 +703,15 @@ class TestActivityContextSignIn:
         assert sent_payload.recipient is not None
         assert sent_payload.recipient.is_targeted is not True
         assert ctx.state.user is not None
-        pending = ctx.state.user["__oauth:pending"]
-        assert pending["version"] == 1
-        assert pending["hints"][0]["connection_name"] == "test-connection"
-        assert pending["hints"][0]["sso_offered"] is False
-        assert isinstance(pending["hints"][0]["created_at"], float)
+        # Two keys per connection with ISO 8601 values: the layout shared with the C# SDK.
+        # No SSO was offered here, so only the base marker is written.
+        pending = ctx.state.user["__oauth:pending:test-connection"]
+        assert "__oauth:pending:sso:test-connection" not in ctx.state.user
+        assert datetime.fromisoformat(pending).tzinfo is not None
 
         reloaded = await loader.load("test-conversation", "user-001")
         assert reloaded.user is not None
-        assert reloaded.user["__oauth:pending"] == pending
+        assert reloaded.user["__oauth:pending:test-connection"] == pending
 
     @pytest.mark.asyncio
     async def test_sign_in_restores_persisted_hints_when_card_send_fails(self) -> None:
@@ -719,17 +726,8 @@ class TestActivityContextSignIn:
         loader = TurnStateLoader(LocalStorage())
         ctx.state = await loader.load("test-conversation", "user-001")
         assert ctx.state.user is not None
-        previous = {
-            "version": 1,
-            "hints": [
-                {
-                    "connection_name": "existing-connection",
-                    "created_at": time.time(),
-                    "sso_offered": False,
-                }
-            ],
-        }
-        ctx.state.user["__oauth:pending"] = previous
+        previous = pending_iso(time.time())
+        ctx.state.user["__oauth:pending:existing-connection"] = previous
         await loader.save(ctx.state)
 
         ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
@@ -755,7 +753,8 @@ class TestActivityContextSignIn:
 
         reloaded = await loader.load("test-conversation", "user-001")
         assert reloaded.user is not None
-        assert reloaded.user["__oauth:pending"] == previous
+        assert reloaded.user["__oauth:pending:existing-connection"] == previous
+        assert "__oauth:pending:test-connection" not in reloaded.user
 
     @pytest.mark.asyncio
     async def test_sign_in_restores_hint_when_pre_send_persistence_fails(self) -> None:
@@ -771,17 +770,8 @@ class TestActivityContextSignIn:
         loader = TurnStateLoader(storage)
         ctx.state = await loader.load("test-conversation", "user-001")
         assert ctx.state.user is not None
-        previous = {
-            "version": 1,
-            "hints": [
-                {
-                    "connection_name": "existing-connection",
-                    "created_at": time.time(),
-                    "sso_offered": False,
-                }
-            ],
-        }
-        ctx.state.user["__oauth:pending"] = previous
+        previous = pending_iso(time.time())
+        ctx.state.user["__oauth:pending:existing-connection"] = previous
         await loader.save(ctx.state)
         storage.async_set = AsyncMock(side_effect=[RuntimeError("save failed"), None])
 
@@ -807,7 +797,8 @@ class TestActivityContextSignIn:
 
         mock_sender.send.assert_not_called()
         assert storage.async_set.await_count == 2
-        assert ctx.state.user["__oauth:pending"] == previous
+        assert ctx.state.user["__oauth:pending:existing-connection"] == previous
+        assert "__oauth:pending:test-connection" not in ctx.state.user
         await loader.save(ctx.state)
         assert storage.async_set.await_count == 2
 
@@ -828,16 +819,7 @@ class TestActivityContextSignIn:
         assert ctx.state.user is not None
         # A pre-existing hint means the rollback is a write (not a delete), so the
         # patched ``async_set`` below is what fails.
-        ctx.state.user["__oauth:pending"] = {
-            "version": 1,
-            "hints": [
-                {
-                    "connection_name": "existing-connection",
-                    "created_at": time.time(),
-                    "sso_offered": False,
-                }
-            ],
-        }
+        ctx.state.user["__oauth:pending:existing-connection"] = pending_iso(time.time())
         await loader.save(ctx.state)
 
         ctx.api.users.get_token = AsyncMock(side_effect=Exception("no token"))
@@ -917,8 +899,9 @@ class TestActivityContextSignIn:
         # SSO token exchange remains available in group chats.
         assert sent_payload.attachments[0].content.token_exchange_resource is resource_response.token_exchange_resource
         assert ctx.state.user is not None
-        pending = ctx.state.user["__oauth:pending"]
-        assert pending["hints"][0]["sso_offered"] is True
+        # SSO was offered, so both markers are written.
+        assert "__oauth:pending:test-connection" in ctx.state.user
+        assert "__oauth:pending:sso:test-connection" in ctx.state.user
 
     @pytest.mark.asyncio
     async def test_sign_in_channel_targets_and_omits_token_exchange(self) -> None:
@@ -1005,7 +988,7 @@ class TestActivityContextSignIn:
 
     @pytest.mark.asyncio
     async def test_sign_in_stores_pending_hints_newest_first(self) -> None:
-        """The stored hints document keeps the most recent sign-in first."""
+        """Pending hints are read back with the most recent sign-in first."""
         from microsoft_teams.apps.routing.activity_context import SignInOptions
 
         mock_activity = MessageActivity(
@@ -1040,13 +1023,16 @@ class TestActivityContextSignIn:
             await ctx.sign_in(options=SignInOptions(connection_name="second-connection"))
 
         assert ctx.state.user is not None
-        hints = ctx.state.user["__oauth:pending"]["hints"]
-        assert [hint["connection_name"] for hint in hints] == ["second-connection", "test-connection"]
-        assert hints[0]["created_at"] >= hints[1]["created_at"]
+        # Storage is one key per connection and carries no ordering of its own; the
+        # newest-first guarantee is applied when the hints are read back.
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(ctx.state)] == [
+            "second-connection",
+            "test-connection",
+        ]
 
         reloaded = await loader.load("test-conversation", "user-001")
         assert reloaded.user is not None
-        assert [hint["connection_name"] for hint in reloaded.user["__oauth:pending"]["hints"]] == [
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(reloaded)] == [
             "second-connection",
             "test-connection",
         ]

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -687,6 +687,23 @@ class TestOauthHandlers:
         assert isinstance(result, InvokeResponse) and result.body is None
         assert result.status == 412
 
+    @pytest.mark.asyncio
+    async def test_sign_in_verify_state_generic_exception_emits_error_event(
+        self, oauth_handlers, mock_context, verify_state_activity
+    ):
+        """A non-HTTP crash still reaches the app's global error handler."""
+        mock_context.activity = verify_state_activity
+        generic_error = ValueError("Generic error")
+        mock_context.api.users.get_token.side_effect = generic_error
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
+            "error", ErrorEvent(error=generic_error, context={"activity": verify_state_activity})
+        )
+        assert isinstance(result, InvokeResponse) and result.body is None
+        assert result.status == 412
+
     @pytest.fixture
     def failure_activity(self):
         """Create a SignInFailureInvokeActivity."""

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -80,11 +80,7 @@ def iso(epoch_seconds: float) -> str:
 
 
 def pending_marker_keys(state: TurnStateContainer) -> set[str]:
-    """The reserved pending sign-in keys currently stored in user state.
-
-    Asserting on the raw keys keeps these tests pinned to the on-the-wire layout
-    shared with the C# SDK, rather than to whatever the helpers happen to return.
-    """
+    """The reserved pending sign-in keys currently stored in user state."""
     assert state.user is not None
     return {key for key in state.user if key.startswith("__oauth:pending:")}
 

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import time
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, Mock
 
@@ -74,22 +75,28 @@ def create_turn_state(user_data: dict[str, Any] | None = None) -> TurnStateConta
     )
 
 
+def iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+def pending_marker_keys(state: TurnStateContainer) -> set[str]:
+    """The reserved pending sign-in keys currently stored in user state.
+
+    Asserting on the raw keys keeps these tests pinned to the on-the-wire layout
+    shared with the C# SDK, rather than to whatever the helpers happen to return.
+    """
+    assert state.user is not None
+    return {key for key in state.user if key.startswith("__oauth:pending:")}
+
+
 def create_pending_state(*hints: tuple[str, float, bool]) -> TurnStateContainer:
-    return create_turn_state(
-        {
-            "__oauth:pending": {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": connection_name,
-                        "created_at": created_at,
-                        "sso_offered": sso_offered,
-                    }
-                    for connection_name, created_at, sso_offered in hints
-                ],
-            }
-        }
-    )
+    user_data: dict[str, Any] = {}
+    for connection_name, created_at, sso_offered in hints:
+        stamp = iso(created_at)
+        user_data[f"__oauth:pending:{connection_name}"] = stamp
+        if sso_offered:
+            user_data[f"__oauth:pending:sso:{connection_name}"] = stamp
+    return create_turn_state(user_data)
 
 
 def oauth_http_error(status: int, message: str) -> HTTPStatusError:
@@ -978,7 +985,7 @@ class TestOauthHandlers:
         params = mock_context.api.users.get_token.call_args.args[0]
         assert params.connection_name == "GitHub"
         assert state.user is not None
-        assert "__oauth:pending" not in state.user
+        assert pending_marker_keys(state) == set()
 
     @pytest.mark.asyncio
     async def test_verify_state_probes_pending_hints_then_remaining_flows(
@@ -1014,8 +1021,7 @@ class TestOauthHandlers:
         assert attempted == ["Graph", "GitHub"]
         assert calls == ["github:GitHub"]
         assert state.user is not None
-        remaining = state.user["__oauth:pending"]["hints"]
-        assert [hint["connection_name"] for hint in remaining] == ["graph"]
+        assert pending_marker_keys(state) == {"__oauth:pending:graph", "__oauth:pending:sso:graph"}
 
     @pytest.mark.asyncio
     async def test_sso_failure_keeps_hint_so_button_click_still_routes_to_that_flow(
@@ -1049,7 +1055,7 @@ class TestOauthHandlers:
         assert attempted == ["GitHub"]
         assert calls == ["github:GitHub"]
         assert state.user is not None
-        assert "__oauth:pending" not in state.user
+        assert pending_marker_keys(state) == set()
 
     @pytest.mark.asyncio
     async def test_retired_sso_hint_does_not_attribute_a_second_failure(
@@ -1073,7 +1079,8 @@ class TestOauthHandlers:
         await oauth_handlers.sign_in_failure(mock_context)
         assert calls == ["github:GitHub", "github:GitHub"]
         assert mock_context.state.user is not None
-        assert [hint["sso_offered"] for hint in mock_context.state.user["__oauth:pending"]["hints"]] == [False]
+        # The SSO marker is retired; the sign-in itself is still pending.
+        assert pending_marker_keys(mock_context.state) == {"__oauth:pending:GitHub"}
 
     @pytest.mark.asyncio
     async def test_legacy_default_connection_hint_is_cleared_without_warning(
@@ -1093,7 +1100,7 @@ class TestOauthHandlers:
         params = mock_context.api.users.get_token.call_args.args[0]
         assert params.connection_name == "test-connection"
         assert state.user is not None
-        assert "__oauth:pending" not in state.user
+        assert pending_marker_keys(state) == set()
 
     @pytest.mark.asyncio
     async def test_sign_in_failure_routes_to_pending_flow_after_global_events(
@@ -1130,12 +1137,12 @@ class TestOauthHandlers:
             "github:GitHub",
         ]
         assert state.user is not None
-        remaining = state.user["__oauth:pending"]["hints"]
         # The failed connection keeps its hint (the card's sign-in button is still live) but
         # loses its SSO marker so it cannot re-attribute a second failure.
-        assert {hint["connection_name"]: hint["sso_offered"] for hint in remaining} == {
-            "test-connection": True,
-            "GitHub": False,
+        assert pending_marker_keys(state) == {
+            "__oauth:pending:test-connection",
+            "__oauth:pending:sso:test-connection",
+            "__oauth:pending:GitHub",
         }
 
     @pytest.mark.asyncio
@@ -1149,17 +1156,9 @@ class TestOauthHandlers:
         async def replace_hint(event):
             assert event.connection_name == "GitHub"
             assert state.user is not None
-            assert [hint["sso_offered"] for hint in state.user["__oauth:pending"]["hints"]] == [False]
-            state.user["__oauth:pending"] = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": "GitHub",
-                        "created_at": time.time(),
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            assert pending_marker_keys(state) == {"__oauth:pending:GitHub"}
+            state.user["__oauth:pending:GitHub"] = datetime.now(timezone.utc).isoformat()
+            state.user["__oauth:pending:sso:GitHub"] = state.user["__oauth:pending:GitHub"]
 
         oauth_handlers.event_emitter.on("sign_in_failure", replace_hint)
         mock_context.activity = failure_activity
@@ -1168,9 +1167,10 @@ class TestOauthHandlers:
         await oauth_handlers.sign_in_failure(mock_context)
 
         assert state.user is not None
-        remaining = state.user["__oauth:pending"]["hints"]
-        assert [hint["connection_name"] for hint in remaining] == [github.connection_name]
-        assert [hint["sso_offered"] for hint in remaining] == [True]
+        assert pending_marker_keys(state) == {
+            f"__oauth:pending:{github.connection_name}",
+            f"__oauth:pending:sso:{github.connection_name}",
+        }
 
     @pytest.mark.asyncio
     async def test_sign_in_failure_ignores_more_recent_non_sso_hint(
@@ -1255,7 +1255,7 @@ class TestOauthHandlers:
 
     @pytest.mark.parametrize(
         "pending_kind",
-        ["malformed", "unknown", "stale", "future", "nonfinite", "oversized"],
+        ["malformed", "not-iso", "unknown", "stale", "future", "nonfinite", "oversized"],
     )
     @pytest.mark.asyncio
     async def test_invalid_pending_attribution_falls_back_to_default_and_is_cleared(
@@ -1279,74 +1279,30 @@ class TestOauthHandlers:
         async def on_github(_):
             calls.append("github")
 
+        now = time.time()
         if pending_kind == "malformed":
-            pending: Any = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": ["GitHub"],
-                        "created_at": time.time(),
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            # A list is not a timestamp.
+            pending: Any = ["GitHub"]
+        elif pending_kind == "not-iso":
+            pending = "not-a-timestamp"
         elif pending_kind == "unknown":
-            pending = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": "Missing",
-                        "created_at": time.time(),
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            pending = iso(now)
         elif pending_kind == "stale":
-            pending = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": "GitHub",
-                        "created_at": time.time() - 301,
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            pending = iso(now - 301)
         elif pending_kind == "future":
-            pending = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": "GitHub",
-                        "created_at": time.time() + 61,
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            pending = iso(now + 61)
         elif pending_kind == "nonfinite":
-            pending = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": "GitHub",
-                        "created_at": float("inf"),
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            pending = float("inf")
         else:
-            pending = {
-                "version": 1,
-                "hints": [
-                    {
-                        "connection_name": "GitHub",
-                        "created_at": 10**1000,
-                        "sso_offered": True,
-                    }
-                ],
-            }
+            pending = 10**1000
 
-        state = create_turn_state({"__oauth:pending": pending})
+        connection = "Missing" if pending_kind == "unknown" else "GitHub"
+        state = create_turn_state(
+            {
+                f"__oauth:pending:{connection}": pending,
+                f"__oauth:pending:sso:{connection}": pending,
+            }
+        )
         mock_context.activity = verify_state_activity
         mock_context.state = state
         mock_context.api.users.get_token.return_value = mock_token_response
@@ -1358,7 +1314,7 @@ class TestOauthHandlers:
         params = mock_context.api.users.get_token.call_args.args[0]
         assert params.connection_name == "Test-Connection"
         assert state.user is not None
-        assert "__oauth:pending" not in state.user
+        assert pending_marker_keys(state) == set()
         assert "Discarding" in caplog.text
         warnings = [record for record in caplog.records if record.levelno >= logging.WARNING]
         if pending_kind == "unknown":

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -411,22 +411,24 @@ class TestOauthHandlers:
     async def test_sign_in_token_exchange_generic_exception(
         self, oauth_handlers, mock_context, token_exchange_activity
     ):
-        """Test token exchange with generic exception."""
+        """A non-HTTP crash propagates instead of being reported as a 412 miss.
+
+        412 tells Teams the exchange merely missed and to offer the sign-in
+        button. A transport fault or a bug is not a miss, so it travels up to the
+        app's error handling, which emits the ErrorEvent once and re-raises.
+        """
         mock_context.activity = token_exchange_activity
         generic_error = ValueError("Generic error")
         mock_context.api.users.exchange_token.side_effect = generic_error
 
-        result = await oauth_handlers.sign_in_token_exchange(mock_context)
+        with pytest.raises(ValueError, match="Generic error"):
+            await oauth_handlers.sign_in_token_exchange(mock_context)
 
-        # Verify error event emitted for non-HTTP exceptions
-        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
-            "error", ErrorEvent(error=generic_error, context={"activity": token_exchange_activity})
-        )
-
-        # Verify failure response
-        assert isinstance(result, InvokeResponse) and isinstance(result.body, TokenExchangeInvokeResponse)
-        assert result.status == 412
-        assert result.body.failure_detail == "Generic error"
+        # The app processor owns the ErrorEvent for propagated errors; emitting
+        # here too would report the same failure twice.
+        oauth_handlers.event_emitter.emit_async.assert_not_awaited()
+        # next() still runs, so the middleware chain is not left dangling.
+        mock_context.next.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sign_in_token_exchange_unexpected_exception_records_failure_oauth_error(
@@ -455,13 +457,14 @@ class TestOauthHandlers:
                 lambda *args: record_exception_calls.append(args),
             )
 
-            await oauth_handlers.sign_in_token_exchange(mock_context)
+            with pytest.raises(ValueError, match="Generic error"):
+                await oauth_handlers.sign_in_token_exchange(mock_context)
 
+        # No invoke.response.status: the handler never produced a response.
         assert tracer.spans[0].attributes == {
             "oauth.connection": "test-connection",
             "oauth.operation": "token_exchange",
             "oauth.error.type": "exception",
-            "invoke.response.status": 412,
             "oauth.result": "failure",
         }
         assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
@@ -609,13 +612,14 @@ class TestOauthHandlers:
                 lambda *args: record_exception_calls.append(args),
             )
 
-            await oauth_handlers.sign_in_verify_state(mock_context)
+            with pytest.raises(ValueError, match="Generic error"):
+                await oauth_handlers.sign_in_verify_state(mock_context)
 
+        # No invoke.response.status: the handler never produced a response.
         assert tracer.spans[0].attributes == {
             "oauth.connection": "test-connection",
             "oauth.operation": "verify_state",
             "oauth.error.type": "exception",
-            "invoke.response.status": 412,
             "oauth.result": "failure",
         }
         assert operation_calls[0][:3] == ("test-connection", "verify_state", "failure")
@@ -626,6 +630,7 @@ class TestOauthHandlers:
     async def test_sign_in_verify_state_expected_http_error_records_failure_without_oauth_error(
         self, oauth_handlers, mock_context, verify_state_activity
     ):
+        """An expected miss is not an OAuth error and ends as 404, not 412."""
         mock_context.activity = verify_state_activity
         mock_request = Mock(spec=Request)
         mock_response = Mock(spec=Response)
@@ -652,15 +657,85 @@ class TestOauthHandlers:
         assert tracer.spans[0].attributes == {
             "oauth.connection": "test-connection",
             "oauth.operation": "verify_state",
-            "invoke.response.status": 412,
-            "oauth.result": "failure",
+            "invoke.response.status": 404,
+            "oauth.result": "no_token",
         }
-        assert operation_calls[0][:3] == ("test-connection", "verify_state", "failure")
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "no_token")
         assert error_calls == []
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("status_code", [400, 404, 412])
+    async def test_sign_in_verify_state_expected_miss_statuses_end_as_404(
+        self, oauth_handlers, mock_context, verify_state_activity, status_code
+    ):
+        """400, 404 and 412 are all candidate misses, not terminal failures.
+
+        ``signin/verifyState`` carries no connection name, so the Token Service
+        rejecting a code only rules out the connection that was probed. Treating
+        400 or 412 as terminal would abandon the remaining candidates.
+        """
+        mock_context.activity = verify_state_activity
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = status_code
+        mock_context.api.users.get_token.side_effect = HTTPStatusError(
+            f"HTTP {status_code}", request=Mock(spec=Request), response=mock_response
+        )
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert isinstance(result, InvokeResponse) and result.body is None
+        assert result.status == 404
+
+    @pytest.mark.asyncio
+    async def test_sign_in_verify_state_probes_every_candidate_before_giving_up(
+        self, oauth_handlers, mock_context, verify_state_activity, mock_token_response
+    ):
+        """A miss on one candidate must not stop the probe.
+
+        Red-green: with 400 treated as terminal, the second connection is never
+        probed and this returns 404 instead of signing the user in.
+        """
+        mock_context.activity = verify_state_activity
+        flow = oauth_handlers.oauth_registry.add(OAuthFlow("graph"))
+
+        def responses(params):
+            if params.connection_name == "graph":
+                return mock_token_response
+            mock_response = Mock(spec=Response)
+            mock_response.status_code = 400
+            raise HTTPStatusError("Bad request", request=Mock(spec=Request), response=mock_response)
+
+        mock_context.api.users.get_token.side_effect = responses
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert result is None
+        probed = [call.args[0].connection_name for call in mock_context.api.users.get_token.await_args_list]
+        assert "graph" in probed
+        assert flow.connection_name == "graph"
+
+    @pytest.mark.asyncio
+    async def test_sign_in_verify_state_unexpected_http_status_stops_immediately(
+        self, oauth_handlers, mock_context, verify_state_activity
+    ):
+        """A 500 is not a miss, so probing stops and the status is preserved."""
+        mock_context.activity = verify_state_activity
+        oauth_handlers.oauth_registry.add(OAuthFlow("graph"))
+        mock_response = Mock(spec=Response)
+        mock_response.status_code = 500
+        mock_context.api.users.get_token.side_effect = HTTPStatusError(
+            "Server error", request=Mock(spec=Request), response=mock_response
+        )
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert isinstance(result, InvokeResponse)
+        assert result.status == 500
+        assert mock_context.api.users.get_token.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_sign_in_verify_state_http_error_404(self, oauth_handlers, mock_context, verify_state_activity):
-        """Test state verification with HTTP 404 error."""
+        """A 404 from the only candidate exhausts the probe and returns 404."""
         mock_context.activity = verify_state_activity
 
         # Create mock HTTP error
@@ -673,39 +748,37 @@ class TestOauthHandlers:
 
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 
-        # Verify 412 response
         assert isinstance(result, InvokeResponse) and result.body is None
-        assert result.status == 412
+        assert result.status == 404
 
     @pytest.mark.asyncio
     async def test_sign_in_verify_state_generic_exception(self, oauth_handlers, mock_context, verify_state_activity):
-        """Test state verification with generic exception."""
+        """A non-HTTP crash propagates rather than being flattened into a 412."""
         mock_context.activity = verify_state_activity
         generic_error = ValueError("Generic error")
         mock_context.api.users.get_token.side_effect = generic_error
 
-        result = await oauth_handlers.sign_in_verify_state(mock_context)
-
-        # Verify 412 response
-        assert isinstance(result, InvokeResponse) and result.body is None
-        assert result.status == 412
+        with pytest.raises(ValueError, match="Generic error"):
+            await oauth_handlers.sign_in_verify_state(mock_context)
 
     @pytest.mark.asyncio
-    async def test_sign_in_verify_state_generic_exception_emits_error_event(
+    async def test_sign_in_verify_state_generic_exception_does_not_double_report(
         self, oauth_handlers, mock_context, verify_state_activity
     ):
-        """A non-HTTP crash still reaches the app's global error handler."""
+        """The propagated crash is reported once, by the app processor.
+
+        ``ActivityProcessor`` already emits an ErrorEvent and re-raises for any
+        exception out of a handler, so emitting here as well would surface the
+        same failure twice. ``next()`` still runs from the finally block.
+        """
         mock_context.activity = verify_state_activity
-        generic_error = ValueError("Generic error")
-        mock_context.api.users.get_token.side_effect = generic_error
+        mock_context.api.users.get_token.side_effect = ValueError("Generic error")
 
-        result = await oauth_handlers.sign_in_verify_state(mock_context)
+        with pytest.raises(ValueError, match="Generic error"):
+            await oauth_handlers.sign_in_verify_state(mock_context)
 
-        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
-            "error", ErrorEvent(error=generic_error, context={"activity": verify_state_activity})
-        )
-        assert isinstance(result, InvokeResponse) and result.body is None
-        assert result.status == 412
+        oauth_handlers.event_emitter.emit_async.assert_not_awaited()
+        mock_context.next.assert_awaited_once()
 
     @pytest.fixture
     def failure_activity(self):

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -1251,7 +1251,7 @@ class TestOauthHandlers:
 
     @pytest.mark.parametrize(
         "pending_kind",
-        ["malformed", "not-iso", "unknown", "stale", "future", "nonfinite", "oversized"],
+        ["non-string", "not-iso", "unknown", "stale", "future"],
     )
     @pytest.mark.asyncio
     async def test_invalid_pending_attribution_falls_back_to_default_and_is_cleared(
@@ -1276,7 +1276,7 @@ class TestOauthHandlers:
             calls.append("github")
 
         now = time.time()
-        if pending_kind == "malformed":
+        if pending_kind == "non-string":
             # A list is not a timestamp.
             pending: Any = ["GitHub"]
         elif pending_kind == "not-iso":
@@ -1285,12 +1285,8 @@ class TestOauthHandlers:
             pending = iso(now)
         elif pending_kind == "stale":
             pending = iso(now - 301)
-        elif pending_kind == "future":
-            pending = iso(now + 61)
-        elif pending_kind == "nonfinite":
-            pending = float("inf")
         else:
-            pending = 10**1000
+            pending = iso(now + 61)
 
         connection = "Missing" if pending_kind == "unknown" else "GitHub"
         state = create_turn_state(

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -9,7 +9,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Iterator
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from httpx import HTTPStatusError, Request, Response
@@ -977,9 +977,12 @@ class TestOauthHandlers:
         assert calls == ["global", "flow"]
 
     @pytest.mark.asyncio
-    async def test_flow_handler_error_propagates_stops_later_handlers_and_still_calls_next(
+    async def test_flow_handler_error_does_not_stop_later_handlers_and_still_calls_next(
         self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
     ):
+        # Per-flow handlers go through EventEmitter.emit_async, which isolates
+        # them: a raising handler is logged, later handlers still run, and the
+        # failure does not escape into the invoke response.
         flow = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
         calls = []
         oauth_handlers.event_emitter.emit_async.side_effect = lambda name, _: calls.append(f"global:{name}")
@@ -990,16 +993,15 @@ class TestOauthHandlers:
             raise RuntimeError("handler failed")
 
         @flow.on_signin
-        async def skipped(_):
-            calls.append("flow:skipped")
+        async def still_runs(_):
+            calls.append("flow:still_runs")
 
         mock_context.activity = token_exchange_activity
         mock_context.api.users.exchange_token.return_value = mock_token_response
 
-        with pytest.raises(RuntimeError, match="handler failed"):
-            await oauth_handlers.sign_in_token_exchange(mock_context)
+        assert await oauth_handlers.sign_in_token_exchange(mock_context) is None
 
-        assert calls == ["global:sign_in", "flow:failing"]
+        assert calls == ["global:sign_in", "flow:failing", "flow:still_runs"]
         mock_context.next.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -1293,10 +1295,65 @@ class TestOauthHandlers:
 
         assert calls == [
             "global:error:None",
-            "global:sign_in_failure:test-connection",
+            # Registered flows exist but nothing attributed the callback, so the
+            # failed connection is unknown rather than the default. Fan-out still
+            # reaches every flow, each with its own canonical name.
+            "global:sign_in_failure:None",
             "graph:Graph",
             "github:GitHub",
         ]
+
+    @pytest.mark.asyncio
+    async def test_legacy_mode_without_registered_flows_reports_default_connection(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        # No flows registered, so the default connection is the only connection
+        # there is. Naming it is accurate here, unlike the registered case.
+        calls = []
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, event: calls.append(
+            f"global:{name}:{getattr(event, 'connection_name', None)}"
+        )
+        mock_context.activity = failure_activity
+        mock_context.state = None
+
+        with patch("microsoft_teams.apps.app_oauth.record_oauth_operation") as record:
+            assert await oauth_handlers.sign_in_failure(mock_context) is None
+
+        assert calls == ["global:error:None", "global:sign_in_failure:test-connection"]
+        assert record.call_args[0][0] == "test-connection"
+
+    @pytest.mark.asyncio
+    async def test_unattributed_failure_telemetry_does_not_name_the_default_connection(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        # The whole point of reporting None: a dashboard must not show
+        # "test-connection" failing when the failed connection is unknown.
+        oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        mock_context.activity = failure_activity
+        mock_context.state = None
+
+        with patch("microsoft_teams.apps.app_oauth.record_oauth_operation") as record:
+            assert await oauth_handlers.sign_in_failure(mock_context) is None
+
+        assert record.call_args[0][0] is None
+
+    @pytest.mark.asyncio
+    async def test_attributed_failure_telemetry_names_the_resolved_flow(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        mock_context.activity = failure_activity
+        mock_context.state = create_pending_state(
+            ("test-connection", time.time() - 10, True),
+            ("GitHub", time.time(), True),
+        )
+
+        with patch("microsoft_teams.apps.app_oauth.record_oauth_operation") as record:
+            assert await oauth_handlers.sign_in_failure(mock_context) is None
+
+        assert record.call_args[0][0] == "GitHub"
 
     @pytest.mark.asyncio
     async def test_registered_default_flow_handles_connectionless_callbacks_without_state(

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -3,7 +3,9 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import asyncio
 import logging
+import time
 from contextlib import contextmanager
 from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, Mock
@@ -35,6 +37,7 @@ from microsoft_teams.apps.oauth_flow import OAuthFlow, OAuthFlowRegistry
 from microsoft_teams.apps.routing import ActivityContext
 from microsoft_teams.apps.routing.activity_route_configs import ACTIVITY_ROUTES
 from microsoft_teams.apps.routing.router import ActivityRouter
+from microsoft_teams.apps.state import TurnState, TurnStateContainer
 from microsoft_teams.apps.token_provider import AppTokenProvider
 from microsoft_teams.common import EventEmitter, LocalStorage
 
@@ -62,6 +65,39 @@ class RecordingTracer:
         yield span
 
 
+def create_turn_state(user_data: dict[str, Any] | None = None) -> TurnStateContainer:
+    return TurnStateContainer(
+        conversation=TurnState(),
+        conversation_id="conv-456",
+        user=TurnState(user_data),
+        user_id="user-123",
+    )
+
+
+def create_pending_state(*hints: tuple[str, float, bool]) -> TurnStateContainer:
+    return create_turn_state(
+        {
+            "__oauth:pending": {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": connection_name,
+                        "created_at": created_at,
+                        "sso_offered": sso_offered,
+                    }
+                    for connection_name, created_at, sso_offered in hints
+                ],
+            }
+        }
+    )
+
+
+def oauth_http_error(status: int, message: str) -> HTTPStatusError:
+    request = Request("GET", "https://token.example")
+    response = Response(status, request=request)
+    return HTTPStatusError(message, request=request, response=response)
+
+
 class TestOauthHandlers:
     """Test cases for OauthHandlers class."""
 
@@ -84,6 +120,7 @@ class TestOauthHandlers:
         context.api.users.exchange_token = AsyncMock()
         context.api.users.get_token = AsyncMock()
         context.next = AsyncMock()
+        context.state = None
         return context
 
     @pytest.fixture
@@ -153,8 +190,13 @@ class TestOauthHandlers:
         assert call_args.exchange_request.token == "test-token"
 
         # Verify event emission
-        oauth_handlers.event_emitter.emit.assert_called_once_with(
-            "sign_in", SignInEvent(activity_ctx=mock_context, token_response=mock_token_response)
+        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
+            "sign_in",
+            SignInEvent(
+                activity_ctx=mock_context,
+                token_response=mock_token_response,
+                connection_name="test-connection",
+            ),
         )
 
         # Verify the context is marked signed-in with the exchanged token so
@@ -247,7 +289,7 @@ class TestOauthHandlers:
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
         # Verify no error event emitted for 404
-        oauth_handlers.event_emitter.emit.assert_not_called()
+        oauth_handlers.event_emitter.emit_async.assert_not_awaited()
 
         # Verify failure response
         assert isinstance(result, InvokeResponse) and isinstance(result.body, TokenExchangeInvokeResponse)
@@ -309,7 +351,7 @@ class TestOauthHandlers:
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
         # Verify error event emitted for 500
-        oauth_handlers.event_emitter.emit.assert_called_once_with(
+        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
             "error", ErrorEvent(error=http_error, context={"activity": token_exchange_activity})
         )
 
@@ -374,7 +416,7 @@ class TestOauthHandlers:
         result = await oauth_handlers.sign_in_token_exchange(mock_context)
 
         # Verify error event emitted for non-HTTP exceptions
-        oauth_handlers.event_emitter.emit.assert_called_once_with(
+        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
             "error", ErrorEvent(error=generic_error, context={"activity": token_exchange_activity})
         )
 
@@ -443,8 +485,13 @@ class TestOauthHandlers:
         assert call_args.code == "verify-state"
 
         # Verify event emission
-        oauth_handlers.event_emitter.emit.assert_called_once_with(
-            "sign_in", SignInEvent(activity_ctx=mock_context, token_response=mock_token_response)
+        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
+            "sign_in",
+            SignInEvent(
+                activity_ctx=mock_context,
+                token_response=mock_token_response,
+                connection_name="test-connection",
+            ),
         )
 
         # Verify the context is marked signed-in with the verified token so
@@ -524,7 +571,7 @@ class TestOauthHandlers:
         result = await oauth_handlers.sign_in_verify_state(mock_context)
 
         # Verify error event emitted
-        oauth_handlers.event_emitter.emit.assert_called_once_with(
+        oauth_handlers.event_emitter.emit_async.assert_awaited_once_with(
             "error", ErrorEvent(error=http_error, context={"activity": verify_state_activity})
         )
 
@@ -684,7 +731,7 @@ class TestOauthHandlers:
 
         await oauth_handlers.sign_in_failure(mock_context)
 
-        error_calls = [c for c in oauth_handlers.event_emitter.emit.call_args_list if c[0][0] == "error"]
+        error_calls = [c for c in oauth_handlers.event_emitter.emit_async.call_args_list if c[0][0] == "error"]
         assert len(error_calls) == 1
         error_event = error_calls[0][0][1]
         assert isinstance(error_event, ErrorEvent)
@@ -699,7 +746,9 @@ class TestOauthHandlers:
 
         await oauth_handlers.sign_in_failure(mock_context)
 
-        failure_calls = [c for c in oauth_handlers.event_emitter.emit.call_args_list if c[0][0] == "sign_in_failure"]
+        failure_calls = [
+            c for c in oauth_handlers.event_emitter.emit_async.call_args_list if c[0][0] == "sign_in_failure"
+        ]
         assert len(failure_calls) == 1
         event = failure_calls[0][0][1]
         assert isinstance(event, SignInFailureEvent)
@@ -752,6 +801,638 @@ class TestOauthHandlers:
         await oauth_handlers.sign_in_failure(mock_context)
 
         mock_context.next.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_token_exchange_routes_case_insensitive_explicit_connection_without_state(
+        self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
+    ):
+        graph = oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @graph.on_signin
+        async def on_graph(event):
+            calls.append(("graph", event.connection_name))
+
+        @github.on_signin
+        async def on_github(event):
+            calls.append(("github", event.connection_name))
+
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, event: calls.append(
+            (f"global:{name}", getattr(event, "connection_name", None))
+        )
+        token_exchange_activity.value.connection_name = "gItHuB"
+        mock_context.activity = token_exchange_activity
+        mock_context.state = None
+        mock_context.api.users.exchange_token.return_value = mock_token_response
+
+        result = await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert result is None
+        assert calls == [("global:sign_in", "GitHub"), ("github", "GitHub")]
+        params = mock_context.api.users.exchange_token.call_args.args[0]
+        assert params.connection_name == "gItHuB"
+
+    @pytest.mark.asyncio
+    async def test_token_exchange_invokes_global_then_flow_handlers_in_registration_order(
+        self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
+    ):
+        flow = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        calls = []
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, _: calls.append(f"global:{name}")
+
+        @flow.on_signin
+        async def first(_):
+            calls.append("flow:first")
+
+        @flow.on_signin
+        async def second(_):
+            calls.append("flow:second")
+
+        mock_context.activity = token_exchange_activity
+        mock_context.api.users.exchange_token.return_value = mock_token_response
+
+        await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert calls == ["global:sign_in", "flow:first", "flow:second"]
+
+    @pytest.mark.asyncio
+    async def test_async_global_handler_completes_before_flow_handler(
+        self, mock_context, token_exchange_activity, mock_token_response
+    ):
+        emitter = EventEmitter()
+        registry = OAuthFlowRegistry()
+        flow = registry.add(OAuthFlow("test-connection"))
+        handlers = OauthHandlers("test-connection", emitter, registry)
+        calls = []
+
+        async def global_handler(_):
+            await asyncio.sleep(0)
+            calls.append("global")
+
+        emitter.on("sign_in", global_handler)
+
+        @flow.on_signin
+        async def flow_handler(_):
+            calls.append("flow")
+
+        mock_context.activity = token_exchange_activity
+        mock_context.api.users.exchange_token.return_value = mock_token_response
+
+        await handlers.sign_in_token_exchange(mock_context)
+
+        assert calls == ["global", "flow"]
+
+    @pytest.mark.asyncio
+    async def test_flow_handler_error_propagates_stops_later_handlers_and_still_calls_next(
+        self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
+    ):
+        flow = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        calls = []
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, _: calls.append(f"global:{name}")
+
+        @flow.on_signin
+        async def failing(_):
+            calls.append("flow:failing")
+            raise RuntimeError("handler failed")
+
+        @flow.on_signin
+        async def skipped(_):
+            calls.append("flow:skipped")
+
+        mock_context.activity = token_exchange_activity
+        mock_context.api.users.exchange_token.return_value = mock_token_response
+
+        with pytest.raises(RuntimeError, match="handler failed"):
+            await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert calls == ["global:sign_in", "flow:failing"]
+        mock_context.next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_token_exchange_is_not_deduplicated_in_pr4(
+        self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
+    ):
+        flow = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        callback_count = 0
+
+        @flow.on_signin
+        async def on_signin(_):
+            nonlocal callback_count
+            callback_count += 1
+
+        mock_context.activity = token_exchange_activity
+        mock_context.api.users.exchange_token.return_value = mock_token_response
+
+        await oauth_handlers.sign_in_token_exchange(mock_context)
+        await oauth_handlers.sign_in_token_exchange(mock_context)
+
+        assert mock_context.api.users.exchange_token.await_count == 2
+        assert callback_count == 2
+
+    @pytest.mark.asyncio
+    async def test_verify_state_routes_to_pending_non_default_flow(
+        self, oauth_handlers, mock_context, verify_state_activity, mock_token_response
+    ):
+        default = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @default.on_signin
+        async def on_default(_):
+            calls.append("default")
+
+        @github.on_signin
+        async def on_github(event):
+            calls.append(f"github:{event.connection_name}")
+
+        state = create_pending_state(("github", time.time(), False))
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, event: calls.append(
+            f"global:{name}:{event.connection_name}"
+        )
+        mock_context.activity = verify_state_activity
+        mock_context.state = state
+        mock_context.api.users.get_token.return_value = mock_token_response
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert result is None
+        assert calls == ["global:sign_in:GitHub", "github:GitHub"]
+        params = mock_context.api.users.get_token.call_args.args[0]
+        assert params.connection_name == "GitHub"
+        assert state.user is not None
+        assert "__oauth:pending" not in state.user
+
+    @pytest.mark.asyncio
+    async def test_verify_state_probes_pending_hints_then_remaining_flows(
+        self, oauth_handlers, mock_context, verify_state_activity, mock_token_response
+    ):
+        graph = oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @graph.on_signin
+        async def on_graph(_):
+            calls.append("graph")
+
+        @github.on_signin
+        async def on_github(event):
+            calls.append(f"github:{event.connection_name}")
+
+        state = create_pending_state(
+            ("GitHub", time.time() - 10, False),
+            ("graph", time.time(), True),
+        )
+        mock_context.activity = verify_state_activity
+        mock_context.state = state
+        mock_context.api.users.get_token.side_effect = [
+            oauth_http_error(404, "Not found for Graph"),
+            mock_token_response,
+        ]
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert result is None
+        attempted = [call.args[0].connection_name for call in mock_context.api.users.get_token.await_args_list]
+        assert attempted == ["Graph", "GitHub"]
+        assert calls == ["github:GitHub"]
+        assert state.user is not None
+        remaining = state.user["__oauth:pending"]["hints"]
+        assert [hint["connection_name"] for hint in remaining] == ["graph"]
+
+    @pytest.mark.asyncio
+    async def test_sso_failure_keeps_hint_so_button_click_still_routes_to_that_flow(
+        self, oauth_handlers, mock_context, failure_activity, verify_state_activity, mock_token_response
+    ):
+        """After silent SSO fails, Teams shows the sign-in button on the same card.
+
+        The follow-up verify-state carries no connection name, so the retired hint is what
+        keeps it on GitHub instead of probing (and possibly mis-attributing to) Graph.
+        """
+        oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @github.on_signin
+        async def on_github(event):
+            calls.append(f"github:{event.connection_name}")
+
+        state = create_pending_state(("GitHub", time.time(), True))
+        mock_context.state = state
+
+        mock_context.activity = failure_activity
+        await oauth_handlers.sign_in_failure(mock_context)
+
+        mock_context.activity = verify_state_activity
+        mock_context.api.users.get_token.return_value = mock_token_response
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert result is None
+        attempted = [call.args[0].connection_name for call in mock_context.api.users.get_token.await_args_list]
+        assert attempted == ["GitHub"]
+        assert calls == ["github:GitHub"]
+        assert state.user is not None
+        assert "__oauth:pending" not in state.user
+
+    @pytest.mark.asyncio
+    async def test_retired_sso_hint_does_not_attribute_a_second_failure(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @github.on_signin_failure
+        async def on_github(event):
+            calls.append(f"github:{event.connection_name}")
+
+        mock_context.activity = failure_activity
+        mock_context.state = create_pending_state(("GitHub", time.time(), True))
+
+        await oauth_handlers.sign_in_failure(mock_context)
+        assert calls == ["github:GitHub"]
+
+        # Second failure: the hint's SSO marker is spent, so this falls back to the
+        # notify-all-registered-flows path rather than re-attributing to GitHub.
+        await oauth_handlers.sign_in_failure(mock_context)
+        assert calls == ["github:GitHub", "github:GitHub"]
+        assert mock_context.state.user is not None
+        assert [hint["sso_offered"] for hint in mock_context.state.user["__oauth:pending"]["hints"]] == [False]
+
+    @pytest.mark.asyncio
+    async def test_legacy_default_connection_hint_is_cleared_without_warning(
+        self, oauth_handlers, mock_context, verify_state_activity, mock_token_response, caplog
+    ):
+        """A legacy app (no registered flows) must not log warnings on its happy path."""
+        state = create_pending_state(("test-connection", time.time(), True))
+        mock_context.activity = verify_state_activity
+        mock_context.state = state
+        mock_context.api.users.get_token.return_value = mock_token_response
+
+        with caplog.at_level(logging.WARNING, logger="microsoft_teams.apps.oauth_flow"):
+            result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert result is None
+        assert caplog.records == []
+        params = mock_context.api.users.get_token.call_args.args[0]
+        assert params.connection_name == "test-connection"
+        assert state.user is not None
+        assert "__oauth:pending" not in state.user
+
+    @pytest.mark.asyncio
+    async def test_sign_in_failure_routes_to_pending_flow_after_global_events(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        default = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @default.on_signin_failure
+        async def on_default(_):
+            calls.append("default")
+
+        @github.on_signin_failure
+        async def on_github(event):
+            calls.append(f"github:{event.connection_name}")
+
+        state = create_pending_state(
+            ("test-connection", time.time() - 10, True),
+            ("GitHub", time.time(), True),
+        )
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, event: calls.append(
+            f"global:{name}:{getattr(event, 'connection_name', None)}"
+        )
+        mock_context.activity = failure_activity
+        mock_context.state = state
+
+        result = await oauth_handlers.sign_in_failure(mock_context)
+
+        assert result is None
+        assert calls == [
+            "global:error:None",
+            "global:sign_in_failure:GitHub",
+            "github:GitHub",
+        ]
+        assert state.user is not None
+        remaining = state.user["__oauth:pending"]["hints"]
+        # The failed connection keeps its hint (the card's sign-in button is still live) but
+        # loses its SSO marker so it cannot re-attribute a second failure.
+        assert {hint["connection_name"]: hint["sso_offered"] for hint in remaining} == {
+            "test-connection": True,
+            "GitHub": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_sign_in_failure_preserves_replacement_hint_created_by_global_handler(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        state = create_pending_state(("GitHub", time.time(), True))
+        oauth_handlers.event_emitter = EventEmitter()
+
+        async def replace_hint(event):
+            assert event.connection_name == "GitHub"
+            assert state.user is not None
+            assert [hint["sso_offered"] for hint in state.user["__oauth:pending"]["hints"]] == [False]
+            state.user["__oauth:pending"] = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": "GitHub",
+                        "created_at": time.time(),
+                        "sso_offered": True,
+                    }
+                ],
+            }
+
+        oauth_handlers.event_emitter.on("sign_in_failure", replace_hint)
+        mock_context.activity = failure_activity
+        mock_context.state = state
+
+        await oauth_handlers.sign_in_failure(mock_context)
+
+        assert state.user is not None
+        remaining = state.user["__oauth:pending"]["hints"]
+        assert [hint["connection_name"] for hint in remaining] == [github.connection_name]
+        assert [hint["sso_offered"] for hint in remaining] == [True]
+
+    @pytest.mark.asyncio
+    async def test_sign_in_failure_ignores_more_recent_non_sso_hint(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        graph = oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @graph.on_signin_failure
+        async def on_graph(event):
+            calls.append(f"graph:{event.connection_name}")
+
+        @github.on_signin_failure
+        async def on_github(_):
+            calls.append("github")
+
+        mock_context.activity = failure_activity
+        mock_context.state = create_pending_state(
+            ("Graph", time.time() - 10, True),
+            ("GitHub", time.time(), False),
+        )
+
+        await oauth_handlers.sign_in_failure(mock_context)
+
+        assert calls == ["graph:Graph"]
+
+    @pytest.mark.asyncio
+    async def test_sign_in_failure_without_attribution_notifies_all_registered_flows(
+        self, oauth_handlers, mock_context, failure_activity
+    ):
+        graph = oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+        oauth_handlers.event_emitter.emit_async.side_effect = lambda name, event: calls.append(
+            f"global:{name}:{getattr(event, 'connection_name', None)}"
+        )
+
+        @graph.on_signin_failure
+        async def on_graph(event):
+            calls.append(f"graph:{event.connection_name}")
+
+        @github.on_signin_failure
+        async def on_github(event):
+            calls.append(f"github:{event.connection_name}")
+
+        mock_context.activity = failure_activity
+        mock_context.state = None
+
+        await oauth_handlers.sign_in_failure(mock_context)
+
+        assert calls == [
+            "global:error:None",
+            "global:sign_in_failure:test-connection",
+            "graph:Graph",
+            "github:GitHub",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_registered_default_flow_handles_connectionless_callbacks_without_state(
+        self, oauth_handlers, mock_context, verify_state_activity, failure_activity, mock_token_response
+    ):
+        flow = oauth_handlers.oauth_registry.add(OAuthFlow("Test-Connection"))
+        calls = []
+
+        @flow.on_signin
+        async def on_signin(event):
+            calls.append(f"success:{event.connection_name}")
+
+        @flow.on_signin_failure
+        async def on_failure(event):
+            calls.append(f"failure:{event.connection_name}")
+
+        mock_context.state = None
+        mock_context.activity = verify_state_activity
+        mock_context.api.users.get_token.return_value = mock_token_response
+        await oauth_handlers.sign_in_verify_state(mock_context)
+        mock_context.activity = failure_activity
+        await oauth_handlers.sign_in_failure(mock_context)
+
+        assert calls == ["success:Test-Connection", "failure:Test-Connection"]
+
+    @pytest.mark.parametrize(
+        "pending_kind",
+        ["malformed", "unknown", "stale", "future", "nonfinite", "oversized"],
+    )
+    @pytest.mark.asyncio
+    async def test_invalid_pending_attribution_falls_back_to_default_and_is_cleared(
+        self,
+        pending_kind,
+        oauth_handlers,
+        mock_context,
+        verify_state_activity,
+        mock_token_response,
+        caplog,
+    ):
+        default = oauth_handlers.oauth_registry.add(OAuthFlow("Test-Connection"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        calls = []
+
+        @default.on_signin
+        async def on_default(event):
+            calls.append(f"default:{event.connection_name}")
+
+        @github.on_signin
+        async def on_github(_):
+            calls.append("github")
+
+        if pending_kind == "malformed":
+            pending: Any = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": ["GitHub"],
+                        "created_at": time.time(),
+                        "sso_offered": True,
+                    }
+                ],
+            }
+        elif pending_kind == "unknown":
+            pending = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": "Missing",
+                        "created_at": time.time(),
+                        "sso_offered": True,
+                    }
+                ],
+            }
+        elif pending_kind == "stale":
+            pending = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": "GitHub",
+                        "created_at": time.time() - 301,
+                        "sso_offered": True,
+                    }
+                ],
+            }
+        elif pending_kind == "future":
+            pending = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": "GitHub",
+                        "created_at": time.time() + 61,
+                        "sso_offered": True,
+                    }
+                ],
+            }
+        elif pending_kind == "nonfinite":
+            pending = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": "GitHub",
+                        "created_at": float("inf"),
+                        "sso_offered": True,
+                    }
+                ],
+            }
+        else:
+            pending = {
+                "version": 1,
+                "hints": [
+                    {
+                        "connection_name": "GitHub",
+                        "created_at": 10**1000,
+                        "sso_offered": True,
+                    }
+                ],
+            }
+
+        state = create_turn_state({"__oauth:pending": pending})
+        mock_context.activity = verify_state_activity
+        mock_context.state = state
+        mock_context.api.users.get_token.return_value = mock_token_response
+
+        with caplog.at_level(logging.DEBUG):
+            await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert calls == ["default:Test-Connection"]
+        params = mock_context.api.users.get_token.call_args.args[0]
+        assert params.connection_name == "Test-Connection"
+        assert state.user is not None
+        assert "__oauth:pending" not in state.user
+        assert "Discarding" in caplog.text
+        warnings = [record for record in caplog.records if record.levelno >= logging.WARNING]
+        if pending_kind == "unknown":
+            # A hint for an unregistered connection is normal (every legacy `ctx.sign_in()`
+            # produces one), so it is discarded quietly.
+            assert warnings == []
+        else:
+            # Corrupt or impossible state is worth surfacing.
+            assert warnings != []
+
+    @pytest.mark.asyncio
+    async def test_verify_state_without_attribution_probes_registered_flow(
+        self, oauth_handlers, mock_context, verify_state_activity, mock_token_response
+    ):
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        called = False
+
+        @github.on_signin
+        async def on_github(_):
+            nonlocal called
+            called = True
+
+        mock_context.activity = verify_state_activity
+        mock_context.state = None
+        mock_context.api.users.get_token.return_value = mock_token_response
+
+        await oauth_handlers.sign_in_verify_state(mock_context)
+
+        params = mock_context.api.users.get_token.call_args.args[0]
+        assert params.connection_name == "GitHub"
+        assert called is True
+        emitted_event = oauth_handlers.event_emitter.emit_async.call_args.args[1]
+        assert emitted_event.connection_name == "GitHub"
+
+    @pytest.mark.asyncio
+    async def test_verify_state_probe_falls_back_to_legacy_default(
+        self, oauth_handlers, mock_context, verify_state_activity, mock_token_response
+    ):
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        called = False
+
+        @github.on_signin
+        async def on_github(_):
+            nonlocal called
+            called = True
+
+        mock_context.activity = verify_state_activity
+        mock_context.state = None
+        mock_context.api.users.get_token.side_effect = [
+            oauth_http_error(404, "Not found for GitHub"),
+            mock_token_response,
+        ]
+
+        await oauth_handlers.sign_in_verify_state(mock_context)
+
+        attempted = [call.args[0].connection_name for call in mock_context.api.users.get_token.await_args_list]
+        assert attempted == ["GitHub", "test-connection"]
+        assert called is False
+        emitted_event = oauth_handlers.event_emitter.emit_async.call_args.args[1]
+        assert emitted_event.connection_name == "test-connection"
+
+    @pytest.mark.asyncio
+    async def test_verify_state_non_404_service_error_keeps_status_with_pending_flow(
+        self, oauth_handlers, mock_context, verify_state_activity
+    ):
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        called = False
+
+        @github.on_signin
+        async def on_github(_):
+            nonlocal called
+            called = True
+
+        oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+        state = create_pending_state(("github", time.time(), True))
+        response = Mock(spec=Response)
+        response.status_code = 503
+        mock_context.api.users.get_token.side_effect = HTTPStatusError(
+            "Unavailable",
+            request=Mock(spec=Request),
+            response=response,
+        )
+        mock_context.activity = verify_state_activity
+        mock_context.state = state
+
+        result = await oauth_handlers.sign_in_verify_state(mock_context)
+
+        assert isinstance(result, InvokeResponse)
+        assert result.status == 503
+        assert called is False
+        assert mock_context.api.users.get_token.await_count == 1
 
     def test_oauth_handlers_initialization(self, mock_event_emitter):
         """Test OauthHandlers initialization."""

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -379,3 +379,33 @@ def _agent365_activity():
         },
     )
     return ActivityTypeAdapter.validate_python(core_activity.model_dump(by_alias=True, exclude_none=True))
+
+
+def test_oauth_operation_without_a_connection_omits_the_connection_attribute():
+    """An unattributed signin/failure must not be filed under a guessed connection.
+
+    Omitting the attribute keeps the operation countable while leaving the
+    connection genuinely absent, so no dashboard blames an uninvolved connection.
+    """
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+    meter = meter_provider.get_meter("Microsoft.Teams.Apps")
+
+    with patch("microsoft_teams.apps.diagnostics._helpers.get_meter", return_value=meter):
+        record_oauth_operation(None, "signin_failure", "notified", 1.5)
+
+    metrics = {}
+    metrics_data = metric_reader.get_metrics_data()
+    assert metrics_data is not None
+    for resource_metric in metrics_data.resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                metrics[metric.name] = metric
+
+    point = metrics["microsoft.teams.oauth.operations"].data.data_points[0]
+    assert point.value == 1
+    assert point.attributes == {"oauth.operation": "signin_failure", "oauth.result": "notified"}
+    assert "oauth.connection" not in point.attributes
+
+    duration_point = metrics["microsoft.teams.oauth.operation.duration"].data.data_points[0]
+    assert "oauth.connection" not in duration_point.attributes

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from microsoft_teams.apps import App, OAuthFlow, OAuthFlowRegistry
 from microsoft_teams.apps.routing import SignInOptions
+from microsoft_teams.apps.state import StateOptions, TurnStateLoader
+from microsoft_teams.common.storage import LocalStorage
 
 
 class TestOAuthFlowOperations:
@@ -391,3 +393,104 @@ class TestFlowHandlerDispatch:
 
         assert flow.on_signin(success_handler) is success_handler
         assert flow.on_signin_failure(failure_handler) is failure_handler
+
+
+class TestOAuthAutoEnablesState:
+    """Registering a flow turns state on when the app never said either way.
+
+    Connection-less ``signin/verifyState`` and ``signin/failure`` callbacks can
+    only be attributed from a durable pending record, so state defaults on once
+    a flow exists — matching the C# and TypeScript SDKs. An explicit ``state``
+    value, including ``False``, is always left alone.
+    """
+
+    @staticmethod
+    def _app(**options) -> App:
+        return App(client_id="test-client-id", client_secret="test-secret", **options)
+
+    def test_omitted_state_stays_off_without_a_flow(self) -> None:
+        app = self._app()
+
+        assert app.options.state is None
+        assert app._state_loader is None
+        assert app.activity_processor.state_loader is None
+
+    def test_omitted_state_is_enabled_by_registering_a_flow(self) -> None:
+        app = self._app()
+
+        app.add_oauth_flow("graph")
+
+        assert isinstance(app._state_loader, TurnStateLoader)
+        # The processor reads its own reference at dispatch time, so updating
+        # the app alone would leave turns without state.
+        assert app.activity_processor.state_loader is app._state_loader
+
+    def test_auto_enabled_state_uses_the_apps_shared_storage(self) -> None:
+        storage = LocalStorage()
+        app = self._app(storage=storage)
+
+        app.add_oauth_flow("graph")
+
+        assert app._state_loader is not None
+        assert app._state_loader._storage is storage
+
+    def test_explicit_false_is_not_overridden_by_registering_a_flow(self) -> None:
+        app = self._app(state=False)
+
+        app.add_oauth_flow("graph")
+
+        assert app.options.state is False
+        assert app._state_loader is None
+        assert app.activity_processor.state_loader is None
+
+    def test_explicit_true_keeps_its_existing_loader(self) -> None:
+        app = self._app(state=True)
+        loader = app._state_loader
+
+        app.add_oauth_flow("graph")
+
+        assert isinstance(loader, TurnStateLoader)
+        assert app._state_loader is loader
+
+    def test_custom_state_options_are_preserved_exactly(self) -> None:
+        storage = LocalStorage()
+        app = self._app(state=StateOptions(storage=storage, key_prefix="custom"))
+        loader = app._state_loader
+
+        app.add_oauth_flow("graph")
+
+        assert app._state_loader is loader
+        assert app._state_loader is not None
+        assert app._state_loader._storage is storage
+        assert app._state_loader._options.key_prefix == "custom"
+
+    def test_registering_a_second_flow_does_not_rebuild_the_loader(self) -> None:
+        app = self._app()
+        app.add_oauth_flow("graph")
+        loader = app._state_loader
+
+        app.add_oauth_flow("github")
+
+        assert app._state_loader is loader
+        assert app.activity_processor.state_loader is loader
+
+    def test_a_rejected_registration_does_not_enable_state(self) -> None:
+        # State is a side effect of a flow existing. A blank name never becomes
+        # a flow, so it must not switch state on either.
+        app = self._app()
+
+        with pytest.raises(ValueError):
+            app.add_oauth_flow("   ")
+
+        assert app._state_loader is None
+        assert app.activity_processor.state_loader is None
+
+    def test_a_rejected_duplicate_keeps_the_existing_loader(self) -> None:
+        app = self._app()
+        app.add_oauth_flow("graph")
+        loader = app._state_loader
+
+        with pytest.raises(ValueError):
+            app.add_oauth_flow("GRAPH")
+
+        assert app._state_loader is loader

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -186,3 +186,76 @@ class TestAppOAuthFlowIntegration:
     def test_get_missing_flow_on_empty_registry_lists_none(self, app: App) -> None:
         with pytest.raises(ValueError, match="<none>"):
             app.get_oauth_flow("missing")
+
+
+class TestConnectionNameNormalization:
+    """Connection names are trimmed, non-blank, and matched case-insensitively."""
+
+    @pytest.mark.parametrize("name", ["  graph", "graph  ", "\tgraph\n", " graph "])
+    def test_surrounding_whitespace_is_trimmed(self, name: str) -> None:
+        """A stray space in config must not create a second, unreachable flow."""
+        assert OAuthFlow(name).connection_name == "graph"
+
+    def test_inner_whitespace_is_preserved(self) -> None:
+        """Only the edges are noise; the name itself is the service's business."""
+        assert OAuthFlow(" my graph ").connection_name == "my graph"
+
+    @pytest.mark.parametrize("name", ["", " ", "\t", "\n", "   \t  "])
+    def test_blank_names_are_rejected(self, name: str) -> None:
+        """A blank name addresses nothing, so it fails at registration."""
+        with pytest.raises(ValueError, match="connection name"):
+            OAuthFlow(name)
+
+    def test_original_casing_is_preserved(self) -> None:
+        """Events and the Token Service see the name the developer wrote."""
+        assert OAuthFlow("GraphMail").connection_name == "GraphMail"
+
+    @pytest.mark.parametrize("lookup", ["graph", "GRAPH", "Graph", "  graph  "])
+    def test_lookup_is_case_and_whitespace_insensitive(self, lookup: str) -> None:
+        registry = OAuthFlowRegistry()
+        flow = registry.add(OAuthFlow("Graph"))
+
+        assert registry.get(lookup) is flow
+        assert lookup in registry
+
+    @pytest.mark.parametrize("duplicate", ["graph", "GRAPH", " Graph "])
+    def test_duplicates_are_detected_across_casing_and_whitespace(self, duplicate: str) -> None:
+        """Red-green: without trimming, ' Graph ' registers a silent second flow."""
+        registry = OAuthFlowRegistry()
+        registry.add(OAuthFlow("Graph"))
+
+        with pytest.raises(ValueError, match="already"):
+            registry.add(OAuthFlow(duplicate))
+
+    def test_blank_lookup_returns_none_rather_than_raising(self) -> None:
+        """``.get()`` and ``in`` are Mapping operations and must stay total.
+
+        The registry subclasses Mapping, so ``.get()`` only absorbs KeyError. A
+        blank name raising ValueError here would escape through ``.get('')``.
+        """
+        registry = OAuthFlowRegistry()
+        registry.add(OAuthFlow("graph"))
+
+        assert registry.get("") is None
+        assert registry.get("   ") is None
+        assert "" not in registry
+        with pytest.raises(KeyError):
+            registry[""]
+
+    def test_iteration_yields_original_casing(self) -> None:
+        registry = OAuthFlowRegistry()
+        registry.add(OAuthFlow("GraphMail"))
+        registry.add(OAuthFlow(" GraphUser "))
+
+        assert list(registry) == ["GraphMail", "GraphUser"]
+
+    @pytest.mark.asyncio
+    async def test_flow_defaults_carry_the_normalized_name(self) -> None:
+        """The trimmed name is what reaches ctx.sign_in, not the raw one."""
+        flow = OAuthFlow("  graph  ")
+        ctx = MagicMock()
+        ctx.sign_in = AsyncMock(return_value=None)
+
+        await flow.sign_in(ctx)
+
+        assert ctx.sign_in.call_args[0][0].connection_name == "graph"

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 # pyright: basic
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -259,3 +260,134 @@ class TestConnectionNameNormalization:
         await flow.sign_in(ctx)
 
         assert ctx.sign_in.call_args[0][0].connection_name == "graph"
+
+
+class TestFlowHandlerDispatch:
+    """Per-flow handlers accept sync or async callables and are isolated from
+    each other, while still running strictly in registration order."""
+
+    @pytest.mark.asyncio
+    async def test_handlers_run_in_order_each_completing_before_the_next(self) -> None:
+        flow = OAuthFlow("graph")
+        calls: list[str] = []
+
+        @flow.on_signin
+        def first(_) -> None:
+            calls.append("first")
+
+        @flow.on_signin
+        async def second(_) -> None:
+            calls.append("second-start")
+            await asyncio.sleep(0.01)
+            calls.append("second-end")
+
+        @flow.on_signin
+        def third(_) -> None:
+            calls.append("third")
+
+        await flow._invoke_signin_handlers(MagicMock())
+
+        # "third" lands after "second-end", not between the two halves of the
+        # async handler: dispatch awaits each handler before starting the next.
+        assert calls == ["first", "second-start", "second-end", "third"]
+
+    @pytest.mark.asyncio
+    async def test_sync_handler_returning_an_awaitable_is_awaited(self) -> None:
+        flow = OAuthFlow("graph")
+        calls: list[str] = []
+
+        @flow.on_signin
+        def returns_awaitable(_):
+            async def finish() -> None:
+                calls.append("awaited")
+
+            calls.append("called")
+            return finish()
+
+        @flow.on_signin
+        def after(_) -> None:
+            calls.append("after")
+
+        await flow._invoke_signin_handlers(MagicMock())
+
+        assert calls == ["called", "awaited", "after"]
+
+    @pytest.mark.asyncio
+    async def test_raising_sync_handler_does_not_stop_later_handlers(self) -> None:
+        flow = OAuthFlow("graph")
+        calls: list[str] = []
+
+        @flow.on_signin
+        def boom(_) -> None:
+            calls.append("boom")
+            raise RuntimeError("sync handler failed")
+
+        @flow.on_signin
+        async def later(_) -> None:
+            calls.append("later")
+
+        assert await flow._invoke_signin_handlers(MagicMock()) is None
+        assert calls == ["boom", "later"]
+
+    @pytest.mark.asyncio
+    async def test_raising_async_handler_does_not_stop_later_handlers(self) -> None:
+        flow = OAuthFlow("graph")
+        calls: list[str] = []
+
+        @flow.on_signin
+        async def boom(_) -> None:
+            calls.append("boom")
+            raise RuntimeError("async handler failed")
+
+        @flow.on_signin
+        def later(_) -> None:
+            calls.append("later")
+
+        assert await flow._invoke_signin_handlers(MagicMock()) is None
+        assert calls == ["boom", "later"]
+
+    @pytest.mark.asyncio
+    async def test_failure_handlers_are_isolated_and_ordered_too(self) -> None:
+        flow = OAuthFlow("graph")
+        calls: list[str] = []
+
+        @flow.on_signin_failure
+        def boom(_) -> None:
+            calls.append("boom")
+            raise RuntimeError("failure handler failed")
+
+        @flow.on_signin_failure
+        async def later(_) -> None:
+            calls.append("later")
+
+        assert await flow._invoke_signin_failure_handlers(MagicMock()) is None
+        assert calls == ["boom", "later"]
+
+    @pytest.mark.asyncio
+    async def test_success_and_failure_handlers_do_not_cross_over(self) -> None:
+        flow = OAuthFlow("graph")
+        calls: list[str] = []
+
+        @flow.on_signin
+        async def on_success(_) -> None:
+            calls.append("success")
+
+        @flow.on_signin_failure
+        def on_failure(_) -> None:
+            calls.append("failure")
+
+        await flow._invoke_signin_handlers(MagicMock())
+        assert calls == ["success"]
+
+        await flow._invoke_signin_failure_handlers(MagicMock())
+        assert calls == ["success", "failure"]
+
+    def test_decorators_return_the_registered_function(self) -> None:
+        flow = OAuthFlow("graph")
+
+        async def success_handler(_) -> None: ...
+
+        def failure_handler(_) -> None: ...
+
+        assert flow.on_signin(success_handler) is success_handler
+        assert flow.on_signin_failure(failure_handler) is failure_handler

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -56,6 +56,15 @@ class TestOAuthFlowOperations:
         assert passed.connection_name == "graph"
 
     @pytest.mark.asyncio
+    async def test_sign_in_without_state_remains_supported(self) -> None:
+        flow = OAuthFlow("graph")
+        ctx = MagicMock()
+        ctx.sign_in = AsyncMock(return_value=None)
+        ctx.state = None
+
+        assert await flow.sign_in(ctx) is None
+
+    @pytest.mark.asyncio
     async def test_sign_out_targets_flow_connection(self) -> None:
         flow = OAuthFlow("graph")
         ctx = MagicMock()

--- a/packages/apps/tests/test_oauth_pending_local.py
+++ b/packages/apps/tests/test_oauth_pending_local.py
@@ -1,0 +1,240 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+# pyright: basic
+
+from typing import Any, Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import HTTPStatusError, Request, Response
+from microsoft_teams.api import (
+    Account,
+    ConversationAccount,
+    ConversationReference,
+    MessageActivity,
+    MessageActivityInput,
+    SentActivity,
+)
+from microsoft_teams.api.auth.cloud_environment import PUBLIC
+from microsoft_teams.apps import OAuthFlow, OAuthFlowRegistry
+from microsoft_teams.apps import oauth_pending_local as local
+from microsoft_teams.apps.oauth_state import (
+    clear_pending_oauth_sign_in,
+    get_pending_oauth_sign_ins,
+    record_pending_oauth_sign_in,
+)
+from microsoft_teams.apps.routing.activity_context import ActivityContext
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store() -> Iterator[None]:
+    """The store is process-wide, so each test starts and ends from empty."""
+    local._entries.clear()
+    yield
+    local._entries.clear()
+
+
+def _sign_in_context(conversation_id: str = "conv-1", user_id: str = "user-1") -> ActivityContext[Any]:
+    """A context with state disabled, wired well enough to send an OAuth card."""
+    activity = MessageActivity(
+        id="activity-id",
+        channel_id="msteams",
+        from_=Account(id=user_id),
+        recipient=Account(id="bot-id"),
+        conversation=ConversationAccount(id=conversation_id, is_group=False),
+    )
+    api = MagicMock()
+    api.clone.return_value = api
+    api.users.get_token = AsyncMock(
+        side_effect=HTTPStatusError(
+            "HTTP 404",
+            request=Request("GET", "https://token.example"),
+            response=Response(404, request=Request("GET", "https://token.example")),
+        )
+    )
+    resource = MagicMock()
+    resource.token_exchange_resource = None
+    resource.token_post_resource = None
+    resource.sign_in_link = "https://login.example.com"
+    api._bots.sign_in.get_resource = AsyncMock(return_value=resource)
+    api.conversations.create_activity = AsyncMock(
+        return_value=SentActivity(id="sent", activity_params=MessageActivityInput(text="sent"))
+    )
+
+    ctx = ActivityContext(
+        activity=activity,
+        app_id="app-id",
+        storage=MagicMock(),
+        api=api,
+        user_token=None,
+        conversation_ref=ConversationReference(
+            bot=Account(id="bot-id"),
+            conversation=ConversationAccount(id=conversation_id),
+            channel_id="msteams",
+            service_url="https://service.example",
+        ),
+        is_signed_in=False,
+        connection_name="test-connection",
+        app_token=MagicMock(),
+        cloud=PUBLIC,
+    )
+    # State disabled: this is the whole point of the fallback.
+    assert ctx.state is None
+    return ctx
+
+
+class TestStateDisabledAttribution:
+    """With state off, a sign-in and its callback still find each other."""
+
+    @pytest.mark.asyncio
+    async def test_sign_in_records_a_hint_that_the_callback_can_read(self) -> None:
+        """Red-green: without the fallback this returns [] and the callback
+        falls back to probing every connection."""
+        ctx = _sign_in_context()
+
+        await ctx.sign_in()
+
+        hints = get_pending_oauth_sign_ins(None, "conv-1", "user-1")
+        assert [hint.connection_name for hint in hints] == ["test-connection"]
+
+    @pytest.mark.asyncio
+    async def test_the_registry_resolves_the_hint_to_the_right_flow(self) -> None:
+        """The end the callback actually uses: hint -> registered flow."""
+        registry = OAuthFlowRegistry()
+        mail = registry.add(OAuthFlow("graphmail"))
+        registry.add(OAuthFlow("graphuser"))
+        record_pending_oauth_sign_in(None, "graphmail", sso_offered=False, conversation_id="c", user_id="u")
+
+        ctx = MagicMock()
+        ctx.state = None
+        ctx.activity.conversation.id = "c"
+        ctx.activity.from_.id = "u"
+
+        assert registry._pending_flows(ctx) == [mail]
+
+    def test_another_conversation_sees_nothing(self) -> None:
+        """Hints are scoped, so one chat cannot route another chat's callback."""
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id="c1", user_id="u")
+
+        assert get_pending_oauth_sign_ins(None, "c2", "u") == []
+
+    def test_another_user_in_the_same_conversation_sees_nothing(self) -> None:
+        """Two people signing in to the same connection stay independent."""
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id="c", user_id="u1")
+
+        assert get_pending_oauth_sign_ins(None, "c", "u2") == []
+
+    def test_a_different_process_finds_nothing_and_falls_back(self) -> None:
+        """The store is process-local by design; another instance sees empty.
+
+        Emptiness is the contract: the caller then probes every candidate, which
+        is the pre-existing behaviour and still correct, only slower.
+        """
+        assert get_pending_oauth_sign_ins(None, "c", "u") == []
+
+    def test_missing_identifiers_record_nothing(self) -> None:
+        """Without a scope there is no safe key, so nothing is stored."""
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id=None, user_id="u")
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id="c", user_id=None)
+
+        assert dict(local._entries) == {}
+
+    def test_state_when_available_is_used_instead_of_the_store(self) -> None:
+        """The fallback must never shadow real state."""
+        state = MagicMock()
+        state.user = {}
+        record_pending_oauth_sign_in(state, "graph", sso_offered=False, conversation_id="c", user_id="u")
+
+        assert dict(local._entries) == {}
+        assert any(key.startswith("__oauth:pending:") for key in state.user)
+
+
+class TestProcessLocalStoreMechanics:
+    """TTL, bounds, and the small operations built on top of the store."""
+
+    def test_hints_are_newest_first(self) -> None:
+        record_pending_oauth_sign_in(None, "first", sso_offered=False, conversation_id="c", user_id="u")
+        record_pending_oauth_sign_in(None, "second", sso_offered=False, conversation_id="c", user_id="u")
+
+        names = [hint.connection_name for hint in get_pending_oauth_sign_ins(None, "c", "u")]
+        assert names[0] == "second"
+
+    def test_re_signing_in_replaces_the_earlier_attempt(self) -> None:
+        """One connection has at most one pending attempt."""
+        record_pending_oauth_sign_in(None, "graph", sso_offered=True, conversation_id="c", user_id="u")
+        record_pending_oauth_sign_in(None, "GRAPH", sso_offered=False, conversation_id="c", user_id="u")
+
+        hints = get_pending_oauth_sign_ins(None, "c", "u")
+        assert len(hints) == 1
+        assert hints[0].sso_offered is False
+
+    def test_expired_hints_are_dropped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A five-minute-old sign-in is no longer a plausible attribution."""
+        clock = [1000.0]
+        monkeypatch.setattr(local, "time", lambda: clock[0])
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id="c", user_id="u")
+
+        clock[0] += local._TTL_SECONDS - 1
+        assert len(get_pending_oauth_sign_ins(None, "c", "u")) == 1
+
+        clock[0] += 2
+        assert get_pending_oauth_sign_ins(None, "c", "u") == []
+
+    def test_the_store_is_capped(self) -> None:
+        """A long-running process cannot grow this without bound."""
+        for index in range(local._MAX_ENTRIES + 50):
+            record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id=f"c{index}", user_id="u")
+
+        assert len(local._entries) == local._MAX_ENTRIES
+
+    def test_eviction_drops_the_oldest_first(self) -> None:
+        """Deterministic: insertion order is age order, so the front goes."""
+        for index in range(local._MAX_ENTRIES + 1):
+            record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id=f"c{index}", user_id="u")
+
+        assert get_pending_oauth_sign_ins(None, "c0", "u") == []
+        assert len(get_pending_oauth_sign_ins(None, f"c{local._MAX_ENTRIES}", "u")) == 1
+
+    def test_clearing_one_connection_leaves_the_others(self) -> None:
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id="c", user_id="u")
+        record_pending_oauth_sign_in(None, "mail", sso_offered=False, conversation_id="c", user_id="u")
+
+        clear_pending_oauth_sign_in(None, "GRAPH", "c", "u")
+
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(None, "c", "u")] == ["mail"]
+
+    def test_clearing_without_a_name_clears_the_whole_scope(self) -> None:
+        record_pending_oauth_sign_in(None, "graph", sso_offered=False, conversation_id="c", user_id="u")
+        record_pending_oauth_sign_in(None, "mail", sso_offered=False, conversation_id="c", user_id="u")
+
+        clear_pending_oauth_sign_in(None, None, "c", "u")
+
+        assert get_pending_oauth_sign_ins(None, "c", "u") == []
+
+    def test_consuming_sso_keeps_the_hint_for_routing(self) -> None:
+        """The sign-in is still pending; only its silent-SSO attempt is spent."""
+        record_pending_oauth_sign_in(None, "graph", sso_offered=True, conversation_id="c", user_id="u")
+
+        local.mark_sso_consumed("c", "u", "GRAPH")
+
+        hints = get_pending_oauth_sign_ins(None, "c", "u")
+        assert len(hints) == 1
+        assert hints[0].sso_offered is False
+
+    def test_replace_restores_the_original_timestamps(self) -> None:
+        """Rollback puts back what was there, not a fresh set of hints."""
+        record_pending_oauth_sign_in(None, "graph", sso_offered=True, conversation_id="c", user_id="u")
+        snapshot = get_pending_oauth_sign_ins(None, "c", "u")
+        clear_pending_oauth_sign_in(None, None, "c", "u")
+
+        local.replace("c", "u", [(h.connection_name, h.created_at, h.sso_offered) for h in snapshot])
+
+        assert get_pending_oauth_sign_ins(None, "c", "u") == snapshot
+
+    def test_blank_connection_names_are_not_stored(self) -> None:
+        record_pending_oauth_sign_in(None, "   ", sso_offered=False, conversation_id="c", user_id="u")
+
+        assert dict(local._entries) == {}

--- a/packages/apps/tests/test_oauth_state.py
+++ b/packages/apps/tests/test_oauth_state.py
@@ -1,0 +1,296 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from microsoft_teams.apps import TurnState, TurnStateContainer
+from microsoft_teams.apps.oauth_state import (
+    PendingOAuthSignIn,
+    clear_pending_oauth_sign_in,
+    get_pending_oauth_sign_ins,
+    mark_pending_oauth_sso_consumed,
+    record_pending_oauth_sign_in,
+    replace_pending_oauth_sign_ins,
+)
+
+
+def make_state(user_data: dict[str, Any] | None = None) -> TurnStateContainer:
+    return TurnStateContainer(
+        conversation=TurnState(),
+        conversation_id="conv-1",
+        user=TurnState(user_data),
+        user_id="user-1",
+    )
+
+
+def stored_keys(state: TurnStateContainer) -> set[str]:
+    assert state.user is not None
+    return {key for key in state.user if key.startswith("__oauth:pending:")}
+
+
+def iso(epoch_seconds: float) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).isoformat()
+
+
+class TestPendingSignInStorageLayout:
+    """The stored layout is a cross-SDK contract, mirroring C#'s ``OAuthFlow``."""
+
+    def test_records_one_key_per_connection_holding_an_iso_timestamp(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=False)
+
+        assert stored_keys(state) == {"__oauth:pending:Graph"}
+        assert state.user is not None
+        stored = state.user["__oauth:pending:Graph"]
+        # A bare ISO 8601 string, not a wrapper document: C# stores a DateTimeOffset here.
+        assert isinstance(stored, str)
+        assert datetime.fromisoformat(stored).tzinfo is not None
+
+    def test_offering_sso_adds_a_sibling_marker_sharing_the_timestamp(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=True)
+
+        assert stored_keys(state) == {"__oauth:pending:Graph", "__oauth:pending:sso:Graph"}
+        assert state.user is not None
+        assert state.user["__oauth:pending:sso:Graph"] == state.user["__oauth:pending:Graph"]
+
+    def test_connection_casing_is_stored_verbatim(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "GitHub", sso_offered=True)
+
+        # C# preserves the registered casing in the key, so we do too.
+        assert stored_keys(state) == {"__oauth:pending:GitHub", "__oauth:pending:sso:GitHub"}
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["GitHub"]
+
+
+class TestDotNetTimestampInterop:
+    """Every ``DateTimeOffset`` shape .NET emits must round-trip through the reader."""
+
+    @pytest.mark.parametrize(
+        "shape",
+        ["dotnet_7_digit_fraction", "zulu_suffix", "no_fraction", "non_utc_offset", "no_offset"],
+    )
+    def test_reads_timestamps_written_by_the_csharp_sdk(self, shape: str) -> None:
+        moment = datetime.now(timezone.utc).replace(microsecond=214000)
+        if shape == "dotnet_7_digit_fraction":
+            # System.Text.Json writes 7 fractional digits, which Python truncates to 6.
+            raw = moment.isoformat().replace("+00:00", "0+00:00")
+        elif shape == "zulu_suffix":
+            raw = moment.isoformat().replace("+00:00", "Z")
+        elif shape == "no_fraction":
+            moment = moment.replace(microsecond=0)
+            raw = moment.isoformat()
+        elif shape == "non_utc_offset":
+            raw = moment.astimezone(timezone(timedelta(hours=-7))).isoformat()
+        else:
+            # No offset at all is read as UTC.
+            raw = moment.replace(tzinfo=None).isoformat()
+
+        state = make_state({"__oauth:pending:Graph": raw})
+        pending = get_pending_oauth_sign_ins(state)
+
+        assert [hint.connection_name for hint in pending] == ["Graph"]
+        assert pending[0].created_at == pytest.approx(moment.timestamp())
+
+
+class TestPendingSignInLookup:
+    def test_lookup_is_case_insensitive_while_preserving_stored_casing(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "GitHub", sso_offered=True)
+
+        clear_pending_oauth_sign_in(state, "github")
+
+        assert stored_keys(state) == set()
+
+    def test_recording_again_replaces_an_earlier_attempt_under_different_casing(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "GitHub", sso_offered=True)
+        record_pending_oauth_sign_in(state, "github", sso_offered=False)
+
+        # Exactly one attempt survives, under the casing that was recorded last, and
+        # the stale SSO marker from the first attempt does not linger.
+        assert stored_keys(state) == {"__oauth:pending:github"}
+        assert [(h.connection_name, h.sso_offered) for h in get_pending_oauth_sign_ins(state)] == [("github", False)]
+
+    def test_duplicate_casing_keeps_the_newer_attempt_deterministically(self) -> None:
+        now = time.time()
+        # We never write two casings for one connection, but another SDK might.
+        state = make_state(
+            {
+                "__oauth:pending:GitHub": iso(now - 30),
+                "__oauth:pending:github": iso(now),
+            }
+        )
+
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["github"]
+        # The losing key is dropped rather than left to linger until it expires.
+        assert stored_keys(state) == {"__oauth:pending:github"}
+
+    def test_hints_are_returned_newest_first(self) -> None:
+        now = time.time()
+        state = make_state(
+            {
+                "__oauth:pending:older": iso(now - 30),
+                "__oauth:pending:newest": iso(now),
+                "__oauth:pending:middle": iso(now - 10),
+            }
+        )
+
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == [
+            "newest",
+            "middle",
+            "older",
+        ]
+
+    def test_equal_timestamps_break_ties_deterministically(self) -> None:
+        stamp = iso(time.time())
+        state = make_state({"__oauth:pending:beta": stamp, "__oauth:pending:alpha": stamp})
+
+        # Storage order must not leak into the result.
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["alpha", "beta"]
+
+
+class TestSsoMarkerHandling:
+    def test_marking_sso_consumed_retires_only_the_sso_marker(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=True)
+        assert state.user is not None
+        original = state.user["__oauth:pending:Graph"]
+
+        mark_pending_oauth_sso_consumed(state, "graph")
+
+        # The sign-in is still pending on its original schedule; only SSO is spent.
+        assert stored_keys(state) == {"__oauth:pending:Graph"}
+        assert state.user["__oauth:pending:Graph"] == original
+        assert [(h.connection_name, h.sso_offered) for h in get_pending_oauth_sign_ins(state)] == [("Graph", False)]
+
+    def test_connection_named_sso_is_not_mistaken_for_an_sso_marker(self) -> None:
+        # ``sso:`` is a legal start to a connection name. Without its own base marker,
+        # ``__oauth:pending:sso:graph`` is the marker for a connection called "sso:graph".
+        state = make_state({"__oauth:pending:sso:graph": iso(time.time())})
+
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["sso:graph"]
+
+        clear_pending_oauth_sign_in(state, "sso:graph")
+        assert stored_keys(state) == set()
+
+    def test_sso_marker_is_recognised_when_its_base_marker_exists(self) -> None:
+        stamp = iso(time.time())
+        state = make_state({"__oauth:pending:graph": stamp, "__oauth:pending:sso:graph": stamp})
+
+        assert [(h.connection_name, h.sso_offered) for h in get_pending_oauth_sign_ins(state)] == [("graph", True)]
+
+    def test_orphaned_sso_marker_is_dropped_when_its_sign_in_expires(self) -> None:
+        now = time.time()
+        state = make_state(
+            {
+                "__oauth:pending:graph": iso(now - 301),
+                "__oauth:pending:sso:graph": iso(now),
+            }
+        )
+
+        assert get_pending_oauth_sign_ins(state) == []
+        # An SSO marker must not outlive the sign-in it describes.
+        assert stored_keys(state) == set()
+
+
+class TestPendingSignInPruning:
+    @pytest.mark.parametrize("bad_value", [["not-a-string"], 12345, None, "not-a-timestamp", ""])
+    def test_a_single_bad_key_does_not_discard_healthy_ones(self, bad_value: Any) -> None:
+        state = make_state(
+            {
+                "__oauth:pending:broken": bad_value,
+                "__oauth:pending:healthy": iso(time.time()),
+            }
+        )
+
+        # The per-key layout limits the blast radius: only the bad key is dropped.
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["healthy"]
+        assert stored_keys(state) == {"__oauth:pending:healthy"}
+
+    def test_expired_and_future_dated_markers_are_pruned_on_read(self) -> None:
+        now = time.time()
+        state = make_state(
+            {
+                "__oauth:pending:stale": iso(now - 301),
+                "__oauth:pending:future": iso(now + 61),
+                "__oauth:pending:live": iso(now - 30),
+            }
+        )
+
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["live"]
+        assert stored_keys(state) == {"__oauth:pending:live"}
+
+    def test_recording_prunes_expired_markers_left_by_other_connections(self) -> None:
+        state = make_state({"__oauth:pending:abandoned": iso(time.time() - 301)})
+
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=False)
+
+        # Long-lived user state must not accumulate sign-ins that were never completed.
+        assert stored_keys(state) == {"__oauth:pending:Graph"}
+
+    def test_clearing_without_a_connection_removes_every_marker(self) -> None:
+        state = make_state({"unrelated": "keep me"})
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=True)
+        record_pending_oauth_sign_in(state, "GitHub", sso_offered=False)
+
+        clear_pending_oauth_sign_in(state)
+
+        assert stored_keys(state) == set()
+        assert state.user is not None
+        assert state.user["unrelated"] == "keep me"
+
+
+class TestReplacePendingSignIns:
+    def test_replacing_rewrites_the_stored_layout(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=True)
+        now = time.time()
+
+        replace_pending_oauth_sign_ins(
+            state,
+            [PendingOAuthSignIn(connection_name="GitHub", created_at=now, sso_offered=True)],
+        )
+
+        assert stored_keys(state) == {"__oauth:pending:GitHub", "__oauth:pending:sso:GitHub"}
+        restored = get_pending_oauth_sign_ins(state)
+        assert [(h.connection_name, h.sso_offered) for h in restored] == [("GitHub", True)]
+        assert restored[0].created_at == pytest.approx(now, abs=1e-6)
+
+    def test_replacing_with_an_empty_list_clears_everything(self) -> None:
+        state = make_state()
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=True)
+
+        replace_pending_oauth_sign_ins(state, [])
+
+        assert stored_keys(state) == set()
+
+
+class TestMissingState:
+    """Every helper tolerates absent state, so OAuth works without a state store."""
+
+    def test_helpers_are_no_ops_without_state(self) -> None:
+        assert get_pending_oauth_sign_ins(None) == []
+        record_pending_oauth_sign_in(None, "Graph", sso_offered=True)
+        clear_pending_oauth_sign_in(None, "Graph")
+        mark_pending_oauth_sso_consumed(None, "Graph")
+        replace_pending_oauth_sign_ins(None, [])
+
+    def test_helpers_are_no_ops_without_a_user_scope(self) -> None:
+        state = TurnStateContainer(
+            conversation=TurnState(),
+            conversation_id="conv-1",
+            user=None,
+            user_id=None,
+        )
+
+        assert get_pending_oauth_sign_ins(state) == []
+        record_pending_oauth_sign_in(state, "Graph", sso_offered=True)
+        clear_pending_oauth_sign_in(state, "Graph")
+        mark_pending_oauth_sso_consumed(state, "Graph")
+        replace_pending_oauth_sign_ins(state, [])

--- a/packages/apps/tests/test_oauth_state.py
+++ b/packages/apps/tests/test_oauth_state.py
@@ -38,8 +38,6 @@ def iso(epoch_seconds: float) -> str:
 
 
 class TestPendingSignInStorageLayout:
-    """The stored layout is a cross-SDK contract, mirroring C#'s ``OAuthFlow``."""
-
     def test_records_one_key_per_connection_holding_an_iso_timestamp(self) -> None:
         state = make_state()
         record_pending_oauth_sign_in(state, "Graph", sso_offered=False)
@@ -47,7 +45,6 @@ class TestPendingSignInStorageLayout:
         assert stored_keys(state) == {"__oauth:pending:Graph"}
         assert state.user is not None
         stored = state.user["__oauth:pending:Graph"]
-        # A bare ISO 8601 string, not a wrapper document: C# stores a DateTimeOffset here.
         assert isinstance(stored, str)
         assert datetime.fromisoformat(stored).tzinfo is not None
 
@@ -63,7 +60,6 @@ class TestPendingSignInStorageLayout:
         state = make_state()
         record_pending_oauth_sign_in(state, "GitHub", sso_offered=True)
 
-        # C# preserves the registered casing in the key, so we do too.
         assert stored_keys(state) == {"__oauth:pending:GitHub", "__oauth:pending:sso:GitHub"}
         assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["GitHub"]
 

--- a/packages/apps/tests/test_oauth_state.py
+++ b/packages/apps/tests/test_oauth_state.py
@@ -209,6 +209,18 @@ class TestPendingSignInPruning:
         assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["healthy"]
         assert stored_keys(state) == {"__oauth:pending:healthy"}
 
+    def test_state_from_an_earlier_layout_reads_as_absent(self) -> None:
+        legacy = {"version": 1, "hints": [{"connection_name": "GitHub", "created_at": time.time()}]}
+        state = make_state({"__oauth:pending": legacy, "__oauth:pending:healthy": iso(time.time())})
+
+        # The earlier layout kept every hint in one `__oauth:pending` document. That key
+        # has no trailing separator, so the prefix scan never sees it: it reads as absent
+        # and sign-in simply starts over. Nothing needs migrating, and nothing else is
+        # disturbed by leftovers.
+        assert [hint.connection_name for hint in get_pending_oauth_sign_ins(state)] == ["healthy"]
+        assert state.user is not None
+        assert state.user["__oauth:pending"] == legacy
+
     def test_expired_and_future_dated_markers_are_pruned_on_read(self) -> None:
         now = time.time()
         state = make_state(

--- a/packages/apps/tests/test_state.py
+++ b/packages/apps/tests/test_state.py
@@ -173,6 +173,105 @@ class TestTurnStateContainer:
         assert container.conversation["a"] == 1
         assert container.user is not None and container.user["b"] == 2
 
+    @pytest.mark.parametrize(("field_name", "expected"), [("conversation_id", "c1"), ("user_id", "u1")])
+    def test_identity_cannot_be_reassigned_after_construction(self, field_name: str, expected: str):
+        """Identity is fixed at construction so a save cannot be redirected mid-turn.
+
+        ``TurnStateLoader.save`` reads ``conversation_id``/``user_id`` back off the
+        container to build its storage keys, so rebinding either one after load
+        would persist this turn's state under a different conversation or user.
+        """
+        container = TurnStateContainer(conversation=TurnState(), conversation_id="c1", user=TurnState(), user_id="u1")
+
+        # setattr rather than a literal assignment: the runtime guard is what is
+        # under test, and assigning to a setter-less property is also a static
+        # type error, which would fail type-checking instead of running.
+        with pytest.raises(AttributeError):
+            setattr(container, field_name, "hijacked")
+
+        assert getattr(container, field_name) == expected
+
+    def test_scope_contents_stay_mutable(self):
+        """Binding the identity must not make the state itself read-only."""
+        container = TurnStateContainer(conversation=TurnState(), conversation_id="c1", user=TurnState(), user_id="u1")
+        assert container.conversation.is_dirty is False
+
+        container.conversation["a"] = 1
+        assert container.user is not None
+        container.user["b"] = 2
+        del container.conversation["a"]
+        container.conversation["c"] = 3
+
+        assert container.conversation.to_dict() == {"c": 3}
+        assert container.user.to_dict() == {"b": 2}
+        assert container.conversation.is_dirty is True
+        assert container.user.is_dirty is True
+
+    def test_scope_slots_stay_assignable(self):
+        """Only the identity is bound; the scope slots themselves are not.
+
+        Guards against a future change tightening this into a fully frozen
+        container, which would break ``seal()``/``delete()`` and the loader's
+        ability to inject its hooks.
+        """
+        container = TurnStateContainer(conversation=TurnState(), conversation_id="c1")
+        replacement = TurnState({"swapped": True})
+
+        container.conversation = replacement
+        container.user = replacement
+
+        assert container.conversation is replacement
+        assert container.user is replacement
+
+    def test_equality_ignores_injected_hooks(self):
+        """``__eq__`` is hand-written now, so pin the semantics it replaced."""
+
+        async def saver(_: TurnStateContainer) -> None:
+            return None
+
+        base = TurnStateContainer(
+            conversation=TurnState({"a": 1}), conversation_id="c1", user=TurnState(), user_id="u1"
+        )
+        same = TurnStateContainer(
+            conversation=TurnState({"a": 1}), conversation_id="c1", user=TurnState(), user_id="u1"
+        )
+        with_saver = TurnStateContainer(
+            conversation=TurnState({"a": 1}),
+            conversation_id="c1",
+            user=TurnState(),
+            user_id="u1",
+            _saver=saver,
+        )
+        other_conversation = TurnStateContainer(
+            conversation=TurnState({"a": 1}), conversation_id="other", user=TurnState(), user_id="u1"
+        )
+        other_user = TurnStateContainer(
+            conversation=TurnState({"a": 1}), conversation_id="c1", user=TurnState(), user_id="other"
+        )
+
+        assert base == same
+        assert base == with_saver
+        assert base != other_conversation
+        assert base != other_user
+        assert base != "not a container"
+
+    def test_repr_shows_identity_and_hides_injected_hooks(self):
+        """``__repr__`` is hand-written now; keep hooks out of logs and errors."""
+
+        async def saver(_: TurnStateContainer) -> None:
+            return None
+
+        container = TurnStateContainer(
+            conversation=TurnState(), conversation_id="c1", user=TurnState(), user_id="u1", _saver=saver
+        )
+
+        text = repr(container)
+        assert text.startswith("TurnStateContainer(")
+        assert "conversation_id='c1'" in text
+        assert "user_id='u1'" in text
+        assert "saver" not in text
+        assert "deleter" not in text
+
 
 # ---------------------------------------------------------------------------
 # TurnStateLoader

--- a/packages/common/src/microsoft_teams/common/events/event_emitter.py
+++ b/packages/common/src/microsoft_teams/common/events/event_emitter.py
@@ -88,16 +88,9 @@ class EventEmitter(EventEmitterProtocol[EventTypeT]):
             Subscription ID for removing the handler later
         """
 
-        if inspect.iscoroutinefunction(handler):
-
-            async def once_wrapper(value: Any) -> None:  # pyright: ignore[reportRedeclaration]
-                self.off(subscription_id)
-                await handler(value)
-        else:
-
-            def once_wrapper(value: Any) -> None:
-                self.off(subscription_id)
-                handler(value)
+        def once_wrapper(value: Any) -> Any:
+            self.off(subscription_id)
+            return handler(value)
 
         subscription_id = self._get_next_id()
 
@@ -141,16 +134,13 @@ class EventEmitter(EventEmitterProtocol[EventTypeT]):
         handler_count = len(self._subscriptions[event])
         logger.debug("Emitting event '%s' to %d handler(s)", event, handler_count)
 
-        awaitables: list[Awaitable[None]] = []
+        awaitables: list[Awaitable[Any]] = []
 
         for subscription in self._subscriptions[event][:]:  # Copy to avoid modification during iteration
             try:
-                handler = subscription["handler"]
-
-                if inspect.iscoroutinefunction(handler):
-                    awaitables.append(handler(value))
-                else:
-                    handler(value)
+                result = subscription["handler"](value)
+                if inspect.isawaitable(result):
+                    awaitables.append(result)
             except Exception as e:
                 # Continue executing other handlers even if one fails
                 logger.error("Handler failed for event '%s': %s", event, e)
@@ -162,7 +152,8 @@ class EventEmitter(EventEmitterProtocol[EventTypeT]):
             async def run_async_handlers() -> None:
                 results = await asyncio.gather(*awaitables, return_exceptions=True)
                 for i, result in enumerate(results):
-                    if isinstance(result, Exception):
+                    # BaseException, not Exception: otherwise a cancelled handler is dropped silently.
+                    if isinstance(result, BaseException):
                         logger.error("Async handler %d failed for event '%s': %s", i, event, result)
 
             try:
@@ -174,6 +165,32 @@ class EventEmitter(EventEmitterProtocol[EventTypeT]):
             except RuntimeError:
                 # No event loop running, create one
                 asyncio.run(run_async_handlers())
+
+    async def emit_async(self, event: EventTypeT, value: Any = None) -> None:
+        """Emit an event and wait for all synchronous and asynchronous handlers."""
+        if event not in self._subscriptions:
+            return
+
+        handler_count = len(self._subscriptions[event])
+        logger.debug("Emitting event '%s' to %d handler(s) and waiting for completion", event, handler_count)
+
+        awaitables: list[Awaitable[Any]] = []
+        for subscription in self._subscriptions[event][:]:
+            try:
+                result = subscription["handler"](value)
+                if inspect.isawaitable(result):
+                    awaitables.append(result)
+            except Exception as e:
+                logger.error("Handler failed for event '%s': %s", event, e)
+
+        if not awaitables:
+            return
+
+        results = await asyncio.gather(*awaitables, return_exceptions=True)
+        for i, result in enumerate(results):
+            # BaseException, not Exception: otherwise a cancelled handler is dropped silently.
+            if isinstance(result, BaseException):
+                logger.error("Async handler %d failed for event '%s': %s", i, event, result)
 
     def listener_count(self, event: str) -> int:
         """

--- a/packages/common/tests/test_event_emitter.py
+++ b/packages/common/tests/test_event_emitter.py
@@ -241,6 +241,76 @@ class TestEventEmitter:
 
         handler.assert_called_once_with("test_data")
 
+    @pytest.mark.asyncio
+    async def test_emit_async_waits_for_async_handlers(self):
+        emitter = EventEmitter()
+        calls = []
+
+        async def async_handler(data):
+            await asyncio.sleep(0)
+            calls.append(data)
+
+        emitter.on("test_event", async_handler)
+
+        await emitter.emit_async("test_event", "test_data")
+        calls.append("after")
+
+        assert calls == ["test_data", "after"]
+
+    @pytest.mark.asyncio
+    async def test_emit_async_waits_for_awaitable_returned_by_sync_handler(self):
+        emitter = EventEmitter()
+        calls = []
+
+        def handler(data):
+            async def complete():
+                await asyncio.sleep(0)
+                calls.append(data)
+
+            return complete()
+
+        emitter.on("test_event", handler)
+
+        await emitter.emit_async("test_event", "test_data")
+        calls.append("after")
+
+        assert calls == ["test_data", "after"]
+
+    @pytest.mark.asyncio
+    async def test_emit_async_waits_for_async_callable_object(self):
+        emitter = EventEmitter()
+        calls = []
+
+        class Handler:
+            async def __call__(self, data):
+                await asyncio.sleep(0)
+                calls.append(data)
+
+        emitter.on("test_event", Handler())
+
+        await emitter.emit_async("test_event", "test_data")
+        calls.append("after")
+
+        assert calls == ["test_data", "after"]
+
+    @pytest.mark.asyncio
+    async def test_emit_async_waited_handler_exception_doesnt_break_others(self):
+        emitter = EventEmitter()
+        calls = []
+
+        async def failing_handler(data):
+            raise RuntimeError(data)
+
+        async def working_handler(data):
+            calls.append(data)
+
+        emitter.on("test_event", failing_handler)
+        emitter.on("test_event", working_handler)
+
+        await emitter.emit_async("test_event", "test_data")
+
+        assert calls == ["test_data"]
+
     def test_off_during_iteration_safe(self):
         emitter = EventEmitter()
         handler1 = Mock()


### PR DESCRIPTION
**Stack:** #553 (state foundation) → #554 (public state API / dispatch lifecycle) →
#561 (OAuthFlow + registry) → **this PR (4/5)** → PR 5 (token-exchange dedup)

This PR makes callback routing connection-aware.

## Problem

The three sign-in callbacks carry very different amounts of information:

| Callback | Carries connection name? |
| --- | --- |
| `signin/tokenExchange` | ✅ yes, in `activity.value.connection_name` |
| `signin/verifyState` | ❌ no — only an opaque magic code |
| `signin/failure` | ❌ no — only a failure code/message |

Token exchange can be routed directly. The other two cannot, so the app has to
remember which connection it last offered a sign-in on.

## Approach

**Explicit routing where possible.** `signin/tokenExchange` routes purely on the
connection name in the payload — no state required, and it works with state
disabled.

**Pending markers for connection-less callbacks.** When a sign-in card is sent,
`ctx.sign_in()` records the attempt in per-turn *user* state under private
reserved keys — up to two per connection, each holding an ISO 8601 UTC timestamp:

```python
"__oauth:pending:GitHub":     "2026-08-26T20:48:20.214000+00:00"
"__oauth:pending:sso:GitHub": "2026-08-26T20:48:20.214000+00:00"  # only when SSO was offered
```

**Probing with fallback.** `signin/verifyState` tries attributed flows first, then
the remaining registered flows, then the legacy default connection, stopping at
the first connection that returns a token. Attribution makes the normal path a
single Token Service call; the fan-out is the fallback for missing or stale
markers. It is intentionally uncapped — dropping candidates would turn a slow
sign-in into a silently failed one.

**Failure attribution.** `signin/failure` is attributed to the newest attempt that
actually offered silent SSO. With no attribution it falls back to notifying every
registered flow.

**SSO markers are retired, not deleted.** After a silent-SSO failure Teams still
renders the sign-in button on the same card, so the sign-in is still pending even
though its SSO attempt is spent. Only the `sso:` key is dropped: the attempt can
no longer re-attribute a second failure, but a follow-up `verifyState` still
routes straight to the right connection, and it expires on its original schedule.

## Behavior

- `SignInEvent.connection_name` and `SignInFailureEvent.connection_name` are now
  populated, preserving the registry's original casing (lookup is
  case-insensitive; `"github"` resolves the flow registered as `"GitHub"`).
- Global `sign_in` / `sign_in_failure` events fire before per-flow handlers, and
  are now **awaited**, so an async global handler is guaranteed to complete first.
- Legacy single-connection apps are unchanged: with no flows registered, routing
  falls through to `default_connection_name` exactly as before.
- Legacy and registered modes are not mutually exclusive — a registered default
  flow and unregistered connections coexist.
- Error precedence and Token Service status handling are untouched: only 404
  continues probing, 400/412 return 412, and any other status propagates
  unchanged and still emits `error`. No service failure is masked as a
  logged-out/unknown callback.
- Any stored value that is not a parseable ISO 8601 timestamp, along with stale,
  future-dated and unknown-connection markers, is discarded and routing falls
  back to the default connection.

## State is optional

State is only required for the two callbacks that genuinely cannot self-identify.
With state disabled, `tokenExchange` still routes correctly and `verifyState` /
`failure` use the registered-flow fallback. No generic TTL knobs are introduced —
storage expiry remains provider-configured; the 5-minute freshness window is
OAuth-specific and internal.

## Race fix: markers are flushed before the card is sent

Turn state is normally persisted at end-of-turn, but a token-exchange callback can
arrive *before* the turn that sent the card has finished. `ctx.sign_in()` now
flushes the marker to storage before sending the card, and rolls it back (best
effort, without masking the caller's error) if the send fails.

## Container identity is bound at load

`TurnStateContainer.conversation_id` and `.user_id` describe *which* state was
loaded. Reassigning them after construction cannot move the data and would make
the container save under a key that no longer matches its contents, so they are
now read-only: private backing fields behind getter-only properties, rejected at
both runtime and type-check time.

The contained `TurnState` objects stay fully mutable and `seal()`, `delete()` and
`_save()` are unchanged. The constructor signature is identical (`conversation_id=`
/ `user_id=` keywords), so no call site moved. `TurnStateContainer` is no longer a
`@dataclass` — `__eq__` and `__repr__` are hand-written to reproduce the generated
ones exactly, including excluding the injected hooks.

## Supporting changes

- `EventEmitter.emit_async()` — awaits all handlers. Purely additive; existing
  `emit()` stays fire-and-forget and `EventEmitterProtocol` is unchanged, so
  external implementers are unaffected.
- The `emit()` refactor fixes two latent bugs: awaitables returned by callables
  that aren't `async def` (e.g. `functools.partial`, `__call__`) were created and
  never awaited, and an async `once` handler could fire twice.
- `TurnStateContainer._save()` / `TurnState._mark_dirty()` — internal hooks for
  the mid-turn flush and its rollback.

## Not in this PR

Token-exchange deduplication (in-flight guard + completed marker) is PR 5.
Duplicate `tokenExchange` callbacks still run the exchange twice here, and there
are tests pinning that so the change in PR 5 is visible.
