### PR TITLE
fix: accept installationUpdate upgrade action

### DIFF
--- a/packages/api/src/microsoft_teams/api/activities/install_update/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/install_update/__init__.py
@@ -3,22 +3,23 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+
 from typing import Annotated, Union
 
 from pydantic import Field
 
 from .add import InstalledActivity
 from .remove import UninstalledActivity
-from .upgrade import UpgradedActivity
+from .upgrade import InstalledUpgradeActivity
 
 InstallUpdateActivity = Annotated[
-    Union[InstalledActivity, UninstalledActivity, UpgradedActivity],
+    Union[InstalledActivity, UninstalledActivity, InstalledUpgradeActivity],
     Field(discriminator="action"),
 ]
 
 __all__ = [
     "InstalledActivity",
     "UninstalledActivity",
-    "UpgradedActivity",
+    "InstalledUpgradeActivity",
     "InstallUpdateActivity",
 ]

--- a/packages/api/src/microsoft_teams/api/activities/install_update/__init__.py
+++ b/packages/api/src/microsoft_teams/api/activities/install_update/__init__.py
@@ -9,11 +9,16 @@ from pydantic import Field
 
 from .add import InstalledActivity
 from .remove import UninstalledActivity
+from .upgrade import UpgradedActivity
 
-InstallUpdateActivity = Annotated[Union[InstalledActivity, UninstalledActivity], Field(discriminator="action")]
+InstallUpdateActivity = Annotated[
+    Union[InstalledActivity, UninstalledActivity, UpgradedActivity],
+    Field(discriminator="action"),
+]
 
 __all__ = [
     "InstalledActivity",
     "UninstalledActivity",
+    "UpgradedActivity",
     "InstallUpdateActivity",
 ]

--- a/packages/api/src/microsoft_teams/api/activities/install_update/upgrade.py
+++ b/packages/api/src/microsoft_teams/api/activities/install_update/upgrade.py
@@ -1,0 +1,15 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Literal
+
+from ...models import ActivityBase, CustomBaseModel
+
+
+class UpgradedActivity(ActivityBase, CustomBaseModel):
+    type: Literal["installationUpdate"] = "installationUpdate"  #
+
+    action: Literal["upgrade"] = "upgrade"
+    """Install update action"""

--- a/packages/api/src/microsoft_teams/api/activities/install_update/upgrade.py
+++ b/packages/api/src/microsoft_teams/api/activities/install_update/upgrade.py
@@ -8,7 +8,7 @@ from typing import Literal
 from ...models import ActivityBase, CustomBaseModel
 
 
-class UpgradedActivity(ActivityBase, CustomBaseModel):
+class InstalledUpgradeActivity(ActivityBase, CustomBaseModel):
     type: Literal["installationUpdate"] = "installationUpdate"  #
 
     action: Literal["upgrade"] = "upgrade"

--- a/packages/api/tests/unit/test_install_update.py
+++ b/packages/api/tests/unit/test_install_update.py
@@ -1,0 +1,44 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+# pyright: basic
+
+from microsoft_teams.api.activities import ActivityTypeAdapter
+from microsoft_teams.api.activities.install_update import UpgradedActivity
+
+
+def test_installation_update_upgrade_parses() -> None:
+    """Regression test for installationUpdate payloads that use action=upgrade."""
+    payload = {
+        "action": "upgrade",
+        "channelId": "msteams",
+        "conversation": {
+            "conversationType": "personal",
+            "id": "xxx",
+            "tenantId": "xxx",
+        },
+        "entities": [
+            {
+                "locale": "en-US",
+                "type": "clientInfo",
+            }
+        ],
+        "from": {
+            "aadObjectId": "xxx",
+            "id": "xxx",
+        },
+        "id": "xxx",
+        "recipient": {
+            "id": "xxx",
+            "name": "xxx",
+        },
+        "serviceUrl": "https://smba.trafficmanager.net/emea/xxx/",
+        "timestamp": "2026-08-26T13:38:36.356Z",
+        "type": "installationUpdate",
+    }
+
+    activity = ActivityTypeAdapter.validate_python(payload)
+
+    assert isinstance(activity, UpgradedActivity)
+    assert activity.action == "upgrade"

--- a/packages/api/tests/unit/test_install_update.py
+++ b/packages/api/tests/unit/test_install_update.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 # pyright: basic
 
 from microsoft_teams.api.activities import ActivityTypeAdapter
-from microsoft_teams.api.activities.install_update import UpgradedActivity
+from microsoft_teams.api.activities.install_update import InstalledUpgradeActivity
 
 
 def test_installation_update_upgrade_parses() -> None:
@@ -40,5 +40,5 @@ def test_installation_update_upgrade_parses() -> None:
 
     activity = ActivityTypeAdapter.validate_python(payload)
 
-    assert isinstance(activity, UpgradedActivity)
+    assert isinstance(activity, InstalledUpgradeActivity)
     assert activity.action == "upgrade"


### PR DESCRIPTION
## Summary
Fixes issue #579 

where `installationUpdate` payloads with `action = "upgrade"` raised a validation error because only `add` and `remove` were accepted.

## Changes
- Add support for `installationUpdate.action = "upgrade"`
- Extend the install update activity union with `UpgradedActivity`
- Add a regression test for the upgrade payload from issue #579

## Validation
- `packages/api/tests/unit/test_install_update.py` 