### PR TITLE
feat(apps): simplify route registration and deprecate plugins

### DIFF
--- a/examples/http-adapters/src/fastapi_non_managed.py
+++ b/examples/http-adapters/src/fastapi_non_managed.py
@@ -8,8 +8,8 @@ Licensed under the MIT License.
 # Teams echo bot where YOU manage the server lifecycle.
 #
 # This demonstrates the "non-managed" pattern — you create your own FastAPI app
-# with your own routes, wrap it in a FastAPIAdapter, call app.initialize() to
-# register the Teams routes, then start uvicorn yourself.
+# with your own routes, wrap it in a FastAPIAdapter, call app.register_routes()
+# synchronously, then initialize async resources and start uvicorn yourself.
 #
 # This is ideal when:
 # - You have an existing FastAPI app and want to add Teams bot support
@@ -61,6 +61,7 @@ adapter = FastAPIAdapter(app=my_fastapi)
 
 # 3. Create the Teams app with the adapter
 app = App(http_server_adapter=adapter)
+app.register_routes()
 
 
 # 4. Handle incoming messages — streaming demo
@@ -84,8 +85,8 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 async def main():
     port = int(os.getenv("PORT", "3978"))
 
-    # 5. Initialize only — registers /api/messages on our FastAPI app
-    #    Does NOT start a server
+    # 5. Initialize async resources. The Teams route is already registered.
+    #    This does not start a server.
     await app.initialize()
 
     print(f"Starting server on http://localhost:{port}")

--- a/packages/apps/README.md
+++ b/packages/apps/README.md
@@ -19,9 +19,9 @@ Handles activity routing, authentication, and provides Microsoft Graph integrati
 ## Features
 
 - **Activity Routing**: Decorator-based routing for different activity types
+- **Activity Middleware**: Composable middleware through `app.use()`
 - **OAuth Integration**: Built-in OAuth flow handling for user authentication
 - **Microsoft Graph Integration**: Type-safe Graph client access via `user_graph` and `app_graph` properties
-- **Plugin System**: Extensible plugin architecture for adding functionality
 
 ## Basic Usage
 
@@ -38,6 +38,34 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 # Start the app
 await app.start()
 ```
+
+## Caller-owned ASGI applications
+
+Use `register_routes()` when an existing FastAPI or other ASGI application owns
+the server lifecycle and needs its route table built synchronously:
+
+```python
+from fastapi import FastAPI
+from microsoft_teams.apps import App, FastAPIAdapter
+
+asgi_app = FastAPI()
+app = App(http_server_adapter=FastAPIAdapter(app=asgi_app))
+app.register_routes()
+
+# Run remaining asynchronous initialization from the host's startup lifecycle.
+await app.initialize()
+```
+
+`register_routes()` configures Teams authentication and activity dispatch, but
+does not initialize plugins, bind a port, or start and stop the server. Calls are
+idempotent.
+
+## Legacy plugins
+
+The `plugins=` option, `PluginBase`, and `@Plugin` extension model are deprecated
+and will be removed in the next major release. Use `app.use()` for activity
+middleware, `app.event()` for application events, your ASGI host's lifespan hooks
+for setup and cleanup, and regular Python composition for dependencies.
 
 ## Unauthenticated Requests
 

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -7,6 +7,7 @@ import asyncio
 import importlib.metadata
 import logging
 import os
+import warnings
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Optional, TypeVar, Union, Unpack, cast, overload
 
 from dependency_injector import providers
@@ -126,6 +127,15 @@ class App(ActivityHandlerMixin):
         )
 
         plugins: List[PluginBase] = list(self.options.plugins)
+        if plugins:
+            warnings.warn(
+                "The plugin API is deprecated and will be removed in the next major release. "
+                "Use app.use() for activity middleware, app.event() for application events, "
+                "host lifecycle hooks for setup and cleanup, and app.register_routes() "
+                "for caller-owned HTTP servers.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Create HttpServer (not a plugin — owned directly by App)
         adapter = self.options.http_server_adapter or FastAPIAdapter()
@@ -203,6 +213,20 @@ class App(ActivityHandlerMixin):
         """Token source for resources the SDK does not call automatically."""
         return self._token_provider
 
+    def register_routes(self) -> None:
+        """Synchronously register the Teams messaging route on the configured HTTP adapter.
+
+        This method wires activity dispatch and authentication without initializing
+        plugins or taking ownership of the HTTP server lifecycle. Repeated calls are
+        safe and do not register duplicate routes.
+        """
+        self.server.on_request = self._process_activity_event
+        self.server.initialize(
+            credentials=self.credentials,
+            cloud=self.cloud,
+            dangerously_allow_unauthenticated_requests=self.options.dangerously_allow_unauthenticated_requests,
+        )
+
     async def initialize(self) -> None:
         """
         Initialize the Teams application without starting the HTTP server.
@@ -215,19 +239,13 @@ class App(ActivityHandlerMixin):
             return
 
         try:
-            # Initialize plugins first (they may register routes, e.g. BotBuilder's /api/messages)
+            # Keep legacy plugin initialization before route registration for compatibility.
             for plugin in self.plugins:
                 self._plugin_processor.inject(plugin)
                 if hasattr(plugin, "on_init") and callable(plugin.on_init):
                     await plugin.on_init()
 
-            # Initialize HttpServer (JWT validation + messaging endpoint route)
-            self.server.on_request = self._process_activity_event
-            self.server.initialize(
-                credentials=self.credentials,
-                cloud=self.cloud,
-                dangerously_allow_unauthenticated_requests=self.options.dangerously_allow_unauthenticated_requests,
-            )
+            self.register_routes()
 
             self._initialized = True
             logger.info("Teams app initialized successfully")

--- a/packages/apps/src/microsoft_teams/apps/options.py
+++ b/packages/apps/src/microsoft_teams/apps/options.py
@@ -89,6 +89,7 @@ class AppOptions(TypedDict, total=False):
     # Infrastructure
     storage: Optional[Storage[str, Any]]
     plugins: Optional[List[PluginBase]]
+    """Deprecated. Prefer explicit middleware, application events, host lifecycle hooks, and route registration."""
     state: Optional[Union[bool, StateOptions]]
     """Per-turn state opt-in. Off by default (``None``/``False``).
 

--- a/packages/apps/src/microsoft_teams/apps/plugins/metadata.py
+++ b/packages/apps/src/microsoft_teams/apps/plugins/metadata.py
@@ -26,7 +26,11 @@ T = TypeVar("T")
 def Plugin(
     name: Optional[str] = None, version: Optional[str] = None, description: Optional[str] = None
 ) -> Callable[[Type[T]], Type[T]]:
-    """Turns any class into a plugin using the decorator pattern."""
+    """Turns any class into a plugin using the decorator pattern.
+
+    Deprecated:
+        The plugin API will be removed in the next major release.
+    """
 
     def decorator(cls: Type[T]) -> Type[T]:
         plugin_name = name or cls.__name__

--- a/packages/apps/src/microsoft_teams/apps/plugins/plugin_base.py
+++ b/packages/apps/src/microsoft_teams/apps/plugins/plugin_base.py
@@ -11,7 +11,13 @@ from .plugin_start_event import PluginStartEvent
 
 
 class PluginBase:
-    """The base plugin for Teams app plugins."""
+    """The base plugin for Teams app plugins.
+
+    Deprecated:
+        Use ``App.use()`` for activity middleware, ``App.event()`` for application
+        events, host lifecycle hooks for setup and cleanup, and normal Python
+        composition for dependencies.
+    """
 
     async def on_init(self) -> None:
         """Lifecycle method called by the App when the plugin is initialized."""

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -1022,6 +1022,70 @@ class TestApp:
 class TestAppInitialize:
     """Test cases for App.initialize() method."""
 
+    def test_register_routes_is_synchronous_and_idempotent(self):
+        adapter = MagicMock()
+        app = App(
+            http_server_adapter=adapter,
+            dangerously_allow_unauthenticated_requests=True,
+        )
+
+        app.register_routes()
+        app.register_routes()
+
+        adapter.register_route.assert_called_once()
+        method, path, handler = adapter.register_route.call_args.args
+        assert method == "POST"
+        assert path == "/api/messages"
+        assert handler == app.server.handle_request
+        assert app.server.on_request is not None
+
+    @pytest.mark.asyncio
+    async def test_initialize_does_not_duplicate_pre_registered_routes(self):
+        adapter = MagicMock()
+        app = App(
+            http_server_adapter=adapter,
+            dangerously_allow_unauthenticated_requests=True,
+        )
+        app.register_routes()
+
+        await app.initialize()
+
+        adapter.register_route.assert_called_once()
+
+    def test_register_routes_does_not_initialize_plugins(self):
+        @Plugin(name="LegacyPlugin")
+        class LegacyPlugin(PluginBase):
+            def __init__(self):
+                self.initialized = False
+
+            async def on_init(self):
+                self.initialized = True
+
+        plugin = LegacyPlugin()
+        with pytest.warns(DeprecationWarning, match="plugin API is deprecated"):
+            app = App(
+                plugins=[plugin],
+                dangerously_allow_unauthenticated_requests=True,
+            )
+
+        app.register_routes()
+
+        assert not plugin.initialized
+
+    def test_plugins_option_emits_deprecation_warning(self):
+        @Plugin(name="LegacyPlugin")
+        class LegacyPlugin(PluginBase):
+            pass
+
+        plugin = LegacyPlugin()
+        with pytest.warns(DeprecationWarning, match="plugin API is deprecated"):
+            app = App(
+                plugins=[plugin],
+                dangerously_allow_unauthenticated_requests=True,
+            )
+
+        assert app.plugins == [plugin]
+
     @pytest.mark.asyncio
     async def test_initialize_enables_send(self):
         """After initialize(), app.send() should work without starting the server."""


### PR DESCRIPTION
## Summary

- add synchronous, idempotent `App.register_routes()` for caller-owned ASGI applications
- keep `App.initialize()` backward compatible while separating route registration from async plugin initialization
- deprecate the legacy `plugins=`, `PluginBase`, and `@Plugin` extension model without removing behavior or exports
- document replacements using `app.use()`, `app.event()`, host lifespan hooks, normal composition, and explicit route registration
- update the non-managed FastAPI example and add regression coverage

This is the compatibility-preserving first step toward the simpler extension model used across the Teams SDKs. Actual plugin removal is deferred to the next major release.

Closes #447

## Validation

- `ruff format --check`
- `ruff check`
- `pyright`
- `pytest packages` — 1,104 passed
- live `examples/echo` startup and HTTP 200 response from `/docs`