### PR TITLE
feat(oauth): add telemetry for multioauth/state

### DIFF
--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -637,7 +637,6 @@ class OauthHandlers:
         Decorator to register a function that handles the sign-in token exchange.
         """
         activity = ctx.activity
-        api = ctx.api
         next_handler = ctx.next
         pending_flows = self.oauth_registry._pending_flows(ctx)  # pyright: ignore[reportPrivateUsage]
         candidates: list[tuple[str, Optional[OAuthFlow]]] = []
@@ -669,6 +668,41 @@ class OauthHandlers:
                 len(candidates),
                 ", ".join(name for name, _ in candidates),
             )
+        try:
+            if not activity.value.state:
+                _, response = await self._verify_state_candidate(ctx, connection_name, candidates[0][1], None)
+                return response
+
+            logger.debug(
+                f"Verifying sign-in state for user {activity.from_.id} in conversation"
+                f"{activity.conversation.id} with state {activity.value.state}"
+            )
+
+            for candidate_connection_name, flow in candidates:
+                terminal, response = await self._verify_state_candidate(
+                    ctx,
+                    candidate_connection_name,
+                    flow,
+                    activity.value.state,
+                )
+                if terminal:
+                    return response
+
+            # Every candidate missed, so the user holds no token on any of them.
+            # That is "nothing to verify" (404), not a precondition failure.
+            return InvokeResponse(status=404)
+        finally:
+            await next_handler()
+
+    async def _verify_state_candidate(
+        self,
+        ctx: ActivityContext[SignInVerifyStateInvokeActivity],
+        connection_name: str,
+        flow: Optional[OAuthFlow],
+        state: Optional[str],
+    ) -> tuple[bool, Optional[InvokeResponse[None]]]:
+        """Probe one connection and emit one OAuth operation"""
+        activity = ctx.activity
         result = APP_OAUTH_RESULTS.failure
         started_at = perf_counter()
         try:
@@ -680,7 +714,7 @@ class OauthHandlers:
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.verify_state)
 
-                if not activity.value.state:
+                if not state:
                     logger.warning(
                         f"Auth state not present for conversation id '{activity.conversation.id}' "
                         f"and user id '{activity.from_.id}'. "
@@ -688,110 +722,88 @@ class OauthHandlers:
                     result = APP_OAUTH_RESULTS.no_token
                     span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 404)
                     span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    return InvokeResponse(status=404)
+                    return True, InvokeResponse(status=404)
 
-                logger.debug(
-                    f"Verifying sign-in state for user {activity.from_.id} in conversation"
-                    f"{activity.conversation.id} with state {activity.value.state}"
-                )
-
-                for candidate_connection_name, flow in candidates:
-                    # Deliberately rebind the outer name: the ``finally`` block below records
-                    # telemetry against the connection that was probed last, which is the one
-                    # the outcome (success, 412, or exhausted candidates) actually belongs to.
-                    connection_name = candidate_connection_name
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
-                    try:
-                        token = await api.users.get_token(
-                            GetUserTokenParams(
-                                connection_name=connection_name,
-                                user_id=activity.from_.id,
-                                channel_id=activity.channel_id,
-                                code=activity.value.state,
-                            )
+                try:
+                    token = await ctx.api.users.get_token(
+                        GetUserTokenParams(
+                            connection_name=connection_name,
+                            user_id=activity.from_.id,
+                            channel_id=activity.channel_id,
+                            code=state,
                         )
-                    except HTTPStatusError as e:
-                        status = e.response.status_code
-                        if status in (400, 404, 412):
-                            # An expected miss. ``signin/verifyState`` carries no
-                            # connection name, so the Token Service rejecting this
-                            # code only rules out this candidate - it is not a failed
-                            # sign-in until every candidate has been ruled out.
-                            logger.debug(
-                                f"OAuth connection '{connection_name}' did not accept the verify-state code "
-                                f"for user {activity.from_.id} in conversation "
-                                f"{activity.conversation.id} (HTTP {status})."
-                            )
-                            continue
-                        self.oauth_registry._clear_pending(  # pyright: ignore[reportPrivateUsage]
-                            ctx, connection_name
+                    )
+                except HTTPStatusError as e:
+                    status = e.response.status_code
+                    if status in (400, 404, 412):
+                        # A rejection only rules out this candidate; the callback
+                        # carries no connection name, so the remaining flows still
+                        # need to be probed.
+                        logger.debug(
+                            f"OAuth connection '{connection_name}' did not accept the verify-state code "
+                            f"for user {activity.from_.id} in conversation "
+                            f"{activity.conversation.id} (HTTP {status})."
                         )
-                        logger.error(
-                            f"Error verifying sign-in state for user {activity.from_.id} in conversation"
-                            f"{activity.conversation.id}: {e}"
-                        )
-                        await self.event_emitter.emit_async(
-                            "error",
-                            ErrorEvent(error=e, context={"activity": activity}),
-                        )
-                        error_type = APP_OAUTH_ERROR_TYPES.http_error
-                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
-                        record_exception(span, e)
-                        record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
-                        status = status or 500
+                        result = APP_OAUTH_RESULTS.no_token
                         span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                        # Only this candidate's flow: the loop stops here, so the
-                        # remaining candidates were never probed.
-                        await self._notify_terminal_signin_failure(ctx, flow, e, status)
-                        return InvokeResponse(status=status)
-                    except Exception as e:
-                        # A transport fault or a bug, not a Token Service verdict.
-                        # It propagates so the app's error handling reports it once
-                        # rather than being flattened into a 412 that reads as an
-                        # ordinary failed sign-in.
-                        logger.error(
-                            f"Error verifying sign-in state for user {activity.from_.id} in conversation"
-                            f"{activity.conversation.id}: {e}"
-                        )
-                        error_type = APP_OAUTH_ERROR_TYPES.exception
-                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
-                        record_exception(span, e)
-                        record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
-                        result = APP_OAUTH_RESULTS.failure
-                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                        raise
-
-                    ctx.is_signed_in = True
-                    ctx.user_token = token.token
+                        return False, None
                     self.oauth_registry._clear_pending(  # pyright: ignore[reportPrivateUsage]
                         ctx, connection_name
                     )
-                    event = SignInEvent(
-                        activity_ctx=ctx,
-                        token_response=token,
-                        connection_name=connection_name,
+                    logger.error(
+                        f"Error verifying sign-in state for user {activity.from_.id} in conversation"
+                        f"{activity.conversation.id}: {e}"
                     )
-                    result = APP_OAUTH_RESULTS.success
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
+                    await self.event_emitter.emit_async(
+                        "error",
+                        ErrorEvent(error=e, context={"activity": activity}),
+                    )
+                    error_type = APP_OAUTH_ERROR_TYPES.http_error
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                    record_exception(span, e)
+                    record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
+                    status = status or 500
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
                     span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    await self.event_emitter.emit_async("sign_in", event)
-                    if flow is not None:
-                        await flow._invoke_signin_handlers(  # pyright: ignore[reportPrivateUsage]
-                            event
-                        )
-                    logger.debug(
-                        f"Sign-in state verified for user {activity.from_.id} in conversation "
-                        f"{activity.conversation.id}"
+                    await self._notify_terminal_signin_failure(ctx, flow, e, status)
+                    return True, InvokeResponse(status=status)
+                except Exception as e:
+                    # A transport fault or bug is not an ordinary candidate miss.
+                    logger.error(
+                        f"Error verifying sign-in state for user {activity.from_.id} in conversation"
+                        f"{activity.conversation.id}: {e}"
                     )
-                    return None
+                    error_type = APP_OAUTH_ERROR_TYPES.exception
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                    record_exception(span, e)
+                    record_oauth_error(connection_name, APP_OAUTH_OPERATIONS.verify_state, error_type)
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    raise
 
-                # Every candidate missed, so the user holds no token on any of them.
-                # That is "nothing to verify" (404), not a precondition failure.
-                result = APP_OAUTH_RESULTS.no_token
-                span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 404)
+                ctx.is_signed_in = True
+                ctx.user_token = token.token
+                self.oauth_registry._clear_pending(  # pyright: ignore[reportPrivateUsage]
+                    ctx, connection_name
+                )
+                event = SignInEvent(
+                    activity_ctx=ctx,
+                    token_response=token,
+                    connection_name=connection_name,
+                )
+                result = APP_OAUTH_RESULTS.success
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                return InvokeResponse(status=404)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 200)
+                await self.event_emitter.emit_async("sign_in", event)
+                if flow is not None:
+                    await flow._invoke_signin_handlers(  # pyright: ignore[reportPrivateUsage]
+                        event
+                    )
+                logger.debug(
+                    f"Sign-in state verified for user {activity.from_.id} in conversation {activity.conversation.id}"
+                )
+                return True, None
         finally:
             record_oauth_operation(
                 connection_name,
@@ -799,4 +811,3 @@ class OauthHandlers:
                 result,
                 (perf_counter() - started_at) * 1000,
             )
-            await next_handler()

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -674,7 +674,7 @@ class OauthHandlers:
                 return response
 
             logger.debug(
-                f"Verifying sign-in state for user {activity.from_.id} in conversation"
+                f"Verifying sign-in state for user {activity.from_.id} in conversation "
                 f"{activity.conversation.id} with state {activity.value.state}"
             )
 

--- a/packages/apps/src/microsoft_teams/apps/app_oauth.py
+++ b/packages/apps/src/microsoft_teams/apps/app_oauth.py
@@ -158,7 +158,7 @@ class OauthHandlers:
         started_at = perf_counter()
         try:
             with get_tracer().start_as_current_span(
-                APP_SPAN_NAMES.oauth_token_exchange,
+                APP_SPAN_NAMES.oauth,
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
@@ -210,7 +210,8 @@ class OauthHandlers:
                         span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
                         span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
 
-                        await self._notify_terminal_signin_failure(ctx, flow, e, status)
+                        if await self._notify_terminal_signin_failure(ctx, flow, e, status):
+                            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                         return InvokeResponse(status=status)
 
                     # An expected miss: the Token Service has nothing to exchange.
@@ -263,11 +264,12 @@ class OauthHandlers:
                     connection_name=event_connection_name,
                 )
                 result = APP_OAUTH_RESULTS.success
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                 await self.event_emitter.emit_async("sign_in", event)
                 if flow is not None:
                     await flow._invoke_signin_handlers(event)  # pyright: ignore[reportPrivateUsage]
+                    if flow._has_signin_handlers():  # pyright: ignore[reportPrivateUsage]
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 return None
         finally:
             record_oauth_operation(
@@ -392,7 +394,7 @@ class OauthHandlers:
         started_at = perf_counter()
         try:
             with get_tracer().start_as_current_span(
-                APP_SPAN_NAMES.oauth_token_exchange,
+                APP_SPAN_NAMES.oauth,
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
@@ -427,7 +429,7 @@ class OauthHandlers:
         started_at = perf_counter()
         try:
             with get_tracer().start_as_current_span(
-                APP_SPAN_NAMES.oauth_token_exchange,
+                APP_SPAN_NAMES.oauth,
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
@@ -485,9 +487,9 @@ class OauthHandlers:
         flow: Optional[OAuthFlow],
         error: HTTPStatusError,
         status: int,
-    ) -> None:
+    ) -> bool:
         if flow is None:
-            return
+            return False
         await flow._invoke_signin_failure_handlers(  # pyright: ignore[reportPrivateUsage]
             SignInFailureEvent(
                 activity_ctx=ctx,
@@ -496,6 +498,7 @@ class OauthHandlers:
                 message=str(error),
             )
         )
+        return flow._has_signin_failure_handlers()  # pyright: ignore[reportPrivateUsage]
 
     async def sign_in_failure(
         self, ctx: ActivityContext[SignInFailureInvokeActivity]
@@ -566,7 +569,7 @@ class OauthHandlers:
         started_at = perf_counter()
         try:
             with get_tracer().start_as_current_span(
-                APP_SPAN_NAMES.oauth_signin_failure,
+                APP_SPAN_NAMES.oauth,
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
@@ -604,7 +607,6 @@ class OauthHandlers:
                     message=failure.message,
                 )
                 await self.event_emitter.emit_async("sign_in_failure", event)
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                 for flow in callback_flows:
                     flow_event = (
@@ -620,6 +622,11 @@ class OauthHandlers:
                     await flow._invoke_signin_failure_handlers(  # pyright: ignore[reportPrivateUsage]
                         flow_event
                     )
+                if any(
+                    flow._has_signin_failure_handlers()  # pyright: ignore[reportPrivateUsage]
+                    for flow in callback_flows
+                ):
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 return None
         finally:
             record_oauth_operation(
@@ -707,7 +714,7 @@ class OauthHandlers:
         started_at = perf_counter()
         try:
             with get_tracer().start_as_current_span(
-                APP_SPAN_NAMES.oauth_verify_state,
+                APP_SPAN_NAMES.oauth,
                 record_exception=False,
                 set_status_on_exception=False,
             ) as span:
@@ -766,7 +773,8 @@ class OauthHandlers:
                     status = status or 500
                     span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, status)
                     span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    await self._notify_terminal_signin_failure(ctx, flow, e, status)
+                    if await self._notify_terminal_signin_failure(ctx, flow, e, status):
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                     return True, InvokeResponse(status=status)
                 except Exception as e:
                     # A transport fault or bug is not an ordinary candidate miss.
@@ -792,7 +800,6 @@ class OauthHandlers:
                     connection_name=connection_name,
                 )
                 result = APP_OAUTH_RESULTS.success
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
                 span.set_attribute(APP_ATTRIBUTE_NAMES.invoke_response_status, 200)
                 await self.event_emitter.emit_async("sign_in", event)
@@ -800,6 +807,8 @@ class OauthHandlers:
                     await flow._invoke_signin_handlers(  # pyright: ignore[reportPrivateUsage]
                         event
                     )
+                    if flow._has_signin_handlers():  # pyright: ignore[reportPrivateUsage]
+                        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_callback_invoked, True)
                 logger.debug(
                     f"Sign-in state verified for user {activity.from_.id} in conversation {activity.conversation.id}"
                 )

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -74,6 +74,7 @@ class _AppOAuthErrorTypes:
 
 @dataclass(frozen=True)
 class _AppOAuthOperations:
+    signin: str = "signin"
     signin_failure: str = "signin_failure"
     token_exchange: str = "token_exchange"
     verify_state: str = "verify_state"
@@ -81,6 +82,8 @@ class _AppOAuthOperations:
 
 @dataclass(frozen=True)
 class _AppOAuthResults:
+    cached: str = "token_cached"
+    card_sent: str = "signin_card_sent"
     duplicate: str = "duplicate"
     failure: str = "failure"
     no_token: str = "no_token"
@@ -91,9 +94,13 @@ class _AppOAuthResults:
 @dataclass(frozen=True)
 class _AppSpanNames:
     handler: str = "microsoft.teams.handler"
+    oauth_signin: str = "microsoft.teams.oauth.signin"
     oauth_signin_failure: str = "microsoft.teams.oauth.signin_failure"
     oauth_token_exchange: str = "microsoft.teams.oauth.token_exchange"
     oauth_verify_state: str = "microsoft.teams.oauth.verify_state"
+    state_delete: str = "microsoft.teams.state.delete"
+    state_load: str = "microsoft.teams.state.load"
+    state_save: str = "microsoft.teams.state.save"
     turn: str = "microsoft.teams.activity.process"
 
 

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -88,12 +88,12 @@ class _AppOAuthResults:
     cached: str = "token_cached"
     card_sent: str = "signin_card_sent"
     duplicate: str = "duplicate"
-    failure: str = "failure"
+    failure: str = "operation_failed"
     hit: str = "token_found"
     miss: str = "token_not_found"
     no_token: str = "no_token"
     notified: str = "notified"
-    success: str = "success"
+    success: str = "operation_succeeded"
 
 
 @dataclass(frozen=True)

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_constants.py
@@ -74,8 +74,11 @@ class _AppOAuthErrorTypes:
 
 @dataclass(frozen=True)
 class _AppOAuthOperations:
+    connection_status: str = "connection_status"
+    get_token: str = "get_token"
     signin: str = "signin"
     signin_failure: str = "signin_failure"
+    signout: str = "signout"
     token_exchange: str = "token_exchange"
     verify_state: str = "verify_state"
 
@@ -86,6 +89,8 @@ class _AppOAuthResults:
     card_sent: str = "signin_card_sent"
     duplicate: str = "duplicate"
     failure: str = "failure"
+    hit: str = "token_found"
+    miss: str = "token_not_found"
     no_token: str = "no_token"
     notified: str = "notified"
     success: str = "success"
@@ -94,10 +99,7 @@ class _AppOAuthResults:
 @dataclass(frozen=True)
 class _AppSpanNames:
     handler: str = "microsoft.teams.handler"
-    oauth_signin: str = "microsoft.teams.oauth.signin"
-    oauth_signin_failure: str = "microsoft.teams.oauth.signin_failure"
-    oauth_token_exchange: str = "microsoft.teams.oauth.token_exchange"
-    oauth_verify_state: str = "microsoft.teams.oauth.verify_state"
+    oauth: str = "microsoft.teams.oauth"
     state_delete: str = "microsoft.teams.state.delete"
     state_load: str = "microsoft.teams.state.load"
     state_save: str = "microsoft.teams.state.save"
@@ -111,4 +113,5 @@ APP_METRIC_NAMES = _AppMetricNames()
 APP_OAUTH_ERROR_TYPES = _AppOAuthErrorTypes()
 APP_OAUTH_OPERATIONS = _AppOAuthOperations()
 APP_OAUTH_RESULTS = _AppOAuthResults()
+APP_OAUTH_ALL_CONNECTIONS = "all"
 APP_SPAN_NAMES = _AppSpanNames()

--- a/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
+++ b/packages/apps/src/microsoft_teams/apps/diagnostics/_helpers.py
@@ -3,14 +3,29 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the MIT License.
 """
 
-from typing import Optional
+from contextlib import contextmanager
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Generator, Optional
 
+from httpx import HTTPStatusError
 from opentelemetry import metrics, trace
 from opentelemetry.metrics import Counter, Histogram, Meter
 from opentelemetry.trace import Span, Status, StatusCode, Tracer
 
-from ._constants import APP_ATTRIBUTE_NAMES, APP_METRIC_NAMES
+from ._constants import (
+    APP_ATTRIBUTE_NAMES,
+    APP_METRIC_NAMES,
+    APP_OAUTH_ERROR_TYPES,
+    APP_OAUTH_RESULTS,
+    APP_SPAN_NAMES,
+)
 from ._telemetry import TeamsBotApplicationTelemetry
+
+
+@dataclass
+class OAuthOperationTelemetry:
+    result: str = APP_OAUTH_RESULTS.failure
 
 
 def get_tracer() -> Tracer:
@@ -140,3 +155,40 @@ def record_turn_duration(duration_ms: float, activity_type: str) -> None:
 def record_exception(span: Span, exception: BaseException) -> None:
     span.record_exception(exception)
     span.set_status(Status(StatusCode.ERROR, str(exception)))
+
+
+@contextmanager
+def trace_oauth_operation(
+    connection_name: str,
+    operation: str,
+) -> Generator[tuple[Span, OAuthOperationTelemetry], None, None]:
+    """Trace and measure one OAuth flow operation."""
+    started_at = perf_counter()
+    telemetry = OAuthOperationTelemetry()
+    with get_tracer().start_as_current_span(
+        APP_SPAN_NAMES.oauth,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, connection_name)
+        span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, operation)
+        try:
+            yield span, telemetry
+        except Exception as exception:
+            error_type = (
+                APP_OAUTH_ERROR_TYPES.http_error
+                if isinstance(exception, HTTPStatusError)
+                else APP_OAUTH_ERROR_TYPES.exception
+            )
+            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+            record_exception(span, exception)
+            record_oauth_error(connection_name, operation, error_type)
+            raise
+        finally:
+            span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, telemetry.result)
+            record_oauth_operation(
+                connection_name,
+                operation,
+                telemetry.result,
+                (perf_counter() - started_at) * 1000,
+            )

--- a/packages/apps/src/microsoft_teams/apps/oauth_flow.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_flow.py
@@ -7,11 +7,20 @@ import inspect
 import logging
 from collections import OrderedDict
 from dataclasses import replace
+from time import perf_counter
 from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 from httpx import HTTPStatusError
 from microsoft_teams.api import GetUserTokenParams, SignOutUserParams
 
+from .diagnostics._constants import (
+    APP_ATTRIBUTE_NAMES,
+    APP_OAUTH_ERROR_TYPES,
+    APP_OAUTH_OPERATIONS,
+    APP_OAUTH_RESULTS,
+    APP_SPAN_NAMES,
+)
+from .diagnostics._helpers import get_tracer, record_exception, record_oauth_error, record_oauth_operation
 from .events import SignInEvent, SignInFailureEvent
 from .oauth_connection import connection_lookup_key, normalize_connection_name
 from .oauth_state import (
@@ -148,7 +157,40 @@ class OAuthFlow:
         fallback.
         """
         base = self._defaults if options is None else options
-        return await ctx.sign_in(replace(base, connection_name=self.connection_name))
+        result = APP_OAUTH_RESULTS.failure
+        started_at = perf_counter()
+        try:
+            with get_tracer().start_as_current_span(
+                APP_SPAN_NAMES.oauth_signin,
+                record_exception=False,
+                set_status_on_exception=False,
+            ) as span:
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, self.connection_name)
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.signin)
+                try:
+                    token = await ctx.sign_in(replace(base, connection_name=self.connection_name))
+                except Exception as exception:
+                    error_type = (
+                        APP_OAUTH_ERROR_TYPES.http_error
+                        if isinstance(exception, HTTPStatusError)
+                        else APP_OAUTH_ERROR_TYPES.exception
+                    )
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
+                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                    record_exception(span, exception)
+                    record_oauth_error(self.connection_name, APP_OAUTH_OPERATIONS.signin, error_type)
+                    raise
+
+                result = APP_OAUTH_RESULTS.cached if token is not None else APP_OAUTH_RESULTS.card_sent
+                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
+                return token
+        finally:
+            record_oauth_operation(
+                self.connection_name,
+                APP_OAUTH_OPERATIONS.signin,
+                result,
+                (perf_counter() - started_at) * 1000,
+            )
 
     async def sign_out(self, ctx: ActivityContext[Any]) -> None:
         """Sign the user out of this connection."""

--- a/packages/apps/src/microsoft_teams/apps/oauth_flow.py
+++ b/packages/apps/src/microsoft_teams/apps/oauth_flow.py
@@ -7,20 +7,13 @@ import inspect
 import logging
 from collections import OrderedDict
 from dataclasses import replace
-from time import perf_counter
 from typing import Any, Awaitable, Callable, Iterator, List, Mapping, Optional, Sequence, Tuple, TypeVar, Union
 
 from httpx import HTTPStatusError
 from microsoft_teams.api import GetUserTokenParams, SignOutUserParams
 
-from .diagnostics._constants import (
-    APP_ATTRIBUTE_NAMES,
-    APP_OAUTH_ERROR_TYPES,
-    APP_OAUTH_OPERATIONS,
-    APP_OAUTH_RESULTS,
-    APP_SPAN_NAMES,
-)
-from .diagnostics._helpers import get_tracer, record_exception, record_oauth_error, record_oauth_operation
+from .diagnostics._constants import APP_OAUTH_OPERATIONS, APP_OAUTH_RESULTS
+from .diagnostics._helpers import trace_oauth_operation
 from .events import SignInEvent, SignInFailureEvent
 from .oauth_connection import connection_lookup_key, normalize_connection_name
 from .oauth_state import (
@@ -140,6 +133,12 @@ class OAuthFlow:
     async def _invoke_signin_failure_handlers(self, event: SignInFailureEvent) -> None:
         await _dispatch_handlers(self._on_signin_failure, event, self.connection_name, "on_signin_failure")
 
+    def _has_signin_handlers(self) -> bool:
+        return bool(self._on_signin)
+
+    def _has_signin_failure_handlers(self) -> bool:
+        return bool(self._on_signin_failure)
+
     # -- operations -----------------------------------------------------------
 
     async def sign_in(self, ctx: ActivityContext[Any], options: Optional[SignInOptions] = None) -> Optional[str]:
@@ -157,66 +156,50 @@ class OAuthFlow:
         fallback.
         """
         base = self._defaults if options is None else options
-        result = APP_OAUTH_RESULTS.failure
-        started_at = perf_counter()
-        try:
-            with get_tracer().start_as_current_span(
-                APP_SPAN_NAMES.oauth_signin,
-                record_exception=False,
-                set_status_on_exception=False,
-            ) as span:
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_connection, self.connection_name)
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_operation, APP_OAUTH_OPERATIONS.signin)
-                try:
-                    token = await ctx.sign_in(replace(base, connection_name=self.connection_name))
-                except Exception as exception:
-                    error_type = (
-                        APP_OAUTH_ERROR_TYPES.http_error
-                        if isinstance(exception, HTTPStatusError)
-                        else APP_OAUTH_ERROR_TYPES.exception
-                    )
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_error_type, error_type)
-                    span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                    record_exception(span, exception)
-                    record_oauth_error(self.connection_name, APP_OAUTH_OPERATIONS.signin, error_type)
-                    raise
-
-                result = APP_OAUTH_RESULTS.cached if token is not None else APP_OAUTH_RESULTS.card_sent
-                span.set_attribute(APP_ATTRIBUTE_NAMES.oauth_result, result)
-                return token
-        finally:
-            record_oauth_operation(
-                self.connection_name,
-                APP_OAUTH_OPERATIONS.signin,
-                result,
-                (perf_counter() - started_at) * 1000,
-            )
+        with trace_oauth_operation(
+            self.connection_name,
+            APP_OAUTH_OPERATIONS.signin,
+        ) as (_, telemetry):
+            token = await ctx.sign_in(replace(base, connection_name=self.connection_name))
+            telemetry.result = APP_OAUTH_RESULTS.cached if token is not None else APP_OAUTH_RESULTS.card_sent
+            return token
 
     async def sign_out(self, ctx: ActivityContext[Any]) -> None:
         """Sign the user out of this connection."""
-        await ctx.api.users.sign_out(
-            SignOutUserParams(
-                channel_id=ctx.activity.channel_id,
-                user_id=ctx.activity.from_.id,
-                connection_name=self.connection_name,
-            )
-        )
-
-    async def get_token(self, ctx: ActivityContext[Any]) -> Optional[str]:
-        """The user's token for this connection, or ``None`` if not signed in."""
-        try:
-            res = await ctx.api.users.get_token(
-                GetUserTokenParams(
+        with trace_oauth_operation(
+            self.connection_name,
+            APP_OAUTH_OPERATIONS.signout,
+        ) as (_, telemetry):
+            await ctx.api.users.sign_out(
+                SignOutUserParams(
                     channel_id=ctx.activity.channel_id,
                     user_id=ctx.activity.from_.id,
                     connection_name=self.connection_name,
                 )
             )
-            return res.token
-        except HTTPStatusError as e:
-            if e.response.status_code == 404:
+            telemetry.result = APP_OAUTH_RESULTS.success
+
+    async def get_token(self, ctx: ActivityContext[Any]) -> Optional[str]:
+        """The user's token for this connection, or ``None`` if not signed in."""
+        with trace_oauth_operation(
+            self.connection_name,
+            APP_OAUTH_OPERATIONS.get_token,
+        ) as (_, telemetry):
+            try:
+                response = await ctx.api.users.get_token(
+                    GetUserTokenParams(
+                        channel_id=ctx.activity.channel_id,
+                        user_id=ctx.activity.from_.id,
+                        connection_name=self.connection_name,
+                    )
+                )
+            except HTTPStatusError as error:
+                if error.response.status_code != 404:
+                    raise
+                telemetry.result = APP_OAUTH_RESULTS.miss
                 return None
-            raise
+            telemetry.result = APP_OAUTH_RESULTS.hit
+            return response.token
 
     async def is_signed_in(self, ctx: ActivityContext[Any]) -> bool:
         """Whether the user currently has a token for this connection."""

--- a/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
+++ b/packages/apps/src/microsoft_teams/apps/routing/activity_context.py
@@ -55,6 +55,12 @@ from microsoft_teams.common.experimental import ExperimentalWarning
 from microsoft_teams.common.http.client_token import Token
 
 from ..activity_send import send_or_update_activity
+from ..diagnostics._constants import (
+    APP_OAUTH_ALL_CONNECTIONS,
+    APP_OAUTH_OPERATIONS,
+    APP_OAUTH_RESULTS,
+)
+from ..diagnostics._helpers import trace_oauth_operation
 from ..files import FilesAccessor
 from ..http_stream import HttpStream
 from ..oauth_connection import connection_lookup_key, normalize_connection_name
@@ -578,48 +584,54 @@ class ActivityContext(Generic[T]):
         reported as signed out. Connections that are not registered are passed
         through untouched, and a non-404 lookup failure propagates.
         """
-        statuses = await self.api.users.get_token_status(
-            GetUserTokenStatusParams(
-                channel_id=self.activity.channel_id,
-                user_id=self.activity.from_.id,
-            )
-        )
-        if not self._oauth_connection_names:
-            return statuses
-
-        registered = {
-            key: name
-            for name, key in ((name, connection_lookup_key(name)) for name in self._oauth_connection_names)
-            if key is not None
-        }
-
-        corrected: List[TokenStatus] = []
-        resolved: set[str] = set()
-        for status in statuses:
-            key = connection_lookup_key(status.connection_name)
-            if key is not None:
-                resolved.add(key)
-            if key is None or key not in registered or status.has_token:
-                corrected.append(status)
-                continue
-            # Only reached when the bulk call said False, so a direct hit is a
-            # correction and a direct miss confirms the original answer.
-            if await self.get_user_token(registered[key]) is not None:
-                corrected.append(status.model_copy(update={"has_token": True}))
-            else:
-                corrected.append(status)
-
-        # Registered flows the bulk call omitted entirely.
-        for key, name in registered.items():
-            if key in resolved:
-                continue
-            corrected.append(
-                TokenStatus(
+        with trace_oauth_operation(
+            APP_OAUTH_ALL_CONNECTIONS,
+            APP_OAUTH_OPERATIONS.connection_status,
+        ) as (_, telemetry):
+            statuses = await self.api.users.get_token_status(
+                GetUserTokenStatusParams(
                     channel_id=self.activity.channel_id,
-                    connection_name=name,
-                    has_token=await self.get_user_token(name) is not None,
-                    service_provider_display_name="",
+                    user_id=self.activity.from_.id,
                 )
             )
+            if not self._oauth_connection_names:
+                telemetry.result = APP_OAUTH_RESULTS.success
+                return statuses
 
-        return corrected
+            registered = {
+                key: name
+                for name, key in ((name, connection_lookup_key(name)) for name in self._oauth_connection_names)
+                if key is not None
+            }
+
+            corrected: List[TokenStatus] = []
+            resolved: set[str] = set()
+            for status in statuses:
+                key = connection_lookup_key(status.connection_name)
+                if key is not None:
+                    resolved.add(key)
+                if key is None or key not in registered or status.has_token:
+                    corrected.append(status)
+                    continue
+                # Only reached when the bulk call said False, so a direct hit is a
+                # correction and a direct miss confirms the original answer.
+                if await self.get_user_token(registered[key]) is not None:
+                    corrected.append(status.model_copy(update={"has_token": True}))
+                else:
+                    corrected.append(status)
+
+            # Registered flows the bulk call omitted entirely.
+            for key, name in registered.items():
+                if key in resolved:
+                    continue
+                corrected.append(
+                    TokenStatus(
+                        channel_id=self.activity.channel_id,
+                        connection_name=name,
+                        has_token=await self.get_user_token(name) is not None,
+                        service_provider_display_name="",
+                    )
+                )
+
+            telemetry.result = APP_OAUTH_RESULTS.success
+            return corrected

--- a/packages/apps/src/microsoft_teams/apps/state/loader.py
+++ b/packages/apps/src/microsoft_teams/apps/state/loader.py
@@ -7,16 +7,19 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Awaitable, Callable, Dict, Optional, TypeVar, Union, cast
 from urllib.parse import quote
 
 from microsoft_teams.common import LocalStorage, Storage
 
+from ..diagnostics._constants import APP_SPAN_NAMES
+from ..diagnostics._helpers import get_tracer, record_exception
 from .container import TurnStateContainer
 from .options import StateOptions
 from .turn_state import TurnState
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 class TurnStateLoader:
@@ -48,23 +51,27 @@ class TurnStateLoader:
 
     async def load(self, conversation_id: str, user_id: Optional[str] = None) -> TurnStateContainer:
         """Load both scopes for the turn. ``user`` is ``None`` when ``user_id`` is."""
-        conversation = await self._load_scope(self.conversation_key(conversation_id))
 
-        user: Optional[TurnState] = None
-        if user_id is not None:
-            user = await self._load_scope(self.user_key(conversation_id, user_id))
+        async def load_scopes() -> TurnStateContainer:
+            conversation = await self._load_scope(self.conversation_key(conversation_id))
 
-        async def _delete() -> None:
-            await self.delete(conversation_id, user_id)
+            user: Optional[TurnState] = None
+            if user_id is not None:
+                user = await self._load_scope(self.user_key(conversation_id, user_id))
 
-        return TurnStateContainer(
-            conversation=conversation,
-            user=user,
-            conversation_id=conversation_id,
-            user_id=user_id,
-            _deleter=_delete,
-            _saver=self.save,
-        )
+            async def _delete() -> None:
+                await self.delete(conversation_id, user_id)
+
+            return TurnStateContainer(
+                conversation=conversation,
+                user=user,
+                conversation_id=conversation_id,
+                user_id=user_id,
+                _deleter=_delete,
+                _saver=self.save,
+            )
+
+        return await _trace_state_operation(APP_SPAN_NAMES.state_load, load_scopes)
 
     async def save(self, container: TurnStateContainer) -> None:
         """Persist dirty scopes under the identity the container was loaded for.
@@ -78,37 +85,44 @@ class TurnStateLoader:
         if container.user is not None and not container.user_id:
             raise ValueError("TurnStateContainer.user_id must be set to save user state.")
 
-        pending_deletes: list[str] = []
-        pending_sets: list[tuple[str, str]] = []
-        pending_clean: list[TurnState] = []
-        self._prepare_scope_save(
-            self.conversation_key(container.conversation_id),
-            container.conversation,
-            pending_deletes,
-            pending_sets,
-            pending_clean,
-        )
-        if container.user is not None and container.user_id is not None:
+        async def save_scopes() -> None:
+            pending_deletes: list[str] = []
+            pending_sets: list[tuple[str, str]] = []
+            pending_clean: list[TurnState] = []
             self._prepare_scope_save(
-                self.user_key(container.conversation_id, container.user_id),
-                container.user,
+                self.conversation_key(container.conversation_id),
+                container.conversation,
                 pending_deletes,
                 pending_sets,
                 pending_clean,
             )
+            if container.user is not None and container.user_id is not None:
+                self._prepare_scope_save(
+                    self.user_key(container.conversation_id, container.user_id),
+                    container.user,
+                    pending_deletes,
+                    pending_sets,
+                    pending_clean,
+                )
 
-        for key in pending_deletes:
-            await self._storage.async_delete(key)
-        for key, value in pending_sets:
-            await self._storage.async_set(key, value)
-        for scope in pending_clean:
-            scope.mark_clean()
+            for key in pending_deletes:
+                await self._storage.async_delete(key)
+            for key, value in pending_sets:
+                await self._storage.async_set(key, value)
+            for scope in pending_clean:
+                scope.mark_clean()
+
+        await _trace_state_operation(APP_SPAN_NAMES.state_save, save_scopes)
 
     async def delete(self, conversation_id: str, user_id: Optional[str] = None) -> None:
         """Delete both scope blobs for the turn's identity."""
-        await self._storage.async_delete(self.conversation_key(conversation_id))
-        if user_id is not None:
-            await self._storage.async_delete(self.user_key(conversation_id, user_id))
+
+        async def delete_scopes() -> None:
+            await self._storage.async_delete(self.conversation_key(conversation_id))
+            if user_id is not None:
+                await self._storage.async_delete(self.user_key(conversation_id, user_id))
+
+        await _trace_state_operation(APP_SPAN_NAMES.state_delete, delete_scopes)
 
     async def _load_scope(self, key: str) -> TurnState:
         raw = await self._storage.async_get(key)
@@ -186,3 +200,16 @@ def create_state_loader(
             + "restart and is not shared across instances."
         )
     return TurnStateLoader(storage=storage, options=options)
+
+
+async def _trace_state_operation(name: str, operation: Callable[[], Awaitable[T]]) -> T:
+    with get_tracer().start_as_current_span(
+        name,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        try:
+            return await operation()
+        except Exception as exception:
+            record_exception(span, exception)
+            raise

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -38,7 +38,7 @@ def _capture_oauth_operation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[list[tuple[str, str]], MagicMock]:
     calls: list[tuple[str, str]] = []
-    telemetry = MagicMock(result="failure")
+    telemetry = MagicMock(result="operation_failed")
 
     @contextmanager
     def trace(connection_name: str, operation: str) -> Generator[tuple[MagicMock, MagicMock], None, None]:
@@ -1229,7 +1229,7 @@ class TestActivityContextTokenHelpers:
         assert params.user_id == "user-1"
         assert params.channel_id == "msteams"
         assert telemetry_calls == [("all", "connection_status")]
-        assert telemetry.result == "success"
+        assert telemetry.result == "operation_succeeded"
 
     @pytest.mark.asyncio
     async def test_get_connection_status_propagates_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1245,7 +1245,7 @@ class TestActivityContextTokenHelpers:
         with pytest.raises(RuntimeError):
             await ctx.get_connection_status()
         assert telemetry_calls == [("all", "connection_status")]
-        assert telemetry.result == "failure"
+        assert telemetry.result == "operation_failed"
 
 
 class TestActivityContextPromptPreview:

--- a/packages/apps/tests/test_activity_context.py
+++ b/packages/apps/tests/test_activity_context.py
@@ -6,8 +6,9 @@ Licensed under the MIT License.
 # pyright: basic
 
 import time
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,6 +32,24 @@ from microsoft_teams.apps.oauth_state import get_pending_oauth_sign_ins
 from microsoft_teams.apps.routing.activity_context import ActivityContext, SignInOptions
 from microsoft_teams.apps.state import TurnStateLoader
 from microsoft_teams.common import LocalStorage
+
+
+def _capture_oauth_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[tuple[str, str]], MagicMock]:
+    calls: list[tuple[str, str]] = []
+    telemetry = MagicMock(result="failure")
+
+    @contextmanager
+    def trace(connection_name: str, operation: str) -> Generator[tuple[MagicMock, MagicMock], None, None]:
+        calls.append((connection_name, operation))
+        yield MagicMock(), telemetry
+
+    monkeypatch.setattr(
+        "microsoft_teams.apps.routing.activity_context.trace_oauth_operation",
+        trace,
+    )
+    return calls, telemetry
 
 
 def _create_activity_context(
@@ -1190,7 +1209,7 @@ class TestActivityContextTokenHelpers:
             await ctx.get_user_token()
 
     @pytest.mark.asyncio
-    async def test_get_connection_status_returns_all_connections(self) -> None:
+    async def test_get_connection_status_returns_all_connections(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """get_connection_status makes a single call and returns the status list unfiltered."""
         mock_activity = MagicMock()
         mock_activity.channel_id = "msteams"
@@ -1199,6 +1218,7 @@ class TestActivityContextTokenHelpers:
         ctx, _ = _create_activity_context(activity=mock_activity)
         statuses = [MagicMock(), MagicMock()]
         ctx.api.users.get_token_status = AsyncMock(return_value=statuses)
+        telemetry_calls, telemetry = _capture_oauth_operation(monkeypatch)
 
         result = await ctx.get_connection_status()
 
@@ -1208,9 +1228,11 @@ class TestActivityContextTokenHelpers:
         assert params.include_filter is None
         assert params.user_id == "user-1"
         assert params.channel_id == "msteams"
+        assert telemetry_calls == [("all", "connection_status")]
+        assert telemetry.result == "success"
 
     @pytest.mark.asyncio
-    async def test_get_connection_status_propagates_errors(self) -> None:
+    async def test_get_connection_status_propagates_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Unlike get_user_token, get_connection_status lets service failures surface."""
         mock_activity = MagicMock()
         mock_activity.channel_id = "msteams"
@@ -1218,9 +1240,12 @@ class TestActivityContextTokenHelpers:
 
         ctx, _ = _create_activity_context(activity=mock_activity)
         ctx.api.users.get_token_status = AsyncMock(side_effect=RuntimeError("service down"))
+        telemetry_calls, telemetry = _capture_oauth_operation(monkeypatch)
 
         with pytest.raises(RuntimeError):
             await ctx.get_connection_status()
+        assert telemetry_calls == [("all", "connection_status")]
+        assert telemetry.result == "failure"
 
 
 class TestActivityContextPromptPreview:

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -8,7 +8,7 @@ import logging
 import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any, Iterator
+from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -60,7 +60,7 @@ class RecordingTracer:
         self.spans: list[RecordingSpan] = []
 
     @contextmanager
-    def start_as_current_span(self, name: str, **kwargs: Any) -> Iterator[RecordingSpan]:
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Generator[RecordingSpan, None, None]:
         span = RecordingSpan(name, kwargs)
         self.spans.append(span)
         yield span
@@ -214,33 +214,45 @@ class TestOauthHandlers:
         mock_context.next.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("with_callback", [False, True])
     async def test_sign_in_token_exchange_records_success_telemetry(
-        self, oauth_handlers, mock_context, token_exchange_activity, mock_token_response
+        self,
+        oauth_handlers,
+        mock_context,
+        token_exchange_activity,
+        mock_token_response,
+        monkeypatch: pytest.MonkeyPatch,
+        with_callback: bool,
     ):
         mock_context.activity = token_exchange_activity
         mock_context.api.users.exchange_token.return_value = mock_token_response
+        if with_callback:
+            flow = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+
+            @flow.on_signin
+            async def on_signin(_):
+                pass
+
         tracer = RecordingTracer()
+        operation_calls = []
+        monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+        monkeypatch.setattr(
+            "microsoft_teams.apps.app_oauth.record_oauth_operation",
+            lambda *args: operation_calls.append(args),
+        )
 
-        with (
-            pytest.MonkeyPatch.context() as monkeypatch,
-        ):
-            operation_calls = []
-            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
-            monkeypatch.setattr(
-                "microsoft_teams.apps.app_oauth.record_oauth_operation",
-                lambda *args: operation_calls.append(args),
-            )
+        await oauth_handlers.sign_in_token_exchange(mock_context)
 
-            await oauth_handlers.sign_in_token_exchange(mock_context)
-
-        assert tracer.spans[0].name == "microsoft.teams.oauth.token_exchange"
+        assert tracer.spans[0].name == "microsoft.teams.oauth"
         assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
-        assert tracer.spans[0].attributes == {
+        expected_attributes = {
             "oauth.connection": "test-connection",
             "oauth.operation": "token_exchange",
-            "oauth.callback.invoked": True,
             "oauth.result": "success",
         }
+        if with_callback:
+            expected_attributes["oauth.callback.invoked"] = True
+        assert tracer.spans[0].attributes == expected_attributes
         assert operation_calls[0][:3] == ("test-connection", "token_exchange", "success")
         assert operation_calls[0][3] >= 0
         assert "test-token" not in tracer.spans[0].attributes.values()
@@ -860,29 +872,43 @@ class TestOauthHandlers:
         assert result is None
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("with_callback", [False, True])
     async def test_sign_in_failure_records_notified_telemetry_without_message(
-        self, oauth_handlers, mock_context, failure_activity
+        self,
+        oauth_handlers,
+        mock_context,
+        failure_activity,
+        monkeypatch: pytest.MonkeyPatch,
+        with_callback: bool,
     ):
         mock_context.activity = failure_activity
+        if with_callback:
+            flow = oauth_handlers.oauth_registry.add(OAuthFlow("test-connection"))
+
+            @flow.on_signin_failure
+            async def on_signin_failure(_):
+                pass
+
+            mock_context.state = create_pending_state(("test-connection", time.time(), True))
         tracer = RecordingTracer()
+        operation_calls = []
+        monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+        monkeypatch.setattr(
+            "microsoft_teams.apps.app_oauth.record_oauth_operation",
+            lambda *args: operation_calls.append(args),
+        )
 
-        with pytest.MonkeyPatch.context() as monkeypatch:
-            operation_calls = []
-            monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
-            monkeypatch.setattr(
-                "microsoft_teams.apps.app_oauth.record_oauth_operation",
-                lambda *args: operation_calls.append(args),
-            )
+        await oauth_handlers.sign_in_failure(mock_context)
 
-            await oauth_handlers.sign_in_failure(mock_context)
-
-        assert tracer.spans[0].attributes == {
+        expected_attributes = {
             "oauth.connection": "test-connection",
             "oauth.operation": "signin_failure",
             "oauth.failure.code": "resourcematchfailed",
-            "oauth.callback.invoked": True,
             "oauth.result": "notified",
         }
+        if with_callback:
+            expected_attributes["oauth.callback.invoked"] = True
+        assert tracer.spans[0].attributes == expected_attributes
         assert operation_calls[0][:3] == ("test-connection", "signin_failure", "notified")
         assert "Resource match failed" not in tracer.spans[0].attributes.values()
 
@@ -1112,7 +1138,12 @@ class TestOauthHandlers:
         monkeypatch: pytest.MonkeyPatch,
     ):
         oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
-        oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        github = oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+
+        @github.on_signin
+        async def on_signin(_):
+            pass
+
         mock_context.activity = verify_state_activity
         mock_context.state = create_pending_state(("Graph", time.time(), False))
         mock_context.api.users.get_token.side_effect = [
@@ -1130,6 +1161,7 @@ class TestOauthHandlers:
 
         assert await oauth_handlers.sign_in_verify_state(mock_context) is None
 
+        assert [span.name for span in tracer.spans] == ["microsoft.teams.oauth", "microsoft.teams.oauth"]
         assert [span.attributes for span in tracer.spans] == [
             {
                 "oauth.connection": "Graph",

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -248,12 +248,12 @@ class TestOauthHandlers:
         expected_attributes = {
             "oauth.connection": "test-connection",
             "oauth.operation": "token_exchange",
-            "oauth.result": "success",
+            "oauth.result": "operation_succeeded",
         }
         if with_callback:
             expected_attributes["oauth.callback.invoked"] = True
         assert tracer.spans[0].attributes == expected_attributes
-        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "success")
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "operation_succeeded")
         assert operation_calls[0][3] >= 0
         assert "test-token" not in tracer.spans[0].attributes.values()
         assert "access-token" not in tracer.spans[0].attributes.values()
@@ -345,9 +345,9 @@ class TestOauthHandlers:
             "oauth.connection": "test-connection",
             "oauth.operation": "token_exchange",
             "invoke.response.status": 412,
-            "oauth.result": "failure",
+            "oauth.result": "operation_failed",
         }
-        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "operation_failed")
         assert error_calls == []
 
     @pytest.mark.asyncio
@@ -413,9 +413,9 @@ class TestOauthHandlers:
             "oauth.operation": "token_exchange",
             "oauth.error.type": "http_error",
             "invoke.response.status": 500,
-            "oauth.result": "failure",
+            "oauth.result": "operation_failed",
         }
-        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "operation_failed")
         assert error_calls == [("test-connection", "token_exchange", "http_error")]
         assert record_exception_calls == [(tracer.spans[0], http_error)]
 
@@ -477,9 +477,9 @@ class TestOauthHandlers:
             "oauth.connection": "test-connection",
             "oauth.operation": "token_exchange",
             "oauth.error.type": "exception",
-            "oauth.result": "failure",
+            "oauth.result": "operation_failed",
         }
-        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "failure")
+        assert operation_calls[0][:3] == ("test-connection", "token_exchange", "operation_failed")
         assert error_calls == [("test-connection", "token_exchange", "exception")]
         assert record_exception_calls == [(tracer.spans[0], generic_error)]
 
@@ -632,9 +632,9 @@ class TestOauthHandlers:
             "oauth.connection": "test-connection",
             "oauth.operation": "verify_state",
             "oauth.error.type": "exception",
-            "oauth.result": "failure",
+            "oauth.result": "operation_failed",
         }
-        assert operation_calls[0][:3] == ("test-connection", "verify_state", "failure")
+        assert operation_calls[0][:3] == ("test-connection", "verify_state", "operation_failed")
         assert error_calls == [("test-connection", "verify_state", "exception")]
         assert record_exception_calls == [(tracer.spans[0], generic_error)]
 
@@ -1173,13 +1173,13 @@ class TestOauthHandlers:
                 "oauth.connection": "GitHub",
                 "oauth.operation": "verify_state",
                 "oauth.callback.invoked": True,
-                "oauth.result": "success",
+                "oauth.result": "operation_succeeded",
                 "invoke.response.status": 200,
             },
         ]
         assert [call[:3] for call in operation_calls] == [
             ("Graph", "verify_state", "no_token"),
-            ("GitHub", "verify_state", "success"),
+            ("GitHub", "verify_state", "operation_succeeded"),
         ]
 
     @pytest.mark.asyncio

--- a/packages/apps/tests/test_app_oauth.py
+++ b/packages/apps/tests/test_app_oauth.py
@@ -1103,6 +1103,54 @@ class TestOauthHandlers:
         assert pending_marker_keys(state) == {"__oauth:pending:graph", "__oauth:pending:sso:graph"}
 
     @pytest.mark.asyncio
+    async def test_verify_state_records_each_connection_attempt(
+        self,
+        oauth_handlers,
+        mock_context,
+        verify_state_activity,
+        mock_token_response,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        oauth_handlers.oauth_registry.add(OAuthFlow("Graph"))
+        oauth_handlers.oauth_registry.add(OAuthFlow("GitHub"))
+        mock_context.activity = verify_state_activity
+        mock_context.state = create_pending_state(("Graph", time.time(), False))
+        mock_context.api.users.get_token.side_effect = [
+            oauth_http_error(404, "Not found for Graph"),
+            mock_token_response,
+        ]
+        tracer = RecordingTracer()
+        operation_calls = []
+
+        monkeypatch.setattr("microsoft_teams.apps.app_oauth.get_tracer", lambda: tracer)
+        monkeypatch.setattr(
+            "microsoft_teams.apps.app_oauth.record_oauth_operation",
+            lambda *args: operation_calls.append(args),
+        )
+
+        assert await oauth_handlers.sign_in_verify_state(mock_context) is None
+
+        assert [span.attributes for span in tracer.spans] == [
+            {
+                "oauth.connection": "Graph",
+                "oauth.operation": "verify_state",
+                "invoke.response.status": 404,
+                "oauth.result": "no_token",
+            },
+            {
+                "oauth.connection": "GitHub",
+                "oauth.operation": "verify_state",
+                "oauth.callback.invoked": True,
+                "oauth.result": "success",
+                "invoke.response.status": 200,
+            },
+        ]
+        assert [call[:3] for call in operation_calls] == [
+            ("Graph", "verify_state", "no_token"),
+            ("GitHub", "verify_state", "success"),
+        ]
+
+    @pytest.mark.asyncio
     async def test_sso_failure_clears_hint_and_verify_state_still_resolves_by_probing(
         self, oauth_handlers, mock_context, failure_activity, verify_state_activity, mock_token_response
     ):

--- a/packages/apps/tests/test_apps_diagnostics.py
+++ b/packages/apps/tests/test_apps_diagnostics.py
@@ -278,7 +278,7 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
         record_handler_duration(2.5, "message", "type")
         record_handler_failure("message", "type")
         record_handler_unmatched("invoke", "composeExtension/query")
-        record_oauth_operation("test-connection", "token_exchange", "success", 3.5)
+        record_oauth_operation("test-connection", "token_exchange", "operation_succeeded", 3.5)
         record_oauth_error("test-connection", "token_exchange", "http_error")
 
     metrics = {}
@@ -318,7 +318,7 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
     assert oauth_operations_point.attributes == {
         "oauth.connection": "test-connection",
         "oauth.operation": "token_exchange",
-        "oauth.result": "success",
+        "oauth.result": "operation_succeeded",
     }
 
     oauth_duration_point = metrics["microsoft.teams.oauth.operation.duration"].data.data_points[0]
@@ -326,7 +326,7 @@ def test_app_metrics_are_recorded_with_allowed_attributes():
     assert oauth_duration_point.attributes == {
         "oauth.connection": "test-connection",
         "oauth.operation": "token_exchange",
-        "oauth.result": "success",
+        "oauth.result": "operation_succeeded",
     }
 
     oauth_errors_point = metrics["microsoft.teams.oauth.errors"].data.data_points[0]

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -58,6 +58,27 @@ def _http_status_error(status_code: int) -> HTTPStatusError:
     return HTTPStatusError(f"HTTP {status_code}", request=request, response=response)
 
 
+def _capture_oauth_telemetry(monkeypatch: pytest.MonkeyPatch):
+    tracer = RecordingTracer()
+    operation_calls = []
+    error_calls = []
+    exception_calls = []
+    monkeypatch.setattr("microsoft_teams.apps.diagnostics._helpers.get_tracer", lambda: tracer)
+    monkeypatch.setattr(
+        "microsoft_teams.apps.diagnostics._helpers.record_oauth_operation",
+        lambda *args: operation_calls.append(args),
+    )
+    monkeypatch.setattr(
+        "microsoft_teams.apps.diagnostics._helpers.record_oauth_error",
+        lambda *args: error_calls.append(args),
+    )
+    monkeypatch.setattr(
+        "microsoft_teams.apps.diagnostics._helpers.record_exception",
+        lambda *args: exception_calls.append(args),
+    )
+    return tracer, operation_calls, error_calls, exception_calls
+
+
 class TestOAuthFlowOperations:
     """sign_in / sign_out / get_token / is_signed_in, always on this flow's connection."""
 
@@ -124,18 +145,11 @@ class TestOAuthFlowOperations:
         flow = OAuthFlow("graph")
         ctx = MagicMock()
         ctx.sign_in = AsyncMock(return_value=token)
-        tracer = RecordingTracer()
-        operation_calls = []
-
-        monkeypatch.setattr("microsoft_teams.apps.oauth_flow.get_tracer", lambda: tracer)
-        monkeypatch.setattr(
-            "microsoft_teams.apps.oauth_flow.record_oauth_operation",
-            lambda *args: operation_calls.append(args),
-        )
+        tracer, operation_calls, _, _ = _capture_oauth_telemetry(monkeypatch)
 
         assert await flow.sign_in(ctx) == token
 
-        assert tracer.spans[0].name == "microsoft.teams.oauth.signin"
+        assert tracer.spans[0].name == "microsoft.teams.oauth"
         assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
         assert tracer.spans[0].attributes == {
             "oauth.connection": "graph",
@@ -162,24 +176,7 @@ class TestOAuthFlowOperations:
         flow = OAuthFlow("graph")
         ctx = MagicMock()
         ctx.sign_in = AsyncMock(side_effect=error)
-        tracer = RecordingTracer()
-        operation_calls = []
-        error_calls = []
-        exception_calls = []
-
-        monkeypatch.setattr("microsoft_teams.apps.oauth_flow.get_tracer", lambda: tracer)
-        monkeypatch.setattr(
-            "microsoft_teams.apps.oauth_flow.record_oauth_operation",
-            lambda *args: operation_calls.append(args),
-        )
-        monkeypatch.setattr(
-            "microsoft_teams.apps.oauth_flow.record_oauth_error",
-            lambda *args: error_calls.append(args),
-        )
-        monkeypatch.setattr(
-            "microsoft_teams.apps.oauth_flow.record_exception",
-            lambda *args: exception_calls.append(args),
-        )
+        tracer, operation_calls, error_calls, exception_calls = _capture_oauth_telemetry(monkeypatch)
 
         with pytest.raises(type(error)):
             await flow.sign_in(ctx)
@@ -195,10 +192,11 @@ class TestOAuthFlowOperations:
         assert exception_calls == [(tracer.spans[0], error)]
 
     @pytest.mark.asyncio
-    async def test_sign_out_targets_flow_connection(self) -> None:
+    async def test_sign_out_targets_flow_connection(self, monkeypatch: pytest.MonkeyPatch) -> None:
         flow = OAuthFlow("graph")
         ctx = _api_ctx()
         ctx.api.users.sign_out = AsyncMock(return_value=None)
+        tracer, operation_calls, _, _ = _capture_oauth_telemetry(monkeypatch)
 
         await flow.sign_out(ctx)
 
@@ -207,12 +205,20 @@ class TestOAuthFlowOperations:
         assert params.connection_name == "graph"
         assert params.channel_id == "msteams"
         assert params.user_id == "user-1"
+        assert tracer.spans[0].name == "microsoft.teams.oauth"
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "graph",
+            "oauth.operation": "signout",
+            "oauth.result": "success",
+        }
+        assert operation_calls[0][:3] == ("graph", "signout", "success")
 
     @pytest.mark.asyncio
-    async def test_get_token_targets_flow_connection(self) -> None:
+    async def test_get_token_targets_flow_connection(self, monkeypatch: pytest.MonkeyPatch) -> None:
         flow = OAuthFlow("graph")
         ctx = _api_ctx()
         ctx.api.users.get_token = AsyncMock(return_value=MagicMock(token="tok"))
+        tracer, operation_calls, _, _ = _capture_oauth_telemetry(monkeypatch)
 
         result = await flow.get_token(ctx)
 
@@ -221,25 +227,46 @@ class TestOAuthFlowOperations:
         assert params.connection_name == "graph"
         assert params.channel_id == "msteams"
         assert params.user_id == "user-1"
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "graph",
+            "oauth.operation": "get_token",
+            "oauth.result": "token_found",
+        }
+        assert operation_calls[0][:3] == ("graph", "get_token", "token_found")
 
     @pytest.mark.asyncio
-    async def test_get_token_returns_none_when_no_token_cached(self) -> None:
+    async def test_get_token_returns_none_when_no_token_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """404 is the Token Service saying "not signed in", not a failure."""
         flow = OAuthFlow("graph")
         ctx = _api_ctx()
         ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(404))
+        tracer, operation_calls, error_calls, _ = _capture_oauth_telemetry(monkeypatch)
 
         assert await flow.get_token(ctx) is None
+        assert tracer.spans[0].attributes["oauth.result"] == "token_not_found"
+        assert operation_calls[0][:3] == ("graph", "get_token", "token_not_found")
+        assert error_calls == []
 
     @pytest.mark.asyncio
-    async def test_get_token_reraises_non_404(self) -> None:
+    async def test_get_token_reraises_non_404(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An outage must not be reported as a logged-out user."""
         flow = OAuthFlow("graph")
         ctx = _api_ctx()
-        ctx.api.users.get_token = AsyncMock(side_effect=_http_status_error(503))
+        error = _http_status_error(503)
+        ctx.api.users.get_token = AsyncMock(side_effect=error)
+        tracer, operation_calls, error_calls, exception_calls = _capture_oauth_telemetry(monkeypatch)
 
         with pytest.raises(HTTPStatusError):
             await flow.get_token(ctx)
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "graph",
+            "oauth.operation": "get_token",
+            "oauth.error.type": "http_error",
+            "oauth.result": "failure",
+        }
+        assert operation_calls[0][:3] == ("graph", "get_token", "failure")
+        assert error_calls == [("graph", "get_token", "http_error")]
+        assert exception_calls == [(tracer.spans[0], error)]
 
     @pytest.mark.asyncio
     async def test_is_signed_in_true_when_token_present(self) -> None:

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -185,9 +185,9 @@ class TestOAuthFlowOperations:
             "oauth.connection": "graph",
             "oauth.operation": "signin",
             "oauth.error.type": expected_error_type,
-            "oauth.result": "failure",
+            "oauth.result": "operation_failed",
         }
-        assert operation_calls[0][:3] == ("graph", "signin", "failure")
+        assert operation_calls[0][:3] == ("graph", "signin", "operation_failed")
         assert error_calls == [("graph", "signin", expected_error_type)]
         assert exception_calls == [(tracer.spans[0], error)]
 
@@ -209,9 +209,9 @@ class TestOAuthFlowOperations:
         assert tracer.spans[0].attributes == {
             "oauth.connection": "graph",
             "oauth.operation": "signout",
-            "oauth.result": "success",
+            "oauth.result": "operation_succeeded",
         }
-        assert operation_calls[0][:3] == ("graph", "signout", "success")
+        assert operation_calls[0][:3] == ("graph", "signout", "operation_succeeded")
 
     @pytest.mark.asyncio
     async def test_get_token_targets_flow_connection(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -262,9 +262,9 @@ class TestOAuthFlowOperations:
             "oauth.connection": "graph",
             "oauth.operation": "get_token",
             "oauth.error.type": "http_error",
-            "oauth.result": "failure",
+            "oauth.result": "operation_failed",
         }
-        assert operation_calls[0][:3] == ("graph", "get_token", "failure")
+        assert operation_calls[0][:3] == ("graph", "get_token", "operation_failed")
         assert error_calls == [("graph", "get_token", "http_error")]
         assert exception_calls == [(tracer.spans[0], error)]
 

--- a/packages/apps/tests/test_oauth_flow.py
+++ b/packages/apps/tests/test_oauth_flow.py
@@ -6,6 +6,8 @@ Licensed under the MIT License.
 # pyright: basic
 
 import asyncio
+from contextlib import contextmanager
+from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -14,6 +16,27 @@ from microsoft_teams.apps import App, OAuthFlow, OAuthFlowRegistry
 from microsoft_teams.apps.routing import SignInOptions
 from microsoft_teams.apps.state import StateOptions, TurnStateLoader
 from microsoft_teams.common.storage import LocalStorage
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any]):
+        self.name = name
+        self.options = options
+        self.attributes: dict[str, Any] = {}
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Generator[RecordingSpan, None, None]:
+        span = RecordingSpan(name, kwargs)
+        self.spans.append(span)
+        yield span
 
 
 def _api_ctx() -> MagicMock:
@@ -86,6 +109,90 @@ class TestOAuthFlowOperations:
         ctx.state = None
 
         assert await flow.sign_in(ctx) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("token", "expected_result"),
+        [("tok", "token_cached"), (None, "signin_card_sent")],
+    )
+    async def test_sign_in_records_flow_telemetry(
+        self,
+        token: str | None,
+        expected_result: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        flow = OAuthFlow("graph")
+        ctx = MagicMock()
+        ctx.sign_in = AsyncMock(return_value=token)
+        tracer = RecordingTracer()
+        operation_calls = []
+
+        monkeypatch.setattr("microsoft_teams.apps.oauth_flow.get_tracer", lambda: tracer)
+        monkeypatch.setattr(
+            "microsoft_teams.apps.oauth_flow.record_oauth_operation",
+            lambda *args: operation_calls.append(args),
+        )
+
+        assert await flow.sign_in(ctx) == token
+
+        assert tracer.spans[0].name == "microsoft.teams.oauth.signin"
+        assert tracer.spans[0].options == {"record_exception": False, "set_status_on_exception": False}
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "graph",
+            "oauth.operation": "signin",
+            "oauth.result": expected_result,
+        }
+        assert operation_calls[0][:3] == ("graph", "signin", expected_result)
+        assert operation_calls[0][3] >= 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("error", "expected_error_type"),
+        [
+            (_http_status_error(503), "http_error"),
+            (RuntimeError("sign-in failed"), "exception"),
+        ],
+    )
+    async def test_sign_in_records_and_reraises_failures(
+        self,
+        error: Exception,
+        expected_error_type: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        flow = OAuthFlow("graph")
+        ctx = MagicMock()
+        ctx.sign_in = AsyncMock(side_effect=error)
+        tracer = RecordingTracer()
+        operation_calls = []
+        error_calls = []
+        exception_calls = []
+
+        monkeypatch.setattr("microsoft_teams.apps.oauth_flow.get_tracer", lambda: tracer)
+        monkeypatch.setattr(
+            "microsoft_teams.apps.oauth_flow.record_oauth_operation",
+            lambda *args: operation_calls.append(args),
+        )
+        monkeypatch.setattr(
+            "microsoft_teams.apps.oauth_flow.record_oauth_error",
+            lambda *args: error_calls.append(args),
+        )
+        monkeypatch.setattr(
+            "microsoft_teams.apps.oauth_flow.record_exception",
+            lambda *args: exception_calls.append(args),
+        )
+
+        with pytest.raises(type(error)):
+            await flow.sign_in(ctx)
+
+        assert tracer.spans[0].attributes == {
+            "oauth.connection": "graph",
+            "oauth.operation": "signin",
+            "oauth.error.type": expected_error_type,
+            "oauth.result": "failure",
+        }
+        assert operation_calls[0][:3] == ("graph", "signin", "failure")
+        assert error_calls == [("graph", "signin", expected_error_type)]
+        assert exception_calls == [(tracer.spans[0], error)]
 
     @pytest.mark.asyncio
     async def test_sign_out_targets_flow_connection(self) -> None:

--- a/packages/apps/tests/test_state.py
+++ b/packages/apps/tests/test_state.py
@@ -5,8 +5,9 @@ Licensed under the MIT License.
 
 import json
 import logging
-from typing import Any
-from unittest.mock import MagicMock
+from contextlib import contextmanager
+from typing import Any, Generator
+from unittest.mock import MagicMock, patch
 
 import pytest
 from microsoft_teams.apps.state import (
@@ -18,6 +19,24 @@ from microsoft_teams.apps.state import (
     create_state_loader,
 )
 from microsoft_teams.common import LocalStorage, Storage
+
+
+class RecordingSpan:
+    def __init__(self, name: str, options: dict[str, Any]):
+        self.name = name
+        self.options = options
+
+
+class RecordingTracer:
+    def __init__(self):
+        self.spans: list[RecordingSpan] = []
+
+    @contextmanager
+    def start_as_current_span(self, name: str, **kwargs: Any) -> Generator[RecordingSpan, None, None]:
+        span = RecordingSpan(name, kwargs)
+        self.spans.append(span)
+        yield span
+
 
 # ---------------------------------------------------------------------------
 # TurnState
@@ -432,6 +451,42 @@ class TestTurnStateLoader:
         await loader.delete("c1", "u1")
         assert storage.get("ts:conv:c1") is None
         assert storage.get("ts:user:c1:u1") is None
+
+    async def test_load_save_and_delete_create_state_spans(self):
+        storage = LocalStorage()
+        loader = TurnStateLoader(storage)
+        tracer = RecordingTracer()
+
+        with patch("microsoft_teams.apps.state.loader.get_tracer", return_value=tracer):
+            container = await loader.load("c1", "u1")
+            container.conversation["saved"] = True
+            await loader.save(container)
+            await loader.delete("c1", "u1")
+
+        assert [span.name for span in tracer.spans] == [
+            "microsoft.teams.state.load",
+            "microsoft.teams.state.save",
+            "microsoft.teams.state.delete",
+        ]
+        assert all(
+            span.options == {"record_exception": False, "set_status_on_exception": False} for span in tracer.spans
+        )
+
+    async def test_state_span_records_storage_exception(self):
+        error = RuntimeError("storage unavailable")
+        storage = MagicMock(spec=Storage)
+        storage.async_get.side_effect = error
+        loader = TurnStateLoader(storage)
+        tracer = RecordingTracer()
+
+        with (
+            patch("microsoft_teams.apps.state.loader.get_tracer", return_value=tracer),
+            patch("microsoft_teams.apps.state.loader.record_exception") as record,
+            pytest.raises(RuntimeError, match="storage unavailable"),
+        ):
+            await loader.load("c1")
+
+        record.assert_called_once_with(tracer.spans[0], error)
 
     async def test_corrupt_blob_loads_as_empty(self):
         storage = LocalStorage()


### PR DESCRIPTION
## Summary

aligns PY OAuth and state telemetry with TS and C#

- records a separate `verifyState` span and metric for each OAuth connection attempt
- adds sign-in telemetry for cached-token, card-sent, and failure outcomes
- adds exception-aware spans for state load, save, and delete operations
- preserves existing OAuth routing, callback, response, and state behavior
- adds focused coverage for multi-connection attempts and telemetry error paths