### PR TITLE
Rename IncomingFile.web_url to content_url

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
+++ b/packages/apps/src/microsoft_teams/apps/files/files_accessor.py
@@ -116,9 +116,8 @@ class FilesAccessor:
             # `file_type` is the platform-supplied extension (e.g. `pdf`); left `None` when the wire omits it,
             # matching how peer SDKs surface it.
             extension=content.file_type if content else None,
-            # Maps the wire's `content_url` (a browsable link to the file in OneDrive/SharePoint) to `web_url`; not
-            # fetchable like `download_url`.
-            web_url=attachment.content_url,
+            # Browsable link to the file in OneDrive/SharePoint; not fetchable like `download_url`.
+            content_url=attachment.content_url,
             raw=attachment,
             download_url=download_url,
             client=self._client,

--- a/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
@@ -54,8 +54,12 @@ class IncomingFile:
     source: FileSource
     """Where the SDK found the file. Only `botActivity` is produced today."""
 
-    web_url: Optional[str]
-    """Web URL to the file in OneDrive/SharePoint when known."""
+    content_url: Optional[str]
+    """
+    Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `content_url`.
+
+    Not fetchable for bytes despite the name; those come from `download_url`.
+    """
 
     raw: Any
     """The raw underlying attachment/graph object for escape-hatch access."""
@@ -69,7 +73,7 @@ class IncomingFile:
         unique_id: Optional[str] = None,
         content_type: Optional[str] = None,
         extension: Optional[str] = None,
-        web_url: Optional[str] = None,
+        content_url: Optional[str] = None,
         raw: Any = None,
         download_url: Optional[str] = None,
         client: Optional[httpx.AsyncClient] = None,
@@ -80,7 +84,7 @@ class IncomingFile:
         self.unique_id = unique_id
         self.content_type = content_type
         self.extension = extension
-        self.web_url = web_url
+        self.content_url = content_url
         self.raw = raw
         self._download_url = download_url
         self._client = client

--- a/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
+++ b/packages/apps/src/microsoft_teams/apps/files/incoming_file.py
@@ -58,7 +58,7 @@ class IncomingFile:
     """
     Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `content_url`.
 
-    Not fetchable for bytes despite the name; those come from `download_url`.
+    Not fetchable for bytes despite the name; those come from `download()` or `stream()`.
     """
 
     raw: Any

--- a/packages/apps/tests/test_files_accessor.py
+++ b/packages/apps/tests/test_files_accessor.py
@@ -51,7 +51,7 @@ async def test_maps_a_file_download_info_attachment_to_an_incoming_file() -> Non
     assert file.extension == "pdf"
     assert file.scope == "personal"
     assert file.source == "botActivity"
-    assert file.web_url == "https://contoso.sharepoint.com/report.pdf"
+    assert file.content_url == "https://contoso.sharepoint.com/report.pdf"
     assert file.raw is attachment
 
 


### PR DESCRIPTION
Renames the public `IncomingFile.web_url` property to `content_url`.

## This is not a breaking change

**The property has never been published.** `web_url` arrived with the "Receive files in personal scope" work and no release has been cut since, so there are no consumers to break in any published form.

This is also the last cheap moment: once the files feature ships, the name is locked.

## Why

The value arrives on the wire as the attachment's `content_url`, and `Attachment.content_url` **already exposes it publicly** in this same SDK. That left the same value reachable under two different public names depending on which door you came through:

```python
activity.attachments[0].content_url   # public
ctx.files[0].web_url                  # public, same value, different name
```

Upstream doesn't call it a "web URL" either. APX sources it from `fileInfo.ObjectUrl` and writes it into the Bot Framework attachment's `ContentUrl` slot, so `web_url` was a name this SDK invented at the boundary. The mapping comment in `files_accessor.py` was the only thing holding the two vocabularies together, and it's now unnecessary: the value is a straight pass-through.

## The one real objection, and how it's handled

`content_url` sits next to `download_url`, and it is the one that does **not** return content. That's a genuine footgun, but it already exists on `Attachment.content_url` regardless of what we do here, and it's a docs problem rather than a design problem. Two public names for one value is the design problem. So the docstring now states the trap directly:

> Browsable URL to the file in OneDrive/SharePoint, as sent on the attachment's `content_url`. Not fetchable for bytes despite the name; those come from `download_url`.

## Cross-SDK

Companion to microsoft/teams.ts#773 (`webUrl` → `contentUrl`), with a matching PR for `teams.net` (`WebUrl` → `ContentUrl`). The feature is unreleased in all three, so all three can move together. Published docs in `teams-sdk` are updated separately.

## Validation

598 tests pass; `poe check` clean.
