### PR TITLE
Route threaded replies through Bot Framework reply endpoint

### DIFF
--- a/examples/a2a/src/main.py
+++ b/examples/a2a/src/main.py
@@ -13,7 +13,7 @@ from a2a_server import build_agent_card, make_a2a_app
 from agent import BotAgent
 from dotenv import find_dotenv, load_dotenv
 from fastapi import FastAPI
-from microsoft_teams.api import MessageActivity
+from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext, App, FastAPIAdapter
 from types_ import Config, TurnIdentity
 
@@ -60,8 +60,12 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
             bool(tenant_id),
             bool(service_url),
         )
-        await ctx.reply(
-            "I can't process this message — it's missing the identity context this sample needs for cross-bot handoff."
+        await ctx.send(
+            MessageActivityInput().add_quote(
+                ctx.activity.id,
+                "I can't process this message — it's missing the identity context "
+                "this sample needs for cross-bot handoff.",
+            )
         )
         return
 
@@ -77,7 +81,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]) -> None:
 
     reply = await bot_agent.run(conv_id, identity, text)
     if reply:
-        await ctx.reply(reply)
+        await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, reply))
 
 
 async def main() -> None:

--- a/examples/agent365/src/main.py
+++ b/examples/agent365/src/main.py
@@ -18,6 +18,7 @@ from microsoft_teams.api import (
     AgenticUserWorkloadOnboardingUpdatedActivity,
     AgentLifecycleEventActivity,
     MessageActivity,
+    MessageActivityInput,
 )
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
@@ -132,7 +133,7 @@ async def handle_agentic_user_workload_onboarding_updated(
 @app.on_message_pattern(re.compile(r"hello|hi|greetings"))
 async def handle_greeting(ctx: ActivityContext[MessageActivity]) -> None:
     """Handle greeting messages using the inbound AgenticIdentity when present."""
-    await ctx.reply("Hello! How can I assist you today?")
+    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Hello! How can I assist you today?"))
 
 
 @app.on_message
@@ -142,7 +143,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     logger.info("[Agent365 reactive] From: %s", ctx.activity.from_)
     logger.info("[Agent365 reactive] AgenticIdentity: %s", ctx.activity.recipient.agentic_identity)
 
-    await ctx.reply(TypingActivityInput())
+    await ctx.send(TypingActivityInput())
 
     if "react" in ctx.activity.text.lower():
         await ctx.api.conversations.add_reaction(
@@ -150,11 +151,11 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             activity_id=ctx.activity.id,
             reaction_type="like",
         )
-        await ctx.reply("Added a like reaction to your message.")
+        await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Added a like reaction to your message."))
         return
 
     if "reply" in ctx.activity.text.lower():
-        await ctx.reply("Hello! How can I assist you today?")
+        await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Hello! How can I assist you today?"))
     else:
         await ctx.send(f"You said '{ctx.activity.text}'")
 

--- a/examples/cards/src/main.py
+++ b/examples/cards/src/main.py
@@ -449,7 +449,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     logger.info(f"[GENERAL] From: {ctx.activity.from_}")
 
     if "reply" in ctx.activity.text.lower():
-        await ctx.reply("Hello! How can I assist you today?")
+        await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Hello! How can I assist you today?"))
     else:
         await ctx.send(f"You said '{ctx.activity.text}'")
 

--- a/examples/echo/src/main.py
+++ b/examples/echo/src/main.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import re
 
-from microsoft_teams.api import MessageActivity
+from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
 
@@ -22,7 +22,7 @@ app = App()
 @app.on_message_pattern(re.compile(r"hello|hi|greetings"))
 async def handle_greeting(ctx: ActivityContext[MessageActivity]) -> None:
     """Handle greeting messages."""
-    await ctx.reply("Hello! How can I assist you today?")
+    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Hello! How can I assist you today?"))
 
 
 @app.on_message
@@ -30,10 +30,10 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Handle message activities using the new generated handler system."""
     logger.info(f"[GENERATED onMessage] Message received: {ctx.activity.text}")
     logger.info(f"[GENERATED onMessage] From: {ctx.activity.from_}")
-    await ctx.reply(TypingActivityInput())
+    await ctx.send(TypingActivityInput())
 
     if "reply" in ctx.activity.text.lower():
-        await ctx.reply("Hello! How can I assist you today?")
+        await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Hello! How can I assist you today?"))
     else:
         await ctx.send(f"You said '{ctx.activity.text}'")
 

--- a/examples/formatted-messaging/src/main.py
+++ b/examples/formatted-messaging/src/main.py
@@ -20,7 +20,7 @@ app = App()
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
     """Demonstrate text format options: markdown, extendedmarkdown, xml, and plain."""
-    await ctx.reply(TypingActivityInput())
+    await ctx.send(TypingActivityInput())
     text = ctx.activity.text.lower()
 
     if "extended" in text:
@@ -39,8 +39,8 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
                 "$$E = mc^2$$",
             ]
         )
-        reply = MessageActivityInput(text=rich_content).with_text_format("extendedmarkdown")
-        await ctx.reply(reply)
+        reply = MessageActivityInput().add_quote(ctx.activity.id, rich_content).with_text_format("extendedmarkdown")
+        await ctx.send(reply)
     elif "markdown" in text:
         md_content = "\n".join(
             [
@@ -58,18 +58,22 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
                 "`inline code` and [a link](https://www.microsoft.com)",
             ]
         )
-        reply = MessageActivityInput(text=md_content).with_text_format("markdown")
-        await ctx.reply(reply)
+        reply = MessageActivityInput().add_quote(ctx.activity.id, md_content).with_text_format("markdown")
+        await ctx.send(reply)
     elif "xml" in text:
         xml_content = (
             "<b>Bold</b>, <i>italic</i>, and <strike>strikethrough</strike><br/>"
             "<ul><li>Item one</li><li>Item two</li><li>Item three</li></ul>"
         )
-        reply = MessageActivityInput(text=xml_content).with_text_format("xml")
-        await ctx.reply(reply)
+        reply = MessageActivityInput().add_quote(ctx.activity.id, xml_content).with_text_format("xml")
+        await ctx.send(reply)
     elif "plain" in text:
-        reply = MessageActivityInput(text="This is plain text with no formatting applied.").with_text_format("plain")
-        await ctx.reply(reply)
+        reply = (
+            MessageActivityInput()
+            .add_quote(ctx.activity.id, "This is plain text with no formatting applied.")
+            .with_text_format("plain")
+        )
+        await ctx.send(reply)
     else:
         await ctx.send("Send **markdown**, **extended**, **xml**, or **plain** to see different text formats.")
 

--- a/examples/interacting-with-messages/README.md
+++ b/examples/interacting-with-messages/README.md
@@ -14,7 +14,7 @@ in a separate source module.
 
 | Command | Behavior |
 |---------|----------|
-| `quote reply` | `ctx.reply()` auto-quotes the inbound message |
+| `quote reply` | Deprecated `ctx.reply()` compatibility behavior auto-quotes the inbound message |
 | `quote message` | `ctx.quote()` quotes a previously sent message by ID |
 | `quote add` | `add_quote()` composes a quote with a response |
 | `quote batch` | Combines multiple quotes with mixed responses |
@@ -25,10 +25,10 @@ in a separate source module.
 
 | Command | Behavior |
 |---------|----------|
-| `thread reply` | `ctx.reply()` sends a reactive threaded reply |
+| `thread reply` | Deprecated `ctx.reply()` compatibility behavior sends a reactive threaded reply |
 | `thread send` | `ctx.send()` sends to the same thread without quoting |
 | `thread proactive` | `app.reply()` sends a proactive threaded reply |
-| `thread manual` | `to_threaded_conversation_id()` and `app.send()` provide manual control |
+| `thread manual` | `app.reply()` selects an explicit thread root |
 
 ### Reactions
 

--- a/examples/interacting-with-messages/README.md
+++ b/examples/interacting-with-messages/README.md
@@ -14,21 +14,24 @@ in a separate source module.
 
 | Command | Behavior |
 |---------|----------|
-| `quote reply` | Deprecated `ctx.reply()` compatibility behavior auto-quotes the inbound message |
-| `quote message` | `ctx.quote()` quotes a previously sent message by ID |
-| `quote add` | `add_quote()` composes a quote with a response |
+| `quote reply` | `add_quote()` explicitly quotes the inbound message |
+| `quote message` | `add_quote()` quotes a previously sent message by ID |
 | `quote batch` | Combines multiple quotes with mixed responses |
-| `quote manual` | Combines `add_quote()` and `add_text()` manually |
 | *(quote a message)* | Displays the quoted-message metadata |
 
 ### Threading
 
 | Command | Behavior |
 |---------|----------|
-| `thread reply` | Deprecated `ctx.reply()` compatibility behavior sends a reactive threaded reply |
-| `thread send` | `ctx.send()` sends to the same thread without quoting |
-| `thread proactive` | `app.reply()` sends a proactive threaded reply |
-| `thread manual` | `app.reply()` selects an explicit thread root |
+| `default send` | `ctx.send()` uses the default reactive placement |
+| `thread proactive` | `app.reply()` selects an explicit proactive thread root |
+| `thread proactive quote` | `app.reply()` selects a thread root; `add_quote()` adds quote metadata |
+| `thread proactive targeted` | `app.reply()` sends a targeted activity to an explicit thread root |
+| `thread proactive targeted quote` | Combines targeted thread placement with explicit quote metadata |
+
+Targeted outbound activities use the targeted reply endpoint when a thread root is
+selected, so recipient visibility, thread placement, and quote metadata remain
+independent.
 
 ### Reactions
 

--- a/examples/interacting-with-messages/README.md
+++ b/examples/interacting-with-messages/README.md
@@ -29,6 +29,9 @@ in a separate source module.
 | `thread proactive targeted` | `app.reply()` sends a targeted activity to an explicit thread root |
 | `thread proactive targeted quote` | Combines targeted thread placement with explicit quote metadata |
 
+The proactive commands use `get_proactive_thread_reference()` to resolve typed thread
+metadata, legacy conversation IDs, and root messages consistently.
+
 Targeted outbound activities use the targeted reply endpoint when a thread root is
 selected, so recipient visibility, thread placement, and quote metadata remain
 independent.

--- a/examples/interacting-with-messages/src/main.py
+++ b/examples/interacting-with-messages/src/main.py
@@ -10,15 +10,13 @@ from microsoft_teams.api import MessageActivity
 from microsoft_teams.api.activities.typing import TypingActivityInput
 from microsoft_teams.apps import ActivityContext, App
 from quoting import (
-    handle_quote_add,
     handle_quote_batch,
-    handle_quote_manual,
     handle_quote_message,
     handle_quote_reply,
     handle_quoted_message,
 )
 from reactions import handle_add_reaction, handle_proactive_reaction, handle_reaction_event, handle_remove_reaction
-from threading_handlers import handle_manual_thread, handle_proactive_thread, handle_thread_reply, handle_thread_send
+from threading_handlers import handle_default_send, handle_proactive_thread
 
 logging.basicConfig(level=logging.INFO)
 
@@ -39,14 +37,14 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
             "**Quoting:**\n"
             "- `quote reply` - auto-quote your message\n"
             "- `quote message` - quote a previously sent message\n"
-            "- `quote add` - compose a quote with the message builder\n"
             "- `quote batch` - combine multiple quotes\n"
-            "- `quote manual` - combine a quote and text manually\n\n"
+            "\n"
             "**Threading:**\n"
-            "- `thread reply` - send a reactive threaded reply\n"
-            "- `thread send` - send to the same thread without quoting\n"
-            "- `thread proactive` - send a proactive threaded reply\n"
-            "- `thread manual` - construct a threaded conversation ID manually\n\n"
+            "- `default send` - use default reactive placement\n"
+            "- `thread proactive` - explicitly select a proactive thread root\n"
+            "- `thread proactive quote` - explicitly select a thread root and quote this message\n"
+            "- `thread proactive targeted` - send a targeted reply to an explicit thread root\n"
+            "- `thread proactive targeted quote` - combine targeted thread placement and quoting\n\n"
             "**Reactions:**\n"
             "- `reaction add <type>` - add a reaction to your message\n"
             "- `reaction remove <type>` - add, then remove, a reaction\n"
@@ -60,11 +58,8 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
     handlers = (
         handle_quote_reply,
         handle_quote_message,
-        handle_quote_add,
         handle_quote_batch,
-        handle_quote_manual,
-        handle_thread_reply,
-        handle_thread_send,
+        handle_default_send,
         handle_add_reaction,
         handle_remove_reaction,
     )
@@ -74,7 +69,6 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
 
     app_handlers = (
         handle_proactive_thread,
-        handle_manual_thread,
         handle_proactive_reaction,
     )
     for handler in app_handlers:

--- a/examples/interacting-with-messages/src/quoting.py
+++ b/examples/interacting-with-messages/src/quoting.py
@@ -45,15 +45,6 @@ async def handle_quote_message(ctx: ActivityContext[MessageActivity], text: str)
     return True
 
 
-async def handle_quote_add(ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Compose a quote with a response when the command matches."""
-    if text != "quote add":
-        return False
-    sent = await ctx.send("Please review the latest PR before end of day.")
-    await ctx.send(MessageActivityInput().add_quote(sent.id, "Done! Left my comments on the PR."))
-    return True
-
-
 async def handle_quote_batch(ctx: ActivityContext[MessageActivity], text: str) -> bool:
     """Compose multiple quotes when the command matches."""
     if text != "quote batch":
@@ -68,13 +59,4 @@ async def handle_quote_batch(ctx: ActivityContext[MessageActivity], text: str) -
         .add_quote(sent_c.id)
     )
     await ctx.send(message)
-    return True
-
-
-async def handle_quote_manual(ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Manually combine a quote and text when the command matches."""
-    if text != "quote manual":
-        return False
-    sent = await ctx.send("Deployment to staging is complete.")
-    await ctx.send(MessageActivityInput().add_quote(sent.id).add_text(" Verified - all smoke tests passing."))
     return True

--- a/examples/interacting-with-messages/src/quoting.py
+++ b/examples/interacting-with-messages/src/quoting.py
@@ -32,7 +32,7 @@ async def handle_quote_reply(ctx: ActivityContext[MessageActivity], text: str) -
     """Reply with an automatic quote when the command matches."""
     if text != "quote reply":
         return False
-    await ctx.reply("Thanks for your message! This reply auto-quotes it using reply().")
+    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Thanks for your message!"))
     return True
 
 
@@ -41,7 +41,7 @@ async def handle_quote_message(ctx: ActivityContext[MessageActivity], text: str)
     if text != "quote message":
         return False
     sent = await ctx.send("The meeting has been moved to 3 PM tomorrow.")
-    await ctx.quote(sent.id, "Just to confirm - does the new time work for everyone?")
+    await ctx.send(MessageActivityInput().add_quote(sent.id, "Just to confirm - does the new time work for everyone?"))
     return True
 
 

--- a/examples/interacting-with-messages/src/threading_handlers.py
+++ b/examples/interacting-with-messages/src/threading_handlers.py
@@ -3,7 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from microsoft_teams.api import MessageActivity
+from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext, App
 
 
@@ -11,7 +11,7 @@ async def handle_thread_reply(ctx: ActivityContext[MessageActivity], text: str) 
     """Send a reactive threaded reply when the command matches."""
     if text != "thread reply":
         return False
-    await ctx.reply("This is a threaded reply to your message.")
+    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "This is a threaded reply to your message."))
     return True
 
 

--- a/examples/interacting-with-messages/src/threading_handlers.py
+++ b/examples/interacting-with-messages/src/threading_handlers.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext, App
+from microsoft_teams.apps.utils.thread import parse_threaded_conversation_id
 
 
 async def handle_thread_reply(ctx: ActivityContext[MessageActivity], text: str) -> bool:
@@ -44,4 +45,6 @@ async def handle_manual_thread(app: App, ctx: ActivityContext[MessageActivity], 
 def _thread_reference(ctx: ActivityContext[MessageActivity]) -> tuple[str, str]:
     conversation_id = ctx.conversation_ref.conversation.id
     thread = ctx.activity.channel_data.thread if ctx.activity.channel_data else None
-    return conversation_id, thread.id if thread and thread.id else ctx.activity.id
+    base_conversation_id, legacy_thread_root_id = parse_threaded_conversation_id(conversation_id)
+    thread_root_id = thread.id if thread and thread.id else legacy_thread_root_id or ctx.activity.id
+    return base_conversation_id, thread_root_id

--- a/examples/interacting-with-messages/src/threading_handlers.py
+++ b/examples/interacting-with-messages/src/threading_handlers.py
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 from microsoft_teams.api import MessageActivity, MessageActivityInput
 from microsoft_teams.apps import ActivityContext, App
-from microsoft_teams.apps.utils.thread import parse_threaded_conversation_id
+from microsoft_teams.apps.utils import get_proactive_thread_reference
 
 
 async def handle_default_send(ctx: ActivityContext[MessageActivity], text: str) -> bool:
@@ -27,7 +27,7 @@ async def handle_proactive_thread(app: App, ctx: ActivityContext[MessageActivity
     if text not in variants:
         return False
 
-    conversation_id, thread_root_id = _thread_reference(ctx)
+    conversation_id, thread_root_id = get_proactive_thread_reference(ctx.activity)
     should_quote, is_targeted = variants[text]
     activity = MessageActivityInput(text="This is an explicit proactive threaded reply.")
     if should_quote:
@@ -37,11 +37,3 @@ async def handle_proactive_thread(app: App, ctx: ActivityContext[MessageActivity
 
     await app.reply(conversation_id, thread_root_id, activity)
     return True
-
-
-def _thread_reference(ctx: ActivityContext[MessageActivity]) -> tuple[str, str]:
-    conversation_id = ctx.conversation_ref.conversation.id
-    thread = ctx.activity.channel_data.thread if ctx.activity.channel_data else None
-    base_conversation_id, legacy_thread_root_id = parse_threaded_conversation_id(conversation_id)
-    thread_root_id = thread.id if thread and thread.id else legacy_thread_root_id or ctx.activity.id
-    return base_conversation_id, thread_root_id

--- a/examples/interacting-with-messages/src/threading_handlers.py
+++ b/examples/interacting-with-messages/src/threading_handlers.py
@@ -4,7 +4,7 @@ Licensed under the MIT License.
 """
 
 from microsoft_teams.api import MessageActivity
-from microsoft_teams.apps import ActivityContext, App, to_threaded_conversation_id
+from microsoft_teams.apps import ActivityContext, App
 
 
 async def handle_thread_reply(ctx: ActivityContext[MessageActivity], text: str) -> bool:
@@ -33,16 +33,15 @@ async def handle_proactive_thread(app: App, ctx: ActivityContext[MessageActivity
 
 
 async def handle_manual_thread(app: App, ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Construct a threaded conversation ID manually when the command matches."""
+    """Send to an explicitly selected thread root when the command matches."""
     if text != "thread manual":
         return False
     conversation_id, thread_root_id = _thread_reference(ctx)
-    thread_id = to_threaded_conversation_id(conversation_id, thread_root_id)
-    await app.send(thread_id, "This was sent using to_threaded_conversation_id() + app.send() for manual control.")
+    await app.reply(conversation_id, thread_root_id, "This was sent using app.reply() with an explicit thread root.")
     return True
 
 
 def _thread_reference(ctx: ActivityContext[MessageActivity]) -> tuple[str, str]:
     conversation_id = ctx.conversation_ref.conversation.id
-    parts = conversation_id.split(";messageid=")
-    return conversation_id, parts[1] if len(parts) > 1 else ctx.activity.id
+    thread = ctx.activity.channel_data.thread if ctx.activity.channel_data else None
+    return conversation_id, thread.id if thread and thread.id else ctx.activity.id

--- a/examples/interacting-with-messages/src/threading_handlers.py
+++ b/examples/interacting-with-messages/src/threading_handlers.py
@@ -8,37 +8,34 @@ from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.apps.utils.thread import parse_threaded_conversation_id
 
 
-async def handle_thread_reply(ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Send a reactive threaded reply when the command matches."""
-    if text != "thread reply":
+async def handle_default_send(ctx: ActivityContext[MessageActivity], text: str) -> bool:
+    """Use the default reactive placement for the inbound scope."""
+    if text != "default send":
         return False
-    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "This is a threaded reply to your message."))
-    return True
-
-
-async def handle_thread_send(ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Send to the current thread without quoting when the command matches."""
-    if text != "thread send":
-        return False
-    await ctx.send("This is sent to the same thread, without quoting.")
+    await ctx.send("This uses the default reactive placement for the current conversation.")
     return True
 
 
 async def handle_proactive_thread(app: App, ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Send a proactive threaded reply when the command matches."""
-    if text != "thread proactive":
+    """Send one of the explicit proactive thread-placement variants."""
+    variants = {
+        "thread proactive": (False, False),
+        "thread proactive quote": (True, False),
+        "thread proactive targeted": (False, True),
+        "thread proactive targeted quote": (True, True),
+    }
+    if text not in variants:
         return False
-    conversation_id, thread_root_id = _thread_reference(ctx)
-    await app.reply(conversation_id, thread_root_id, "This is a proactive threaded reply using app.reply().")
-    return True
 
-
-async def handle_manual_thread(app: App, ctx: ActivityContext[MessageActivity], text: str) -> bool:
-    """Send to an explicitly selected thread root when the command matches."""
-    if text != "thread manual":
-        return False
     conversation_id, thread_root_id = _thread_reference(ctx)
-    await app.reply(conversation_id, thread_root_id, "This was sent using app.reply() with an explicit thread root.")
+    should_quote, is_targeted = variants[text]
+    activity = MessageActivityInput(text="This is an explicit proactive threaded reply.")
+    if should_quote:
+        activity = MessageActivityInput().add_quote(ctx.activity.id, "This threaded reply includes a quote.")
+    if is_targeted:
+        activity.with_recipient(ctx.activity.from_, is_targeted=True)
+
+    await app.reply(conversation_id, thread_root_id, activity)
     return True
 
 

--- a/examples/m365extensions/src/main.py
+++ b/examples/m365extensions/src/main.py
@@ -117,7 +117,7 @@ async def _react(ctx: ActivityContext[MessageActivity]):
 
 @TEAMS_APP.on_message_pattern(_command("quote"))
 async def _quote(ctx: ActivityContext[MessageActivity]):
-    await ctx.reply("Quoting your message!")
+    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Quoting your message!"))
 
 
 @TEAMS_APP.on_message_pattern(_command("targeted"))

--- a/examples/mcp-server/src/app.py
+++ b/examples/mcp-server/src/app.py
@@ -11,6 +11,7 @@ from microsoft_teams.api import (
     AdaptiveCardInvokeActivity,
     AdaptiveCardInvokeResponse,
     MessageActivity,
+    MessageActivityInput,
 )
 from microsoft_teams.apps import ActivityContext, App
 from microsoft_teams.cards import AdaptiveCard, TextBlock
@@ -33,7 +34,7 @@ async def handle_message(ctx: ActivityContext[MessageActivity]):
         f"Received message from user {user_id} in conversation {conversation_id}. "
         "Replies to asks now arrive via adaptive card actions."
     )
-    await ctx.reply("Hi! I'll let you know if I need anything.")
+    await ctx.send(MessageActivityInput().add_quote(ctx.activity.id, "Hi! I'll let you know if I need anything."))
 
 
 @app.on_card_action_execute("ask_reply")

--- a/examples/meetings/src/main.py
+++ b/examples/meetings/src/main.py
@@ -100,7 +100,7 @@ async def handle_meeting_participant_leave(ctx: ActivityContext[MeetingParticipa
 
 @app.on_message
 async def handle_message(ctx: ActivityContext[MessageActivity]):
-    await ctx.reply(TypingActivityInput())
+    await ctx.send(TypingActivityInput())
     await ctx.send("Welcome to the meetings sample! This app will notify you for meeting events.")
 
 

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -222,7 +222,8 @@ class ConversationActivityClient(BaseClient):
                 on_response=_set_response_activity_id,
             ),
         )
-        id = response.json()["id"]
+        response_body = response.json()
+        id = response_body.get("id", _PLACEHOLDER_ACTIVITY_ID)
         return SentActivity(id=id, activity_params=activity)
 
     async def delete(

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -167,11 +167,9 @@ class ConversationActivityClient(BaseClient):
         if scoped_client is not self:
             return await scoped_client.reply(conversation_id, activity_id, activity)
 
-        activity_json = activity.model_dump(by_alias=True, exclude_none=True)
-        activity_json["replyToId"] = activity_id
         response = await self.http.post(
-            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities",
-            json=activity_json,
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            json=activity.model_dump(by_alias=True, exclude_none=True),
             _metadata=self._create_activity_telemetry_metadata(
                 API_OUTBOUND_OPERATIONS.reply,
                 conversation_id,

--- a/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/activity.py
@@ -162,16 +162,59 @@ class ConversationActivityClient(BaseClient):
         Returns:
             The created reply activity
         """
+        return await self._reply(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+            is_targeted=False,
+        )
+
+    @experimental("ExperimentalTeamsTargeted")
+    async def reply_targeted(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        """Reply with a targeted activity visible only to the specified recipient."""
+        return await self._reply(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+            is_targeted=True,
+        )
+
+    async def _reply(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None,
+        agentic_identity: AgenticIdentity | None,
+        is_targeted: bool,
+    ) -> SentActivity:
         # TODO: Will be deprecated alongside accessor in ConversationClient
         scoped_client = self._scoped_client(service_url, agentic_identity)
         if scoped_client is not self:
+            if is_targeted:
+                return await scoped_client.reply_targeted(conversation_id, activity_id, activity)
             return await scoped_client.reply(conversation_id, activity_id, activity)
 
+        targeted_query = "?isTargetedActivity=true" if is_targeted else ""
         response = await self.http.post(
-            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/{activity_id}",
+            f"{self._get_service_url(service_url)}/v3/conversations/{conversation_id}/activities/"
+            f"{activity_id}{targeted_query}",
             json=activity.model_dump(by_alias=True, exclude_none=True),
             _metadata=self._create_activity_telemetry_metadata(
-                API_OUTBOUND_OPERATIONS.reply,
+                API_OUTBOUND_OPERATIONS.reply_targeted if is_targeted else API_OUTBOUND_OPERATIONS.reply,
                 conversation_id,
                 service_url=service_url,
                 activity=activity,

--- a/packages/api/src/microsoft_teams/api/clients/conversation/client.py
+++ b/packages/api/src/microsoft_teams/api/clients/conversation/client.py
@@ -79,6 +79,23 @@ class ActivityOperations(ConversationOperations):
             agentic_identity=agentic_identity,
         )
 
+    async def reply_targeted(
+        self,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        """Reply with a targeted activity visible only to the specified recipient."""
+        return await self._client.reply_to_targeted_activity(
+            self._conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
+
     async def delete(
         self,
         activity_id: str,
@@ -331,6 +348,27 @@ class ConversationClient(BaseClient):
         if scoped_client is not self:
             return await scoped_client.reply_to_activity(conversation_id, activity_id, activity)
         return await self._activities_client.reply(
+            conversation_id,
+            activity_id,
+            activity,
+            service_url=service_url,
+            agentic_identity=agentic_identity,
+        )
+
+    async def reply_to_targeted_activity(
+        self,
+        conversation_id: str,
+        activity_id: str,
+        activity: ActivityParams,
+        *,
+        service_url: str | None = None,
+        agentic_identity: AgenticIdentity | None = None,
+    ) -> SentActivity:
+        """Reply with a targeted activity visible only to the specified recipient."""
+        scoped_client = self._scoped_client(service_url, agentic_identity)
+        if scoped_client is not self:
+            return await scoped_client.reply_to_targeted_activity(conversation_id, activity_id, activity)
+        return await self._activities_client.reply_targeted(
             conversation_id,
             activity_id,
             activity,

--- a/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
+++ b/packages/api/src/microsoft_teams/api/diagnostics/_constants.py
@@ -36,6 +36,7 @@ class _ApiOutboundOperations:
     delete: str = "delete"
     delete_targeted: str = "delete_targeted"
     reply: str = "reply"
+    reply_targeted: str = "reply_targeted"
     update: str = "update"
     update_targeted: str = "update_targeted"
 

--- a/packages/api/src/microsoft_teams/api/models/channel_data/__init__.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/__init__.py
@@ -11,6 +11,7 @@ from .notification_info import NotificationInfo
 from .settings import ChannelDataSettings
 from .team_info import TeamInfo
 from .tenant_info import TenantInfo
+from .thread_info import ThreadInfo
 
 __all__ = [
     "ChannelInfo",
@@ -21,4 +22,5 @@ __all__ = [
     "TenantInfo",
     "ChannelData",
     "FeedbackLoop",
+    "ThreadInfo",
 ]

--- a/packages/api/src/microsoft_teams/api/models/channel_data/channel_data.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/channel_data.py
@@ -16,6 +16,7 @@ from .notification_info import NotificationInfo
 from .settings import ChannelDataSettings
 from .team_info import TeamInfo
 from .tenant_info import TenantInfo
+from .thread_info import ThreadInfo
 
 
 class ChannelData(CustomBaseModel):
@@ -46,6 +47,9 @@ class ChannelData(CustomBaseModel):
 
     settings: Optional[ChannelDataSettings] = None
     "Information about the settings in which the message was sent."
+
+    thread: Optional[ThreadInfo] = None
+    "Read-only thread metadata supplied by Teams on inbound activities."
 
     feedback_loop_enabled: Optional[bool] = None
     """

--- a/packages/api/src/microsoft_teams/api/models/channel_data/thread_info.py
+++ b/packages/api/src/microsoft_teams/api/models/channel_data/thread_info.py
@@ -1,0 +1,17 @@
+"""
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+"""
+
+from typing import Optional
+
+from pydantic import Field
+
+from ..custom_base_model import CustomBaseModel
+
+
+class ThreadInfo(CustomBaseModel):
+    """Thread metadata supplied by Teams on inbound activities."""
+
+    id: Optional[str] = Field(default=None, frozen=True)
+    """ID of the root message that identifies the current thread."""

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -1314,6 +1314,21 @@ class TestConversationClientFlattened:
         assert payload["entities"][0]["type"] == "quotedReply"
         assert '<quoted messageId="quoted-1"/>' in payload["text"]
 
+    @pytest.mark.parametrize("method_name", ["reply_to_activity", "reply_to_targeted_activity"])
+    async def test_reply_accepts_response_without_activity_id(self, method_name, mock_activity):
+        """APX may acknowledge a reply without returning its activity ID."""
+        http_client = Client(ClientOptions(base_url="https://test.service.url"))
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={}, headers={"content-type": "application/json"})
+
+        http_client.http._transport = httpx.MockTransport(handler)
+        client = ConversationClient("https://test.service.url", http_client)
+
+        result = await getattr(client, method_name)("conv-1", "act-1", mock_activity)
+
+        assert result.id == "DO_NOT_USE_PLACEHOLDER_ID"
+
     async def test_delete_activity(self, request_capture):
         """delete_activity should DELETE an activity."""
         client = ConversationClient("https://test.service.url", request_capture)

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -515,7 +515,7 @@ class TestConversationActivityOperations:
         )
         assert (
             str(request_capture._capture.last_request.url)
-            == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
         )
         assert "authorization" in request_capture._capture.last_request.headers
 
@@ -564,7 +564,7 @@ class TestConversationActivityOperations:
         await activities.reply("activity-id", mock_activity, service_url=service_url)
         assert (
             str(request_capture._capture.last_request.url)
-            == "https://override.service.url/v3/conversations/test_conversation_id/activities"
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
         )
 
         await activities.delete("activity-id", service_url=service_url)
@@ -931,11 +931,14 @@ class TestConversationActivityOperations:
         # Validate request details
         last_request = request_capture._capture.last_request
         assert last_request.method == "POST"
-        assert str(last_request.url) == f"https://test.service.url/v3/conversations/{conversation_id}/activities"
+        assert (
+            str(last_request.url)
+            == f"https://test.service.url/v3/conversations/{conversation_id}/activities/{activity_id}"
+        )
 
-        # Validate request payload - check that replyToId was added
+        # Placement is represented by the endpoint, not quote metadata in the payload.
         payload = json.loads(last_request.content)
-        assert payload["replyToId"] == activity_id
+        assert "replyToId" not in payload
 
     async def test_activity_delete(self, request_capture):
         """Test deleting an activity."""
@@ -1263,7 +1266,7 @@ class TestConversationClientFlattened:
         assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
 
     async def test_reply_to_activity(self, request_capture, mock_activity):
-        """reply_to_activity should POST a reply with replyToId set."""
+        """reply_to_activity should POST through the reply endpoint."""
         client = ConversationClient("https://test.service.url", request_capture)
 
         result = await client.reply_to_activity("conv-1", "act-1", mock_activity)
@@ -1271,9 +1274,9 @@ class TestConversationClientFlattened:
         assert result is not None
         last_request = request_capture._capture.last_request
         assert last_request.method == "POST"
-        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities"
+        assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
         payload = json.loads(last_request.content)
-        assert payload["replyToId"] == "act-1"
+        assert "replyToId" not in payload
 
     async def test_delete_activity(self, request_capture):
         """delete_activity should DELETE an activity."""

--- a/packages/api/tests/unit/test_conversation_client.py
+++ b/packages/api/tests/unit/test_conversation_client.py
@@ -16,7 +16,13 @@ from microsoft_teams.api.clients import ApiClient
 from microsoft_teams.api.clients.conversation import ConversationClient
 from microsoft_teams.api.clients.conversation.params import CreateConversationParams
 from microsoft_teams.api.diagnostics._outbound import ApiOutboundTelemetryMetadata
-from microsoft_teams.api.models import AgenticIdentity, ConversationResource, PagedMembersResult, TeamsChannelAccount
+from microsoft_teams.api.models import (
+    Account,
+    AgenticIdentity,
+    ConversationResource,
+    PagedMembersResult,
+    TeamsChannelAccount,
+)
 from microsoft_teams.common.http import Client, ClientOptions
 from opentelemetry.trace import Span, SpanKind
 
@@ -567,6 +573,13 @@ class TestConversationActivityOperations:
             == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
         )
 
+        await activities.reply_targeted("activity-id", mock_activity, service_url=service_url)
+        assert (
+            str(request_capture._capture.last_request.url)
+            == "https://override.service.url/v3/conversations/test_conversation_id/activities/activity-id"
+            "?isTargetedActivity=true"
+        )
+
         await activities.delete("activity-id", service_url=service_url)
         assert (
             str(request_capture._capture.last_request.url)
@@ -877,11 +890,13 @@ class TestConversationActivityOperations:
 
         with patch("microsoft_teams.api.diagnostics._outbound.record_outbound_call") as record_outbound_call:
             await client.create_targeted_activity("conv-1", mock_activity)
+            await client.reply_to_targeted_activity("conv-1", "root-1", mock_activity)
             await client.update_targeted_activity("conv-1", "act-1", mock_activity)
             await client.delete_targeted_activity("conv-1", "act-1")
 
         assert record_outbound_call.call_args_list == [
             call("create_targeted"),
+            call("reply_targeted"),
             call("update_targeted"),
             call("delete_targeted"),
         ]
@@ -1277,6 +1292,27 @@ class TestConversationClientFlattened:
         assert str(last_request.url) == "https://test.service.url/v3/conversations/conv-1/activities/act-1"
         payload = json.loads(last_request.content)
         assert "replyToId" not in payload
+
+    async def test_reply_to_targeted_activity(self, request_capture, mock_activity):
+        """reply_to_targeted_activity should POST through the targeted reply endpoint."""
+        client = ConversationClient("https://test.service.url", request_capture)
+        mock_activity.add_quote("quoted-1", "Private reply")
+        mock_activity.recipient = Account(id="user-1", is_targeted=True)
+
+        result = await client.reply_to_targeted_activity("conv-1", "act-1", mock_activity)
+
+        assert result is not None
+        last_request = request_capture._capture.last_request
+        assert last_request.method == "POST"
+        assert (
+            str(last_request.url)
+            == "https://test.service.url/v3/conversations/conv-1/activities/act-1?isTargetedActivity=true"
+        )
+        payload = json.loads(last_request.content)
+        assert "replyToId" not in payload
+        assert payload["recipient"]["isTargeted"] is True
+        assert payload["entities"][0]["type"] == "quotedReply"
+        assert '<quoted messageId="quoted-1"/>' in payload["text"]
 
     async def test_delete_activity(self, request_capture):
         """delete_activity should DELETE an activity."""

--- a/packages/api/tests/unit/test_empty_inbound_objects.py
+++ b/packages/api/tests/unit/test_empty_inbound_objects.py
@@ -8,6 +8,8 @@ from typing import Any, Dict
 
 import pytest
 from microsoft_teams.api.activities import ActivityTypeAdapter
+from microsoft_teams.api.models.channel_data import ThreadInfo
+from pydantic import ValidationError
 
 
 def _activity(**overrides: Any) -> Dict[str, Any]:
@@ -90,3 +92,13 @@ def test_populated_channel_data_is_preserved() -> None:
 def test_absent_channel_data_still_parses() -> None:
     """The pre-existing behaviour for a wholly absent channelData must be unchanged."""
     assert ActivityTypeAdapter.validate_python(_activity()).channel_data is None
+
+
+def test_inbound_thread_metadata_is_typed_and_read_only() -> None:
+    activity = ActivityTypeAdapter.validate_python(_activity(channelData={"thread": {"id": "root-id"}}))
+
+    assert activity.channel_data is not None
+    assert isinstance(activity.channel_data.thread, ThreadInfo)
+    assert activity.channel_data.thread.id == "root-id"
+    with pytest.raises(ValidationError):
+        activity.channel_data.thread.id = "different-root"

--- a/packages/apps/src/microsoft_teams/apps/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/__init__.py
@@ -32,7 +32,7 @@ from .utils.html_widget import (
     try_get_widget_model_context,
     validate_security_policy,
 )
-from .utils.thread import to_threaded_conversation_id
+from .utils.thread import to_threaded_conversation_id  # pyright: ignore[reportDeprecated]
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/packages/apps/src/microsoft_teams/apps/activity_send.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_send.py
@@ -51,7 +51,13 @@ async def send_or_update_activity(
         res = await scoped_api.conversations.update_activity(ref.conversation.id, activity_id, activity)
         return SentActivity.merge(activity, res)
 
-    if is_targeted:
+    if is_targeted and thread_root_id is not None:
+        res = await scoped_api.conversations.reply_to_targeted_activity(
+            ref.conversation.id,
+            thread_root_id,
+            activity,
+        )
+    elif is_targeted:
         res = await scoped_api.conversations.create_targeted_activity(ref.conversation.id, activity)
     elif thread_root_id is not None:
         res = await scoped_api.conversations.reply_to_activity(ref.conversation.id, thread_root_id, activity)

--- a/packages/apps/src/microsoft_teams/apps/activity_send.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_send.py
@@ -19,6 +19,7 @@ async def send_or_update_activity(
     ref: ConversationReference,
     *,
     agentic_identity: AgenticIdentity | None = None,
+    thread_root_id: str | None = None,
 ) -> SentActivity:
     """Send or update an activity using the same routing rules as the removed ActivitySender."""
     is_targeted = (
@@ -52,6 +53,8 @@ async def send_or_update_activity(
 
     if is_targeted:
         res = await scoped_api.conversations.create_targeted_activity(ref.conversation.id, activity)
+    elif thread_root_id is not None:
+        res = await scoped_api.conversations.reply_to_activity(ref.conversation.id, thread_root_id, activity)
     else:
         res = await scoped_api.conversations.create_activity(ref.conversation.id, activity)
     return SentActivity.merge(activity, res)

--- a/packages/apps/src/microsoft_teams/apps/activity_send.py
+++ b/packages/apps/src/microsoft_teams/apps/activity_send.py
@@ -31,8 +31,6 @@ async def send_or_update_activity(
     if is_targeted and ref.conversation.conversation_type == "personal":
         raise ValueError("Targeted messages are not supported in 1:1 (personal) chats.")
 
-    activity.from_ = ref.bot
-    activity.conversation = ref.conversation
     scoped_api = (
         api
         if agentic_identity is None and ref.service_url.rstrip("/") == api.service_url

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -65,7 +65,7 @@ from .state import create_state_loader
 from .token_manager import DEFAULT_TENANT_FOR_GRAPH_TOKEN, TokenManager
 from .token_provider import AppTokenProvider
 from .utils import create_graph_client
-from .utils.thread import to_threaded_conversation_id
+from .utils.thread import parse_threaded_conversation_id
 
 version = importlib.metadata.version("microsoft-teams-apps")
 
@@ -317,9 +317,8 @@ class App(ActivityHandlerMixin):
     ) -> SentActivity:
         """Send an activity proactively to a conversation.
 
-        Sends to the exact conversation ID provided. For channel threads,
-        the conversation ID must include ``;messageid=`` - use :func:`to_threaded_conversation_id`
-        to construct it, or use :meth:`reply` which handles this automatically.
+        Legacy conversation IDs ending in ``;messageid={root_id}`` are accepted for
+        compatibility and translated to the Bot Framework reply endpoint.
         """
 
         if not self._initialized:
@@ -328,11 +327,12 @@ class App(ActivityHandlerMixin):
         if self.id is None:
             raise ValueError("app credentials not configured")
 
+        base_conversation_id, thread_root_id = parse_threaded_conversation_id(conversation_id)
         conversation_ref = ConversationReference(
             channel_id="msteams",
             service_url=service_url or self.api.service_url,
             bot=Account(id=self.id),
-            conversation=ConversationAccount(id=conversation_id),
+            conversation=ConversationAccount(id=base_conversation_id),
         )
 
         if isinstance(activity, str):
@@ -347,6 +347,7 @@ class App(ActivityHandlerMixin):
             activity,
             conversation_ref,
             agentic_identity=agentic_identity,
+            thread_root_id=thread_root_id,
         )
 
     def get_agentic_identity(
@@ -409,13 +410,12 @@ class App(ActivityHandlerMixin):
         """Send an activity proactively to a conversation, optionally as a threaded reply.
 
         **3-arg form** ``reply(conversation_id, message_id, activity)``:
-        Constructs a threaded conversation ID via :func:`to_threaded_conversation_id`
-        and sends to that thread. The service determines whether threading is
-        supported for the given conversation type.
+        Sends through the Bot Framework reply endpoint using ``message_id`` as the
+        thread root.
 
         **2-arg form** ``reply(conversation_id, activity)``:
-        Sends to the exact conversation ID provided - threaded if it contains
-        ``;messageid=``, flat otherwise.
+        Sends to the conversation ID provided. A valid legacy ``;messageid=`` suffix
+        is translated to the reply endpoint.
 
         Args:
             conversation_id: The conversation ID
@@ -425,8 +425,11 @@ class App(ActivityHandlerMixin):
         if activity is not None:
             if not isinstance(message_id, str):
                 raise TypeError("message_id must be a string when activity is provided")
-            return await self.send(
-                to_threaded_conversation_id(conversation_id, message_id),
+            if not message_id or not message_id.isdigit() or message_id == "0":
+                raise ValueError(f'Invalid message_id "{message_id}": must be a non-zero numeric value')
+            return await self._send_to_thread(
+                conversation_id,
+                message_id,
                 activity,
                 service_url=service_url,
                 agentic_identity=agentic_identity,
@@ -437,6 +440,41 @@ class App(ActivityHandlerMixin):
             message_id,
             service_url=service_url,
             agentic_identity=agentic_identity,
+        )
+
+    async def _send_to_thread(
+        self,
+        conversation_id: str,
+        thread_root_id: str,
+        activity: str | ActivityParams | AdaptiveCard,
+        *,
+        service_url: Optional[str] = None,
+        agentic_identity: Optional[AgenticIdentity] = None,
+    ) -> SentActivity:
+        if not self._initialized:
+            raise ValueError("app not initialized - call app.initialize() or app.start() first")
+        if self.id is None:
+            raise ValueError("app credentials not configured")
+
+        base_conversation_id, _ = parse_threaded_conversation_id(conversation_id)
+        conversation_ref = ConversationReference(
+            channel_id="msteams",
+            service_url=service_url or self.api.service_url,
+            bot=Account(id=self.id),
+            conversation=ConversationAccount(id=base_conversation_id),
+        )
+        if isinstance(activity, str):
+            outbound = MessageActivityInput(text=activity)
+        elif isinstance(activity, AdaptiveCard):
+            outbound = MessageActivityInput().add_card(activity)
+        else:
+            outbound = activity
+        return await send_or_update_activity(
+            self.api,
+            outbound,
+            conversation_ref,
+            agentic_identity=agentic_identity,
+            thread_root_id=thread_root_id,
         )
 
     def use(self, middleware: Callable[[ActivityContext[ActivityBase]], Awaitable[None]]) -> None:

--- a/packages/apps/src/microsoft_teams/apps/app.py
+++ b/packages/apps/src/microsoft_teams/apps/app.py
@@ -7,6 +7,7 @@ import asyncio
 import importlib.metadata
 import logging
 import os
+import warnings
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, List, Optional, TypeVar, Union, Unpack, cast, overload
 
 from dependency_injector import providers
@@ -32,6 +33,7 @@ from microsoft_teams.api.auth.cloud_environment import PUBLIC
 from microsoft_teams.api.auth.cloud_environment import from_name as cloud_from_name
 from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Client, ClientOptions, EventEmitter, LocalStorage
+from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from msgraph.graph_service_client import GraphServiceClient
@@ -389,6 +391,10 @@ class App(ActivityHandlerMixin):
     ) -> SentActivity: ...
 
     @overload
+    @deprecated(
+        "The two-argument App.reply(conversation_id, activity) form is deprecated. "
+        "Use App.send(conversation_id, activity) instead."
+    )
     async def reply(
         self,
         conversation_id: str,
@@ -415,7 +421,7 @@ class App(ActivityHandlerMixin):
 
         **2-arg form** ``reply(conversation_id, activity)``:
         Sends to the conversation ID provided. A valid legacy ``;messageid=`` suffix
-        is translated to the reply endpoint.
+        is translated to the reply endpoint. Deprecated; use :meth:`send` instead.
 
         Args:
             conversation_id: The conversation ID
@@ -435,6 +441,12 @@ class App(ActivityHandlerMixin):
                 agentic_identity=agentic_identity,
             )
 
+        warnings.warn(
+            "The two-argument App.reply(conversation_id, activity) form is deprecated. "
+            "Use App.send(conversation_id, activity) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return await self.send(
             conversation_id,
             message_id,

--- a/packages/apps/src/microsoft_teams/apps/app_process.py
+++ b/packages/apps/src/microsoft_teams/apps/app_process.py
@@ -175,7 +175,10 @@ class ActivityProcessor:
             message: str | ActivityParams | AdaptiveCard,
             conversation_ref: Optional[ConversationReference] = None,
         ) -> SentActivity:
-            res = await send(message, conversation_ref)
+            if conversation_ref is None:
+                res = await send(message)
+            else:
+                res = await send(message, conversation_ref)  # pyright: ignore[reportDeprecated]
 
             if not self.event_manager:
                 raise ValueError("EventManager was not initialized properly")

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -66,6 +66,7 @@ from ..oauth_state import (
 from ..plugins.streamer import StreamerProtocol
 from ..state import TurnStateContainer
 from ..utils import create_graph_client
+from ..utils.thread import parse_threaded_conversation_id
 
 if TYPE_CHECKING:
     from msgraph.graph_service_client import GraphServiceClient
@@ -257,11 +258,20 @@ class ActivityContext(Generic[T]):
         self._add_targeted_message_info_entity(activity)
 
         ref = conversation_ref or self.conversation_ref
+        thread_root_id = None if conversation_ref is not None else self._current_thread_root_id()
+        base_conversation_id, legacy_thread_root_id = parse_threaded_conversation_id(ref.conversation.id)
+        if legacy_thread_root_id is not None:
+            ref = ref.model_copy(
+                update={"conversation": ref.conversation.model_copy(update={"id": base_conversation_id})}
+            )
+            if conversation_ref is not None or self.activity.conversation.conversation_type != "personal":
+                thread_root_id = thread_root_id or legacy_thread_root_id
         return await send_or_update_activity(
             self.api,
             activity,
             ref,
             agentic_identity=self.activity.recipient.agentic_identity,
+            thread_root_id=thread_root_id,
         )
 
     async def reply(self, input: str | ActivityParams) -> SentActivity:
@@ -271,8 +281,14 @@ class ActivityContext(Generic[T]):
         In other scopes, sends with a quoted reply.
         To send without quoting, use :meth:`send`.
         """
+        warnings.warn(
+            "ActivityContext.reply() is deprecated because it combines thread placement and quoting. "
+            "Use send() for placement and MessageActivityInput.add_quote() for explicit quote metadata.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self.activity.id:
-            return await self.quote(self.activity.id, input)
+            return await self._send_quote(self.activity.id, input)
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         return await self.send(activity)
 
@@ -288,10 +304,38 @@ class ActivityContext(Generic[T]):
         Returns:
             The sent activity
         """
+        warnings.warn(
+            "ActivityContext.quote() is deprecated. Use MessageActivityInput.add_quote() and send() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await self._send_quote(message_id, input)
+
+    async def _send_quote(self, message_id: str, input: str | ActivityParams) -> SentActivity:
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         if isinstance(activity, MessageActivityInput):
             activity.prepend_quote(message_id)
         return await self.send(activity)
+
+    def _current_thread_root_id(self) -> str | None:
+        if not isinstance(self.activity, MessageActivity):
+            return None
+
+        conversation_type = self.activity.conversation.conversation_type
+        if conversation_type == "personal":
+            return None
+
+        channel_data = self.activity.channel_data
+        if channel_data is not None and channel_data.thread is not None and channel_data.thread.id:
+            return channel_data.thread.id
+
+        _, legacy_thread_root_id = parse_threaded_conversation_id(self.activity.conversation.id)
+        if legacy_thread_root_id is not None:
+            return legacy_thread_root_id
+
+        if conversation_type == "channel":
+            return self.activity.id
+        return None
 
     async def next(self) -> None:
         """Call the next middleware in the chain."""

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -19,6 +19,7 @@ from typing import (
     Sequence,
     TypeGuard,
     TypeVar,
+    overload,
 )
 
 from httpx import HTTPStatusError
@@ -53,6 +54,7 @@ from microsoft_teams.cards import AdaptiveCard
 from microsoft_teams.common import Storage
 from microsoft_teams.common.experimental import ExperimentalWarning
 from microsoft_teams.common.http.client_token import Token
+from typing_extensions import deprecated
 
 from ..activity_send import send_or_update_activity
 from ..files import FilesAccessor
@@ -230,6 +232,23 @@ class ActivityContext(Generic[T]):
 
         return self._app_graph
 
+    @overload
+    async def send(
+        self,
+        message: str | ActivityParams | AdaptiveCard,
+    ) -> SentActivity: ...
+
+    @overload
+    @deprecated(
+        "Passing conversation_ref to ActivityContext.send() is deprecated. "
+        "Use App.send() to send to another conversation."
+    )
+    async def send(
+        self,
+        message: str | ActivityParams | AdaptiveCard,
+        conversation_ref: ConversationReference,
+    ) -> SentActivity: ...
+
     async def send(
         self,
         message: str | ActivityParams | AdaptiveCard,
@@ -243,8 +262,17 @@ class ActivityContext(Generic[T]):
 
         Args:
             message: The message to send, can be a string, ActivityParams, or AdaptiveCard
-            conversation_ref: Optional conversation reference to send to a different conversation or thread
+            conversation_ref: Deprecated conversation reference for a different destination.
+                Use ``App.send()`` for proactive sends.
         """
+        if conversation_ref is not None:
+            warnings.warn(
+                "Passing conversation_ref to ActivityContext.send() is deprecated. "
+                "Use App.send() to send to another conversation.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         if isinstance(message, str):
             activity = MessageActivityInput(text=message)
         elif isinstance(message, AdaptiveCard):
@@ -272,6 +300,10 @@ class ActivityContext(Generic[T]):
             thread_root_id=thread_root_id,
         )
 
+    @deprecated(
+        "ActivityContext.reply() is deprecated because it combines thread placement and quoting. "
+        "Use send() for placement and MessageActivityInput.add_quote() for explicit quote metadata."
+    )
     async def reply(self, input: str | ActivityParams) -> SentActivity:
         """Send a message in the current conversation with a visual quote of the inbound message.
 
@@ -279,17 +311,12 @@ class ActivityContext(Generic[T]):
         In other scopes, sends with a quoted reply.
         To send without quoting, use :meth:`send`.
         """
-        warnings.warn(
-            "ActivityContext.reply() is deprecated because it combines thread placement and quoting. "
-            "Use send() for placement and MessageActivityInput.add_quote() for explicit quote metadata.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if self.activity.id:
             return await self._send_quote(self.activity.id, input)
         activity = MessageActivityInput(text=input) if isinstance(input, str) else input
         return await self.send(activity)
 
+    @deprecated("ActivityContext.quote() is deprecated. Use MessageActivityInput.add_quote() and send() instead.")
     async def quote(self, message_id: str, input: str | ActivityParams) -> SentActivity:
         """
         Send a message to the conversation with a quoted message reference prepended to the text.
@@ -302,11 +329,6 @@ class ActivityContext(Generic[T]):
         Returns:
             The sent activity
         """
-        warnings.warn(
-            "ActivityContext.quote() is deprecated. Use MessageActivityInput.add_quote() and send() instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return await self._send_quote(message_id, input)
 
     async def _send_quote(self, message_id: str, input: str | ActivityParams) -> SentActivity:
@@ -515,7 +537,7 @@ class ActivityContext(Generic[T]):
             )
             if self.state is not None:
                 await self.state._save()  # pyright: ignore[reportPrivateUsage]
-            await self.send(payload, self.conversation_ref)
+            await self.send(payload)
         except Exception:
             # Best-effort rollback: the card never went out, so the pending hint must not
             # linger and mis-route a later callback. A failure here must not replace the

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -74,7 +74,7 @@ from ..oauth_state import (
 from ..plugins.streamer import StreamerProtocol
 from ..state import TurnStateContainer
 from ..utils import create_graph_client
-from ..utils.thread import parse_threaded_conversation_id
+from ..utils.thread import get_default_thread_id, parse_threaded_conversation_id
 
 if TYPE_CHECKING:
     from msgraph.graph_service_client import GraphServiceClient
@@ -346,18 +346,7 @@ class ActivityContext(Generic[T]):
     def _current_thread_root_id(self) -> str | None:
         if not isinstance(self.activity, MessageActivity):
             return None
-
-        channel_data = self.activity.channel_data
-        if channel_data is not None and channel_data.thread is not None and channel_data.thread.id:
-            return channel_data.thread.id
-
-        _, legacy_thread_root_id = parse_threaded_conversation_id(self.activity.conversation.id)
-        if legacy_thread_root_id is not None:
-            return legacy_thread_root_id
-
-        if self.activity.conversation.conversation_type == "channel":
-            return self.activity.id
-        return None
+        return get_default_thread_id(self.activity)
 
     async def next(self) -> None:
         """Call the next middleware in the chain."""

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -237,8 +237,8 @@ class ActivityContext(Generic[T]):
     ) -> SentActivity:
         """Send a message in the current conversation without quoting.
 
-        In channels, sends to the current thread. In scopes that do not
-        support threading (group chat, meetings), sends as a normal message.
+        In group chats and channels, sends to the current thread when the
+        inbound activity identifies one. In personal chats, sends normally.
         To send with a visual quote of the inbound message, use :meth:`reply`.
 
         Args:
@@ -258,14 +258,12 @@ class ActivityContext(Generic[T]):
         self._add_targeted_message_info_entity(activity)
 
         ref = conversation_ref or self.conversation_ref
-        thread_root_id = None if conversation_ref is not None else self._current_thread_root_id()
         base_conversation_id, legacy_thread_root_id = parse_threaded_conversation_id(ref.conversation.id)
         if legacy_thread_root_id is not None:
             ref = ref.model_copy(
                 update={"conversation": ref.conversation.model_copy(update={"id": base_conversation_id})}
             )
-            if conversation_ref is not None or self.activity.conversation.conversation_type != "personal":
-                thread_root_id = thread_root_id or legacy_thread_root_id
+        thread_root_id = legacy_thread_root_id if conversation_ref is not None else self._current_thread_root_id()
         return await send_or_update_activity(
             self.api,
             activity,

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -341,10 +341,6 @@ class ActivityContext(Generic[T]):
         if not isinstance(self.activity, MessageActivity):
             return None
 
-        conversation_type = self.activity.conversation.conversation_type
-        if conversation_type == "personal":
-            return None
-
         channel_data = self.activity.channel_data
         if channel_data is not None and channel_data.thread is not None and channel_data.thread.id:
             return channel_data.thread.id
@@ -353,7 +349,7 @@ class ActivityContext(Generic[T]):
         if legacy_thread_root_id is not None:
             return legacy_thread_root_id
 
-        if conversation_type == "channel":
+        if self.activity.conversation.conversation_type == "channel":
             return self.activity.id
         return None
 

--- a/packages/apps/src/microsoft_teams/apps/utils/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/__init__.py
@@ -6,6 +6,18 @@ Licensed under the MIT License.
 from .activity_utils import extract_tenant_id
 from .graph import create_graph_client
 from .retry import RetryOptions, retry
-from .thread import to_threaded_conversation_id  # pyright: ignore[reportDeprecated]
+from .thread import (
+    get_default_thread_id,
+    get_proactive_thread_reference,
+    to_threaded_conversation_id,  # pyright: ignore[reportDeprecated]
+)
 
-__all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions", "to_threaded_conversation_id"]
+__all__ = [
+    "create_graph_client",
+    "extract_tenant_id",
+    "get_default_thread_id",
+    "get_proactive_thread_reference",
+    "retry",
+    "RetryOptions",
+    "to_threaded_conversation_id",
+]

--- a/packages/apps/src/microsoft_teams/apps/utils/__init__.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/__init__.py
@@ -6,6 +6,6 @@ Licensed under the MIT License.
 from .activity_utils import extract_tenant_id
 from .graph import create_graph_client
 from .retry import RetryOptions, retry
-from .thread import to_threaded_conversation_id
+from .thread import to_threaded_conversation_id  # pyright: ignore[reportDeprecated]
 
 __all__ = ["create_graph_client", "extract_tenant_id", "retry", "RetryOptions", "to_threaded_conversation_id"]

--- a/packages/apps/src/microsoft_teams/apps/utils/thread.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/thread.py
@@ -3,7 +3,17 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
+import re
 
+from typing_extensions import deprecated
+
+_LEGACY_THREADED_CONVERSATION_ID = re.compile(r"^(?P<conversation_id>.+);messageid=(?P<message_id>\d+)$")
+
+
+@deprecated(
+    "to_threaded_conversation_id is deprecated. Use App.reply(conversation_id, message_id, activity) "
+    "to place a message in a thread."
+)
 def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
     """Construct a threaded conversation ID by appending `;messageid={message_id}`
     to the conversation ID. This is the format the service uses to route messages
@@ -25,3 +35,11 @@ def to_threaded_conversation_id(conversation_id: str, message_id: str) -> str:
     # Strip any existing ;messageid= suffix (mirrors the service's conversation-ID normalization)
     base_id = conversation_id.split(";")[0]
     return f"{base_id};messageid={message_id}"
+
+
+def parse_threaded_conversation_id(conversation_id: str) -> tuple[str, str | None]:
+    """Split a valid legacy threaded conversation ID into its base ID and thread root."""
+    match = _LEGACY_THREADED_CONVERSATION_ID.fullmatch(conversation_id)
+    if match is None or match.group("message_id") == "0":
+        return conversation_id, None
+    return match.group("conversation_id"), match.group("message_id")

--- a/packages/apps/src/microsoft_teams/apps/utils/thread.py
+++ b/packages/apps/src/microsoft_teams/apps/utils/thread.py
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 import re
 
+from microsoft_teams.api import MessageActivity
 from typing_extensions import deprecated
 
 _LEGACY_THREADED_CONVERSATION_ID = re.compile(r"^(?P<conversation_id>.+);messageid=(?P<message_id>\d+)$")
@@ -43,3 +44,30 @@ def parse_threaded_conversation_id(conversation_id: str) -> tuple[str, str | Non
     if match is None or match.group("message_id") == "0":
         return conversation_id, None
     return match.group("conversation_id"), match.group("message_id")
+
+
+def get_proactive_thread_reference(activity: MessageActivity) -> tuple[str, str]:
+    """Resolve the base conversation ID and thread root for an inbound message.
+
+    Thread metadata takes precedence over the legacy conversation-ID suffix. For a
+    root message, the inbound activity ID is the thread root.
+    """
+    conversation_id, legacy_thread_root_id = parse_threaded_conversation_id(activity.conversation.id)
+    thread = activity.channel_data.thread if activity.channel_data else None
+    thread_root_id = thread.id if thread and thread.id else legacy_thread_root_id or activity.id
+    return conversation_id, thread_root_id
+
+
+def get_default_thread_id(activity: MessageActivity) -> str | None:
+    """Resolve the thread root for a reactive send in the inbound scope."""
+    thread = activity.channel_data.thread if activity.channel_data else None
+    if thread and thread.id:
+        return thread.id
+
+    _, legacy_thread_root_id = parse_threaded_conversation_id(activity.conversation.id)
+    if legacy_thread_root_id:
+        return legacy_thread_root_id
+
+    if activity.conversation.conversation_type == "channel":
+        return activity.id
+    return None

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -65,6 +65,12 @@ def _create_activity_context(
             activity_params=MessageActivityInput(text="reply"),
         )
     )
+    activities.reply_targeted = AsyncMock(
+        return_value=SentActivity(
+            id="targeted-reply-activity-id",
+            activity_params=MessageActivityInput(text="targeted reply"),
+        )
+    )
     activities.create_targeted = AsyncMock(
         return_value=SentActivity(
             id="targeted-activity-id",
@@ -93,6 +99,10 @@ def _create_activity_context(
         api.conversations.activities(conversation_id)
         return await activities.reply(activity_id, activity)
 
+    async def reply_to_targeted_activity(conversation_id: str, activity_id: str, activity: Any) -> SentActivity:
+        api.conversations.activities(conversation_id)
+        return await activities.reply_targeted(activity_id, activity)
+
     async def create_targeted_activity(conversation_id: str, activity: Any) -> SentActivity:
         api.conversations.activities(conversation_id)
         return await activities.create_targeted(activity)
@@ -104,6 +114,7 @@ def _create_activity_context(
     api.conversations.create_activity = AsyncMock(side_effect=create_activity)
     api.conversations.update_activity = AsyncMock(side_effect=update_activity)
     api.conversations.reply_to_activity = AsyncMock(side_effect=reply_to_activity)
+    api.conversations.reply_to_targeted_activity = AsyncMock(side_effect=reply_to_targeted_activity)
     api.conversations.create_targeted_activity = AsyncMock(side_effect=create_targeted_activity)
     api.conversations.update_targeted_activity = AsyncMock(side_effect=update_targeted_activity)
 
@@ -449,6 +460,28 @@ class TestActivityContextThreadPlacement:
 
         ctx.api.conversations.reply_to_activity.assert_awaited_once()
         assert ctx.api.conversations.reply_to_activity.call_args.args[:2] == ("conversation-id", "group-root")
+
+    @pytest.mark.asyncio
+    async def test_group_chat_targeted_send_uses_targeted_reply_endpoint(self) -> None:
+        ctx = self._context("groupChat", thread_id="group-root")
+        recipient = Account(id="user-id", name="Test User")
+        outbound = (
+            MessageActivityInput()
+            .add_quote("quoted-message-id", "Private response")
+            .with_recipient(recipient, is_targeted=True)
+        )
+
+        await ctx.send(outbound)
+
+        ctx.api.conversations.reply_to_targeted_activity.assert_awaited_once_with(
+            "conversation-id",
+            "group-root",
+            outbound,
+        )
+        assert any(getattr(entity, "type", None) == "quotedReply" for entity in outbound.entities or [])
+        assert '<quoted messageId="quoted-message-id"/>' in (outbound.text or "")
+        ctx.api.conversations.create_targeted_activity.assert_not_awaited()
+        ctx.api.conversations.reply_to_activity.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_channel_send_uses_inbound_thread_metadata(self) -> None:

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -442,16 +442,6 @@ class TestActivityContextThreadPlacement:
         ctx.api.conversations.reply_to_activity.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_personal_legacy_suffix_stays_l1(self) -> None:
-        ctx = self._context("personal", conversation_id="conversation-id;messageid=789")
-
-        await ctx.send("Response")
-
-        ctx.api.conversations.create_activity.assert_awaited_once()
-        assert ctx.api.conversations.create_activity.call_args.args[0] == "conversation-id"
-        ctx.api.conversations.reply_to_activity.assert_not_awaited()
-
-    @pytest.mark.asyncio
     async def test_group_chat_l2_send_stays_in_same_thread(self) -> None:
         ctx = self._context("groupChat", thread_id="group-root")
 

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -14,12 +14,14 @@ import pytest
 from httpx import ConnectError, HTTPStatusError, Request, Response
 from microsoft_teams.api import (
     Account,
+    ChannelData,
     ConversationAccount,
     ConversationReference,
     MessageActivity,
     MessageActivityInput,
     SentActivity,
     TargetedMessageInfoEntity,
+    ThreadInfo,
     TokenExchangeResource,
     TokenStatus,
 )
@@ -57,6 +59,12 @@ def _create_activity_context(
             activity_params=MessageActivityInput(text="updated"),
         )
     )
+    activities.reply = AsyncMock(
+        return_value=SentActivity(
+            id="reply-activity-id",
+            activity_params=MessageActivityInput(text="reply"),
+        )
+    )
     activities.create_targeted = AsyncMock(
         return_value=SentActivity(
             id="targeted-activity-id",
@@ -81,6 +89,10 @@ def _create_activity_context(
         api.conversations.activities(conversation_id)
         return await activities.update(activity_id, activity)
 
+    async def reply_to_activity(conversation_id: str, activity_id: str, activity: Any) -> SentActivity:
+        api.conversations.activities(conversation_id)
+        return await activities.reply(activity_id, activity)
+
     async def create_targeted_activity(conversation_id: str, activity: Any) -> SentActivity:
         api.conversations.activities(conversation_id)
         return await activities.create_targeted(activity)
@@ -91,6 +103,7 @@ def _create_activity_context(
 
     api.conversations.create_activity = AsyncMock(side_effect=create_activity)
     api.conversations.update_activity = AsyncMock(side_effect=update_activity)
+    api.conversations.reply_to_activity = AsyncMock(side_effect=reply_to_activity)
     api.conversations.create_targeted_activity = AsyncMock(side_effect=create_targeted_activity)
     api.conversations.update_targeted_activity = AsyncMock(side_effect=update_targeted_activity)
 
@@ -394,6 +407,84 @@ class TestActivityContextSendTargeted:
 
         # Verify recipient was NOT set for non-targeted messages
         assert sent_activity.recipient is None
+
+
+class TestActivityContextThreadPlacement:
+    def _context(
+        self,
+        conversation_type: str,
+        *,
+        conversation_id: str = "conversation-id",
+        thread_id: str | None = None,
+        activity_id: str = "inbound-id",
+    ) -> ActivityContext[Any]:
+        activity = MessageActivity(
+            id=activity_id,
+            text="Incoming",
+            from_=Account(id="user-id"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id=conversation_id, conversation_type=conversation_type),
+            channel_data=ChannelData(thread=ThreadInfo(id=thread_id)) if thread_id else None,
+        )
+        ctx, _ = _create_activity_context(activity=activity)
+        ctx.conversation_ref.conversation = activity.conversation.model_copy()
+        return ctx
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("conversation_type", ["personal", "groupChat"])
+    async def test_l1_inbound_send_stays_l1(self, conversation_type: str) -> None:
+        ctx = self._context(conversation_type)
+
+        await ctx.send("Response")
+
+        ctx.api.conversations.create_activity.assert_awaited_once()
+        ctx.api.conversations.reply_to_activity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_personal_legacy_suffix_stays_l1(self) -> None:
+        ctx = self._context("personal", conversation_id="conversation-id;messageid=789")
+
+        await ctx.send("Response")
+
+        ctx.api.conversations.create_activity.assert_awaited_once()
+        assert ctx.api.conversations.create_activity.call_args.args[0] == "conversation-id"
+        ctx.api.conversations.reply_to_activity.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_group_chat_l2_send_stays_in_same_thread(self) -> None:
+        ctx = self._context("groupChat", thread_id="group-root")
+
+        await ctx.send("Response")
+
+        ctx.api.conversations.reply_to_activity.assert_awaited_once()
+        assert ctx.api.conversations.reply_to_activity.call_args.args[:2] == ("conversation-id", "group-root")
+
+    @pytest.mark.asyncio
+    async def test_channel_send_uses_inbound_thread_metadata(self) -> None:
+        ctx = self._context("channel", thread_id="channel-root")
+
+        await ctx.send("Response")
+
+        ctx.api.conversations.reply_to_activity.assert_awaited_once()
+        assert ctx.api.conversations.reply_to_activity.call_args.args[:2] == ("conversation-id", "channel-root")
+
+    @pytest.mark.asyncio
+    async def test_channel_root_send_replies_to_inbound_root(self) -> None:
+        ctx = self._context("channel", activity_id="channel-root")
+
+        await ctx.send("Response")
+
+        ctx.api.conversations.reply_to_activity.assert_awaited_once()
+        assert ctx.api.conversations.reply_to_activity.call_args.args[:2] == ("conversation-id", "channel-root")
+
+    @pytest.mark.asyncio
+    async def test_legacy_thread_suffix_is_fallback_and_not_sent_to_service(self) -> None:
+        ctx = self._context("groupChat", conversation_id="conversation-id;messageid=789")
+
+        await ctx.send("Response")
+
+        ctx.api.conversations.reply_to_activity.assert_awaited_once()
+        assert ctx.api.conversations.reply_to_activity.call_args.args[:2] == ("conversation-id", "789")
 
 
 class TestActivityContextSend:

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -183,8 +183,8 @@ class TestActivityContextSendTargeted:
         sent_activity = ctx.api.conversations.activities.return_value.create_targeted.call_args.args[0]
         assert isinstance(sent_activity, MessageActivityInput)
         assert sent_activity.text == "Secret message"
-        assert sent_activity.from_ == ctx.conversation_ref.bot
-        assert sent_activity.conversation == ctx.conversation_ref.conversation
+        assert sent_activity.from_ is None
+        assert sent_activity.conversation is None
         assert sent_activity.recipient is not None
         assert sent_activity.recipient.id == incoming_sender.id
         assert sent_activity.recipient.name == incoming_sender.name

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -232,7 +232,8 @@ class TestActivityContextSendTargeted:
             service_url="https://service.example",
         )
 
-        await ctx.send("Cross-post", other_ref)
+        with pytest.warns(DeprecationWarning, match="conversation_ref"):
+            await ctx.send("Cross-post", other_ref)
 
         mock_sender.send.assert_called_once()
         sent_activity = mock_sender.send.call_args[0][0]

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -928,8 +928,8 @@ class TestApp:
         create.assert_not_called()
         assert result.id == "sent-activity-id"
         sent_activity = activities.create_targeted.call_args.args[0]
-        assert sent_activity.from_.id == "test-client-id"
-        assert sent_activity.conversation.id == "conv-123"
+        assert sent_activity.from_ is None
+        assert sent_activity.conversation is None
 
     @pytest.mark.asyncio
     async def test_send_passes_service_url_and_agentic_identity_to_scoped_api(self, mock_storage) -> None:
@@ -1158,6 +1158,8 @@ class TestAppReply:
         assert activity.recipient is not None
         assert activity.recipient.id == recipient.id
         assert activity.recipient.is_targeted is True
+        assert activity.from_ is None
+        assert activity.conversation is None
         assert any(getattr(entity, "type", None) == "quotedReply" for entity in activity.entities or [])
         assert '<quoted messageId="quoted-message-id"/>' in (activity.text or "")
         started_app.api.conversations.activities.return_value.reply.assert_not_awaited()
@@ -1244,7 +1246,7 @@ class TestAppReply:
         started_app.api.conversations.activities.return_value.reply.assert_awaited_once()
         root_id, activity = started_app.api.conversations.activities.return_value.reply.call_args.args
         assert root_id == "00456"
-        assert activity.conversation.id == "19:abc@thread.skype"
+        assert activity.conversation is None
 
     @pytest.mark.asyncio
     async def test_reply_with_invalid_message_id_raises(self, started_app):

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -1157,7 +1157,8 @@ class TestAppReply:
 
     @pytest.mark.asyncio
     async def test_reply_with_two_args_passes_conversation_id_as_is(self, started_app):
-        await started_app.reply("19:abc@thread.skype", "Hello flat")
+        with pytest.warns(DeprecationWarning, match="two-argument App.reply"):
+            await started_app.reply("19:abc@thread.skype", "Hello flat")
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
 
@@ -1171,12 +1172,13 @@ class TestAppReply:
         )
         service_url = "https://override.service.url"
 
-        await started_app.reply(
-            "19:abc@thread.skype",
-            "Hello flat",
-            service_url=service_url,
-            agentic_identity=agentic_identity,
-        )
+        with pytest.warns(DeprecationWarning, match="two-argument App.reply"):
+            await started_app.reply(
+                "19:abc@thread.skype",
+                "Hello flat",
+                service_url=service_url,
+                agentic_identity=agentic_identity,
+            )
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
         started_app.api.clone.assert_called_once_with(
@@ -1191,7 +1193,8 @@ class TestAppReply:
 
     @pytest.mark.asyncio
     async def test_reply_with_pre_constructed_threaded_id(self, started_app):
-        await started_app.reply("19:abc@thread.skype;messageid=123", "Hello")
+        with pytest.warns(DeprecationWarning, match="two-argument App.reply"):
+            await started_app.reply("19:abc@thread.skype;messageid=123", "Hello")
 
         started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
         started_app.api.conversations.activities.return_value.reply.assert_awaited_once()
@@ -1217,8 +1220,9 @@ class TestAppReply:
         options = AppOptions(client_id="test-client-id", client_secret="test-secret")
         app = App(**options)
 
-        with pytest.raises(ValueError, match="app not initialized"):
-            await app.reply("conv-id", "Hello")
+        with pytest.warns(DeprecationWarning, match="two-argument App.reply"):
+            with pytest.raises(ValueError, match="app not initialized"):
+                await app.reply("conv-id", "Hello")
 
 
 class TestMergeAppOptions:

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -93,6 +93,10 @@ def _wire_flat_activity_methods(api: Any, activities: MagicMock) -> None:
         api.conversations.activities(conversation_id)
         return await activities.reply(activity_id, activity)
 
+    async def reply_to_targeted_activity(conversation_id: str, activity_id: str, activity: Any) -> SentActivity:
+        api.conversations.activities(conversation_id)
+        return await activities.reply_targeted(activity_id, activity)
+
     async def create_targeted_activity(conversation_id: str, activity: Any) -> SentActivity:
         api.conversations.activities(conversation_id)
         return await activities.create_targeted(activity)
@@ -104,6 +108,7 @@ def _wire_flat_activity_methods(api: Any, activities: MagicMock) -> None:
     api.conversations.create_activity = AsyncMock(side_effect=create_activity)
     api.conversations.update_activity = AsyncMock(side_effect=update_activity)
     api.conversations.reply_to_activity = AsyncMock(side_effect=reply_to_activity)
+    api.conversations.reply_to_targeted_activity = AsyncMock(side_effect=reply_to_targeted_activity)
     api.conversations.create_targeted_activity = AsyncMock(side_effect=create_targeted_activity)
     api.conversations.update_targeted_activity = AsyncMock(side_effect=update_targeted_activity)
 
@@ -902,6 +907,9 @@ class TestApp:
         activities.reply = AsyncMock(
             return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
         )
+        activities.reply_targeted = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
         activities.create_targeted = AsyncMock(
             return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
         )
@@ -1044,6 +1052,9 @@ class TestAppInitialize:
         activities.reply = AsyncMock(
             return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
         )
+        activities.reply_targeted = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
         activities.update = AsyncMock(
             return_value=SentActivity(id="existing-msg-id", activity_params=MessageActivityInput(text="updated"))
         )
@@ -1108,6 +1119,9 @@ class TestAppReply:
         activities.reply = AsyncMock(
             return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
         )
+        activities.reply_targeted = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
         activities.update = AsyncMock(
             return_value=SentActivity(id="updated-activity-id", activity_params=MessageActivityInput(text="updated"))
         )
@@ -1125,6 +1139,28 @@ class TestAppReply:
         root_id, activity = started_app.api.conversations.activities.return_value.reply.call_args.args
         assert root_id == "1680000000000"
         assert activity.text == "Hello thread"
+
+    @pytest.mark.asyncio
+    async def test_reply_with_targeted_activity_uses_targeted_reply_endpoint(self, started_app):
+        recipient = Account(id="user-456", name="Test User")
+        outbound = (
+            MessageActivityInput()
+            .add_quote("quoted-message-id", "Private reply")
+            .with_recipient(recipient, is_targeted=True)
+        )
+
+        await started_app.reply("19:abc@thread.skype", "1680000000000", outbound)
+
+        targeted_reply = started_app.api.conversations.activities.return_value.reply_targeted
+        targeted_reply.assert_awaited_once()
+        root_id, activity = targeted_reply.call_args.args
+        assert root_id == "1680000000000"
+        assert activity.recipient is not None
+        assert activity.recipient.id == recipient.id
+        assert activity.recipient.is_targeted is True
+        assert any(getattr(entity, "type", None) == "quotedReply" for entity in activity.entities or [])
+        assert '<quoted messageId="quoted-message-id"/>' in (activity.text or "")
+        started_app.api.conversations.activities.return_value.reply.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_reply_with_three_args_passes_service_url_and_agentic_identity_to_scoped_api(self, started_app):

--- a/packages/apps/tests/test_app.py
+++ b/packages/apps/tests/test_app.py
@@ -89,6 +89,10 @@ def _wire_flat_activity_methods(api: Any, activities: MagicMock) -> None:
         api.conversations.activities(conversation_id)
         return await activities.update(activity_id, activity)
 
+    async def reply_to_activity(conversation_id: str, activity_id: str, activity: Any) -> SentActivity:
+        api.conversations.activities(conversation_id)
+        return await activities.reply(activity_id, activity)
+
     async def create_targeted_activity(conversation_id: str, activity: Any) -> SentActivity:
         api.conversations.activities(conversation_id)
         return await activities.create_targeted(activity)
@@ -99,6 +103,7 @@ def _wire_flat_activity_methods(api: Any, activities: MagicMock) -> None:
 
     api.conversations.create_activity = AsyncMock(side_effect=create_activity)
     api.conversations.update_activity = AsyncMock(side_effect=update_activity)
+    api.conversations.reply_to_activity = AsyncMock(side_effect=reply_to_activity)
     api.conversations.create_targeted_activity = AsyncMock(side_effect=create_targeted_activity)
     api.conversations.update_targeted_activity = AsyncMock(side_effect=update_targeted_activity)
 
@@ -894,6 +899,9 @@ class TestApp:
         )
         activities = MagicMock()
         activities.create = create
+        activities.reply = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
         activities.create_targeted = AsyncMock(
             return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
         )
@@ -1033,6 +1041,9 @@ class TestAppInitialize:
         create = AsyncMock(return_value=SentActivity(id="msg-1", activity_params=MessageActivityInput(text="hi")))
         activities = MagicMock()
         activities.create = create
+        activities.reply = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
         activities.update = AsyncMock(
             return_value=SentActivity(id="existing-msg-id", activity_params=MessageActivityInput(text="updated"))
         )
@@ -1094,6 +1105,9 @@ class TestAppReply:
         )
         activities = MagicMock()
         activities.create = create
+        activities.reply = AsyncMock(
+            return_value=SentActivity(id="sent-activity-id", activity_params=MessageActivityInput(text="sent"))
+        )
         activities.update = AsyncMock(
             return_value=SentActivity(id="updated-activity-id", activity_params=MessageActivityInput(text="updated"))
         )
@@ -1103,10 +1117,14 @@ class TestAppReply:
         return app
 
     @pytest.mark.asyncio
-    async def test_reply_with_three_args_constructs_threaded_id(self, started_app):
+    async def test_reply_with_three_args_uses_reply_endpoint(self, started_app):
         await started_app.reply("19:abc@thread.skype", "1680000000000", "Hello thread")
 
-        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
+        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
+        started_app.api.conversations.activities.return_value.reply.assert_awaited_once()
+        root_id, activity = started_app.api.conversations.activities.return_value.reply.call_args.args
+        assert root_id == "1680000000000"
+        assert activity.text == "Hello thread"
 
     @pytest.mark.asyncio
     async def test_reply_with_three_args_passes_service_url_and_agentic_identity_to_scoped_api(self, started_app):
@@ -1126,16 +1144,16 @@ class TestAppReply:
             agentic_identity=agentic_identity,
         )
 
-        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=1680000000000")
+        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
         started_app.api.clone.assert_called_once_with(
             service_url=service_url,
             agentic_identity=agentic_identity,
         )
-        create = started_app.api.conversations.activities.return_value.create
-        activity = create.call_args.args[0]
+        reply = started_app.api.conversations.activities.return_value.reply
+        activity = reply.call_args.args[1]
         assert isinstance(activity, MessageActivityInput)
         assert activity.text == "Hello thread"
-        assert create.call_args.kwargs == {}
+        assert reply.call_args.kwargs == {}
 
     @pytest.mark.asyncio
     async def test_reply_with_two_args_passes_conversation_id_as_is(self, started_app):
@@ -1175,7 +1193,19 @@ class TestAppReply:
     async def test_reply_with_pre_constructed_threaded_id(self, started_app):
         await started_app.reply("19:abc@thread.skype;messageid=123", "Hello")
 
-        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype;messageid=123")
+        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
+        started_app.api.conversations.activities.return_value.reply.assert_awaited_once()
+        assert started_app.api.conversations.activities.return_value.reply.call_args.args[0] == "123"
+
+    @pytest.mark.asyncio
+    async def test_send_translates_legacy_threaded_conversation_id(self, started_app):
+        await started_app.send("19:abc@thread.skype;messageid=00456", "Hello")
+
+        started_app.api.conversations.activities.assert_called_once_with("19:abc@thread.skype")
+        started_app.api.conversations.activities.return_value.reply.assert_awaited_once()
+        root_id, activity = started_app.api.conversations.activities.return_value.reply.call_args.args
+        assert root_id == "00456"
+        assert activity.conversation.id == "19:abc@thread.skype"
 
     @pytest.mark.asyncio
     async def test_reply_with_invalid_message_id_raises(self, started_app):

--- a/packages/apps/tests/test_function_context.py
+++ b/packages/apps/tests/test_function_context.py
@@ -85,8 +85,8 @@ class TestFunctionContextSend:
 
         assert isinstance(sent_activity, MessageActivityInput)
         assert sent_activity.text == "Hello world"
-        assert sent_activity.from_.id == "bot-123"
-        assert sent_activity.conversation.id == "conv-123"
+        assert sent_activity.from_ is None
+        assert sent_activity.conversation is None
         function_context.api.conversations.activities.assert_called_once_with("conv-123")
 
     async def test_send_adaptive_card(

--- a/packages/apps/tests/test_thread.py
+++ b/packages/apps/tests/test_thread.py
@@ -4,6 +4,9 @@ Licensed under the MIT License.
 """
 
 import pytest
+from microsoft_teams.api import Account, ConversationAccount, MessageActivity
+from microsoft_teams.api.models.channel_data import ChannelData, ThreadInfo
+from microsoft_teams.apps.utils import get_default_thread_id, get_proactive_thread_reference
 from microsoft_teams.apps.utils.thread import to_threaded_conversation_id
 
 
@@ -43,3 +46,54 @@ class TestToThreadedConversationId:
     def test_strips_existing_messageid_and_replaces_with_thread_root(self):
         result = to_threaded_conversation_id("19:abc@thread.skype;messageid=111", "222")
         assert result == "19:abc@thread.skype;messageid=222"
+
+
+class TestGetThreadReference:
+    @staticmethod
+    def _activity(conversation_id: str, *, thread_id: str | None = None) -> MessageActivity:
+        return MessageActivity(
+            id="inbound-id",
+            from_=Account(id="user-id"),
+            recipient=Account(id="bot-id"),
+            conversation=ConversationAccount(id=conversation_id),
+            channel_data=ChannelData(thread=ThreadInfo(id=thread_id)) if thread_id else None,
+        )
+
+    def test_prefers_typed_thread_metadata(self):
+        activity = self._activity("19:abc@thread.skype;messageid=123", thread_id="typed-root")
+
+        assert get_proactive_thread_reference(activity) == ("19:abc@thread.skype", "typed-root")
+
+    def test_uses_legacy_thread_suffix(self):
+        activity = self._activity("19:abc@thread.skype;messageid=123")
+
+        assert get_proactive_thread_reference(activity) == ("19:abc@thread.skype", "123")
+
+    def test_uses_activity_id_for_root_message(self):
+        activity = self._activity("19:abc@thread.skype")
+
+        assert get_proactive_thread_reference(activity) == ("19:abc@thread.skype", "inbound-id")
+
+
+class TestGetCurrentThreadRootId(TestGetThreadReference):
+    def test_uses_typed_thread_metadata(self):
+        activity = self._activity("19:abc@thread.skype", thread_id="typed-root")
+
+        assert get_default_thread_id(activity) == "typed-root"
+
+    def test_uses_legacy_thread_suffix(self):
+        activity = self._activity("19:abc@thread.skype;messageid=123")
+
+        assert get_default_thread_id(activity) == "123"
+
+    def test_uses_activity_id_for_channel_root(self):
+        activity = self._activity("19:abc@thread.skype")
+        activity.conversation.conversation_type = "channel"
+
+        assert get_default_thread_id(activity) == "inbound-id"
+
+    def test_returns_none_for_group_chat_root(self):
+        activity = self._activity("19:abc@thread.skype")
+        activity.conversation.conversation_type = "groupChat"
+
+        assert get_default_thread_id(activity) is None


### PR DESCRIPTION
## Summary
- route L2 group-chat and channel placement through Bot Framework reply endpoints while retaining L1 sends
- add explicit regular and targeted conversation reply APIs; targeted L2 replies use `POST /v3/conversations/{conversationId}/activities/{rootMessageId}?isTargetedActivity=true`
- infer targeted delivery from outbound recipient metadata in proactive `App.reply()` and reactive `ActivityContext.send()`, including targeted activities placed in existing threads
- preserve proactive callers by translating valid legacy `;messageid=` conversation IDs internally
- expose typed, read-only inbound `channelData.thread.id` and apply the reactive personal/group-chat/channel scope matrix
- keep placement independent from explicit `MessageActivityInput.add_quote()` metadata and preserve quote payloads on targeted replies
- omit transport-only `from` and `conversation` fields from outbound payloads, matching .NET and preventing targeted quoted channel replies from being placed at L1
- accept successful reply responses that omit an activity ID, as observed from APX for regular L2 replies
- update the interacting-with-messages sample with default send, proactive thread, quote, targeted, and targeted+quote cases

## Compatibility
Existing regular reply APIs and public send/reply signatures remain supported. Legacy threaded conversation IDs are translated before reaching APX, and the legacy constructor plus quote/reply conveniences are deprecated without changing runtime behavior. Personal-chat targeted restrictions remain unchanged. Transport routing remains in the endpoint/conversation reference rather than duplicated in serialized activity payloads.

## Validation
- 1,190 API/apps tests passed (wheel build test exercised separately by the successful package build)
- focused targeted/reply/outbound payload suites passed
- `uv run poe check`
- `uv run pyright`
- `uv build --all-packages`
- echo sample startup smoke test
- live channel validation: proactive targeted + quote remains in the selected thread