### PR TITLE
feat(api): add setCachePolicy card action

### DIFF
--- a/packages/api/src/microsoft_teams/api/models/card/card_action_type.py
+++ b/packages/api/src/microsoft_teams/api/models/card/card_action_type.py
@@ -19,6 +19,12 @@ class CardActionType(str, Enum):
     SIGN_IN = "signin"
     CALL = "call"
     INVOKE = "invoke"
+    SET_CACHE_POLICY = "setCachePolicy"
+    """Controls caching for a link-unfurling response.
+
+    Set the action value to ``{"type": "no-cache"}`` to prevent Teams from caching
+    the response.
+    """
     SUBMIT = "Action.Submit"
     """Suggested action of type Action.Submit. The action's value is delivered to the bot
     as a suggestedActions/submit invoke without sending a chat-visible message."""

--- a/packages/api/tests/unit/test_card_action.py
+++ b/packages/api/tests/unit/test_card_action.py
@@ -1,0 +1,31 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+import pytest
+from microsoft_teams.api.models.card.card_action import CardAction
+from microsoft_teams.api.models.card.card_action_type import CardActionType
+
+
+@pytest.mark.unit
+class TestCardAction:
+    """Unit tests for CardAction."""
+
+    def test_deserialize_set_cache_policy_action(self) -> None:
+        """Test setCachePolicy actions round-trip through validation and serialization."""
+        action = CardAction.model_validate(
+            {
+                "type": "setCachePolicy",
+                "title": "Open link",
+                "value": {"type": "no-cache"},
+            }
+        )
+
+        assert action.type is CardActionType.SET_CACHE_POLICY
+        assert action.value == {"type": "no-cache"}
+
+        data = action.model_dump(by_alias=True)
+
+        assert data["type"] == "setCachePolicy"
+        assert data["value"] == {"type": "no-cache"}


### PR DESCRIPTION
## Summary

- add `CardActionType.SET_CACHE_POLICY` for the Teams `setCachePolicy` card/suggested-action type
- document the `{"type": "no-cache"}` value used to disable link-unfurling response caching
- add regression coverage for validation and alias-aware serialization while preserving newer action types such as `Action.Submit`

Cross-SDK context: microsoft/teams.ts#574
Originating issue: microsoft/teams.ts#154

## Tests

- `ruff format --check packages/api/src/microsoft_teams/api/models/card/card_action_type.py packages/api/tests/unit/test_card_action.py`
- `ruff check packages/api/src/microsoft_teams/api/models/card/card_action_type.py packages/api/tests/unit/test_card_action.py`
- `pyright packages/api/src/microsoft_teams/api/models/card/card_action_type.py packages/api/tests/unit/test_card_action.py`
- `pytest packages/api/tests/unit/test_card_action.py packages/api/tests/unit/test_suggested_action_submit.py -q`