### PR TITLE
fix: use public httpx Request/Response and bound httpx below 1.0

### DIFF
--- a/examples/a2a/pyproject.toml
+++ b/examples/a2a/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "agent-framework-core",
     "agent-framework-openai",
     "uvicorn>=0.30",
-    "httpx>=0.27",
+    "httpx>=0.27,<1.0",
 ]
 
 [tool.uv.sources]

--- a/packages/apps/pyproject.toml
+++ b/packages/apps/pyproject.toml
@@ -32,7 +32,7 @@ graph = [
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
-    "httpx>=0.27.0",
+    "httpx>=0.27.0,<1.0",
 ]
 
 [build-system]

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "httpx>=0.28.1",
+    "httpx>=0.28.1,<1.0",
 ]
 
 [dependency-groups]

--- a/packages/common/src/microsoft_teams/common/http/client.py
+++ b/packages/common/src/microsoft_teams/common/http/client.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field, replace
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Protocol
 
 import httpx
-from httpx._models import Request, Response
+from httpx import Request, Response
 from httpx._types import QueryParamTypes, RequestContent, RequestData, RequestFiles
 
 from .client_token import Token, resolve_token

--- a/uv.lock
+++ b/uv.lock
@@ -84,7 +84,7 @@ requires-dist = [
     { name = "agent-framework-core" },
     { name = "agent-framework-openai" },
     { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "microsoft-teams-apps", editable = "packages/apps" },
     { name = "microsoft-teams-cards", editable = "packages/cards" },
     { name = "microsoft-teams-common", editable = "packages/common" },
@@ -2016,7 +2016,7 @@ provides-extras = ["graph"]
 
 [package.metadata.requires-dev]
 test = [
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
 ]
@@ -2077,7 +2077,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "httpx", specifier = ">=0.28.1" }]
+requires-dist = [{ name = "httpx", specifier = ">=0.28.1,<1.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fixes #568.

httpx 1.0 removes `httpx._models` and `httpx._types`, and the requirement was unbounded, so once 1.0 ships stable a fresh install resolves to it and every `import microsoft_teams.*` fails at import time.

This does the two safe halves of the issue:

- `Request` and `Response` are public in both 0.x and 1.0, so `packages/common/.../http/client.py` now imports them from `httpx` directly.
- `<1.0` upper bound added in `packages/common`, `packages/apps` and `examples/a2a` (plus the matching `uv.lock` lines).

Left alone deliberately: the `_types` aliases (`QueryParamTypes`, `RequestContent`, `RequestData`, `RequestFiles`). They have no public equivalent in either 0.x or 1.0, and they appear in a lot of public method signatures, so picking a replacement is an API decision rather than a mechanical edit — the upper bound covers them until you decide. Happy to follow up with SDK-owned aliases if you want to go that way.

Verified locally on httpx 0.28.1:

- `from httpx import Request, Response` resolves, and `microsoft_teams.common.http.client` still imports.
- `uv run ruff check .` — All checks passed
- `uv run pytest -q` — 1340 passed

One note: `ruff format --check` reports `packages/api/src/microsoft_teams/api/activities/install_update/__init__.py` would be reformatted. That is pre-existing on `main` — same result with this branch stashed — and untouched here.